### PR TITLE
Remove [Obsolete] attribute for ConsulClient HttpClient constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added the possibility to specify more http request options and meta-data when registrating service checks. 
   It is now possible to specify the http Header(s) (`Headers`), `Method` and `Body` to be used for a given service check.
   A given service check might also now have an identifier (`ID`), `Name` and a description (`Notes`) associated.
+* Fix issue #24 removing constructor's Obsolete attribute for HttpClient injection
 
 ## 1.6.1.1
 * Fix issue #9 preventing use of the library with .NET Framework

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -443,8 +443,6 @@ namespace Consul
         /// </summary>
         /// <param name="config">A Consul client configuration</param>
         /// <param name="client">A custom HttpClient</param>
-        [Obsolete("This constructor is no longer necessary due to the new Action based constructors and will be removed in a future release." +
-            "Please use one of the ConsulClient(Action<>) constructors instead to set internal options on the HttpClient/WebRequestHandler.", false)]
         public ConsulClient(ConsulClientConfiguration config, HttpClient client)
         {
             var ctr = new ConsulClientConfigurationContainer(config, client);

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -442,7 +442,7 @@ namespace Consul
         /// The HttpClient must accept the "application/json" content type and the Timeout property should be set to at least 15 minutes to allow for blocking queries.
         /// </summary>
         /// <param name="config">A Consul client configuration</param>
-        /// <param name="client">A custom HttpClient</param>
+        /// <param name="client">A custom HttpClient. The lifetime, including disposal, of this HttpClient is not handled by ConsulClient</param>
         public ConsulClient(ConsulClientConfiguration config, HttpClient client)
         {
             var ctr = new ConsulClientConfigurationContainer(config, client);


### PR DESCRIPTION
This is to allow continued support for providing an external HttpClient to the ConsulClient. Closes #24