### PR TITLE
Fix NuGet push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,4 +83,5 @@ jobs:
           name: nuget-package
           path: dist
       - name: Publish to NuGet
+        shell: bash
         run: dotnet nuget push dist/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
           name: nuget-package
           path: dist
 
+  # Publish NuGet package when a tag is pushed.
+  # Tests need to succeed on all platforms first, including having a tag name that matches the version number.
   publish:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Forked from PlayFab Inc by G-Research (1.6.1.0)
+## Forked from PlayFab Inc by G-Research (1.6.1)
 * Upgrade to .NET 4.6.1 and .NET Core 2.0
 * Add missing code documentation
 * General cleanup

--- a/Consul.Test/Properties/AssemblyInfo.cs
+++ b/Consul.Test/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using Xunit;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.1.0")]
-[assembly: AssemblyFileVersion("1.6.1.0")]
+[assembly: AssemblyVersion("1.6.1")]
+[assembly: AssemblyFileVersion("1.6.1")]
 //[assembly: CollectionBehavior(DisableTestParallelization = false)]
 [assembly: CollectionBehavior(MaxParallelThreads = 1024)]

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.6.1.0</VersionPrefix>
+    <VersionPrefix>1.6.1</VersionPrefix>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Consul</AssemblyName>

--- a/Consul/Properties/AssemblyInfo.cs
+++ b/Consul/Properties/AssemblyInfo.cs
@@ -33,8 +33,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.1.0")]
-[assembly: AssemblyFileVersion("1.6.1.0")]
+[assembly: AssemblyVersion("1.6.1")]
+[assembly: AssemblyFileVersion("1.6.1")]
 [assembly: InternalsVisibleTo("Consul.Test, PublicKey=" +
     "002400000480000094000000060200000024000052534131000400000100010045f6337bf03a95" +
     "218f1e0b4e70bb91f8ee49fcb58593d78c1008ee646cfcf785ea60bd0b1dde6f5f92ead738e2bd" +


### PR DESCRIPTION
* Fix NuGet push (PowerShell would not do glob expansion for the command)
* Add comments about NuGet publication in the workflow file
* Change version to 1.6.1, as 1.6.1.0 would be trimmed by NuGet