### PR TITLE
Tidy up lock tests and increase timeouts

### DIFF
--- a/Consul.Test/LockTest.cs
+++ b/Consul.Test/LockTest.cs
@@ -300,7 +300,10 @@ namespace Consul.Test
                 }));
             }
 
-            await WithTimeout(Task.WhenAll(tasks));
+            // Set timeout to allow each task to wait up to the lock wait time
+            await WithTimeout(
+                Task.WhenAll(tasks),
+                TimeSpan.FromTicks(2 * contenderPool * Lock.DefaultLockWaitTime.Ticks));
 
             for (var i = 0; i < contenderPool; i++)
             {


### PR DESCRIPTION
* Increases timeouts in lock tests
* Fixes exception checks to actually check an exception is thrown
* Fix tests that didn't actually test anything
* Various tidy ups to make tests more readable

I still need to look at the semaphore tests and make similar changes.