### PR TITLE
Compatibility with Consul 1.7.x

### DIFF
--- a/Consul.Test/AgentTest.cs
+++ b/Consul.Test/AgentTest.cs
@@ -407,7 +407,8 @@ namespace Consul.Test
         [Fact]
         public async Task Agent_ForceLeave()
         {
-            await _client.Agent.ForceLeave("nonexistant");
+            var info = await _client.Agent.Self();
+            await _client.Agent.ForceLeave(info.Response["Config"]["NodeName"]);
             // Success is not throwing an exception
         }
 

--- a/Consul.Test/PolicyTest.cs
+++ b/Consul.Test/PolicyTest.cs
@@ -67,31 +67,6 @@ namespace Consul.Test
         }
 
         [SkippableFact]
-        public async Task Policy_ReadCloneUpdateDelete()
-        {
-            Skip.If(string.IsNullOrEmpty(TestHelper.MasterToken));
-
-            var selfTokenEntry = await _client.Token.Read("self");
-            var clonedTokenEntry = await _client.Token.Clone(selfTokenEntry.Response.AccessorID);
-
-            Assert.NotEqual(TimeSpan.Zero, clonedTokenEntry.RequestTime);
-            Assert.Equal(selfTokenEntry.Response.Description, clonedTokenEntry.Response.Description);
-            Assert.Equal(selfTokenEntry.Response.Local, clonedTokenEntry.Response.Local);
-
-            clonedTokenEntry.Response.Description = "This is an updated clone of the self token";
-            var updatedTokenEntry = await _client.Token.Update(clonedTokenEntry.Response);
-
-            Assert.NotEqual(TimeSpan.Zero, updatedTokenEntry.RequestTime);
-            Assert.Equal(clonedTokenEntry.Response.AccessorID, updatedTokenEntry.Response.AccessorID);
-            Assert.Equal(clonedTokenEntry.Response.SecretID, updatedTokenEntry.Response.SecretID);
-            Assert.Equal(clonedTokenEntry.Response.Local, updatedTokenEntry.Response.Local);
-            Assert.Equal(clonedTokenEntry.Response.Description, updatedTokenEntry.Response.Description);
-
-            var deleteResponse = await _client.Policy.Delete(updatedTokenEntry.Response.AccessorID);
-            Assert.True(deleteResponse.Response);
-        }
-
-        [SkippableFact]
         public async Task Policy_Read()
         {
             Skip.If(string.IsNullOrEmpty(TestHelper.MasterToken));

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -510,7 +510,7 @@ namespace Consul
         /// <summary>
         /// ForceLeave is used to have the agent eject a failed node
         /// </summary>
-        /// <param name="node">The node name to remove. An attempt to eject a node that doesn't exist will still be successful</param>
+        /// <param name="node">The node name to remove</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> ForceLeave(string node, CancellationToken ct = default(CancellationToken))
         {

--- a/Consul/Policy.cs
+++ b/Consul/Policy.cs
@@ -30,13 +30,28 @@ namespace Consul
     {
         public string ID { get; set; }
         public string Name { get; set; }
+        public PolicyLink()
+        : this(string.Empty, string.Empty)
+        {
+        }
+        public PolicyLink(string id)
+        : this(id, string.Empty)
+        {
+        }
+        public PolicyLink(string id, string name)
+        {
+            ID = id;
+            Name = name;
+        }
     }
 
     /// <summary>
     /// PolicyEntry represents an ACL Policy in Consul
     /// </summary>
-    public class PolicyEntry:PolicyLink
+    public class PolicyEntry
     {
+        public string ID { get; set; }
+        public string Name { get; set; }
         public string Description { get; set; }
         public string Rules { get; set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -75,6 +90,7 @@ namespace Consul
             Rules = rules;
             Datacenters = datacenters;
         }
+        public static implicit operator PolicyLink(PolicyEntry p) => new PolicyLink(p.ID);
     }
 
     /// <summary>

--- a/Consul/Role.cs
+++ b/Consul/Role.cs
@@ -30,13 +30,28 @@ namespace Consul
     {
         public string ID { get; set; }
         public string Name { get; set; }
+        public RoleLink()
+        : this(string.Empty, string.Empty)
+        {
+        }
+        public RoleLink(string id)
+        : this(id, string.Empty)
+        {
+        }
+        public RoleLink(string id, string name)
+        {
+            ID = id;
+            Name = name;
+        }
     }
 
     /// <summary>
     /// RoleEntry represents an ACL Role in Consul
     /// </summary>
-    public class RoleEntry : RoleLink
+    public class RoleEntry
     {
+        public string ID { get; set; }
+        public string Name { get; set; }
         public string Description { get; set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public PolicyLink[] Policies { get; set; }
@@ -91,6 +106,7 @@ namespace Consul
             Policies = policies;
             ServiceIdentities = serviceIdentities;
         }
+        public static implicit operator RoleLink(RoleEntry r) => new RoleLink(r.ID);
     }
 
     /// <summary>

--- a/Consul/Token.cs
+++ b/Consul/Token.cs
@@ -18,6 +18,7 @@
 
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -224,9 +225,26 @@ namespace Consul
         /// <param name="writeOptions">Customized write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL token</returns>
-        public async Task<WriteResult<TokenEntry>> Clone(string id, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<TokenEntry>> Clone(string id, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
         {
-            var res = await _client.PutReturning<TokenActionResult>($"/v1/acl/token/{id}/clone", writeOptions).Execute(ct).ConfigureAwait(false);
+            return Clone(id, string.Empty, writeOptions, ct);
+        }
+
+        /// <summary>
+        /// Clones an existing ACL Token in Consul
+        /// </summary>
+        /// <param name="id">The Accessor ID of the ACL Token to clone</param>
+        /// <param name="description">The description for the cloned ACL Token</param>
+        /// <param name="writeOptions">Customized write options</param>
+        /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
+        /// <returns>A write result containing the created ACL token</returns>
+        public async Task<WriteResult<TokenEntry>> Clone(string id, string description, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        {
+            var body = new Dictionary<string, string>
+                {
+                    {"Description", description}
+                };
+            var res = await _client.Put<object, TokenActionResult>($"/v1/acl/token/{id}/clone", body, writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<TokenEntry>(res, res.Response);
         }
 


### PR DESCRIPTION
This PR fixes a few compatibility issues with Consul 1.7.x and above (latest version is 1.8.3 at the time of writing).

- Consul 1.7 requires an existing node name for Agent.ForceLeave, breaking `Consul.Test.AgentTest.Agent_ForceLeave`
- Consul 1.7 requires a body with a JSON object for Token.Clone, breaking `Consul.Test.TokenTest.Token_ReadCloneUpdateDelete`
    Also added a Clone method that allows to set the description for the new token.
- Consul 1.7 requires proper PolicyLink and RoleLink structures, breaking multiple Role and Token tests
    Made PolicyEntry and RoleEntry base classes instead of subclasses of PolicyLink and RoleLink respectively.
    Added implicit conversion methods from xEntry to xLink for convenience and backwards compatibility.

It also removes the useless test `Consul.Test.PolicyTest.Policy_ReadCloneUpdateDelete`. This test was essentially a copy of `Consul.Test.TokenTest.Token_ReadCloneUpdateDelete`, but trying to delete a nonexistent policy, and not even deleting the cloned token.

An example CI run with Consul 1.8.3 can be found here: https://github.com/jgiannuzzi/consuldotnet/actions/runs/246499369