### PR TITLE
Allow further service check property to be specified when registering a service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,12 @@
 # Changelog
 
-## 1.6.1.3
-* Added the possibility to specify the id, name and notes for a service check definition.
-  Added the possibility to indicate when a dead service should be dropped from the registry `DeregisterCriticalServiceAfter` http API parameter
+## 1.7.0
+* Added the possibility to specify more http request options and meta-data when registrating service checks. 
+  It is now possible to specify the http Header(s) (`Headers`), `Method` and `Body` to be used for a given service check.
+  A given service check might also now have an identifier (`ID`), `Name` and a description (`Notes`) associated.
+  Details on the Consul's HTTP API can be found here <https://www.consul.io/api/agent/check>
 
-## 1.6.1.2
-* Added the possibility to specify more http request options when registrating service checks.
-  It is now possible to specify the Header(s), method and body to be used for a given service check.
-  Details might be found here <https://www.consul.io/api/agent/check>
+* Increased minor version and align with NuGet versioning best-practices <https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-basics>
 
 ## 1.6.1.1
 * Fix issue #9 preventing use of the library with .NET Framework

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.6.1.2
+* Added possibility to specify more http request options when registrating service checks.
+  It is now possible to specify the Header(s), method and body to be used for a given service check.
+  Details might be found here <https://www.consul.io/api/agent/check>
+
 ## 1.6.1.1
 * Fix issue #9 preventing use of the library with .NET Framework
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
+## 1.6.1.3
+* Added the possibility to specify the id, name and notes for a service check definition.
+  Added the possibility to indicate when a dead service should be dropped from the registry `DeregisterCriticalServiceAfter` http API parameter
+
 ## 1.6.1.2
-* Added possibility to specify more http request options when registrating service checks.
+* Added the possibility to specify more http request options when registrating service checks.
   It is now possible to specify the Header(s), method and body to be used for a given service check.
   Details might be found here <https://www.consul.io/api/agent/check>
 

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -210,15 +210,6 @@ namespace Consul
     public class AgentCheckRegistration : AgentServiceCheck
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public string ID { get; set; }
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public string Name { get; set; }
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public string Notes { get; set; }
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string ServiceID { get; set; }
     }
 
@@ -236,9 +227,6 @@ namespace Consul
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Notes { get; set; }
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public string DeregisterCriticalServiceAfter { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Script { get; set; }

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -255,6 +255,15 @@ namespace Consul
         public string HTTP { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public Dictionary<string, List<string>> Header { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string Method { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string Body { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string TCP { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -263,12 +272,12 @@ namespace Consul
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public bool TLSSkipVerify { get; set; }
-        
+
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string GRPC { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public bool GRPCUseTLS  { get; set; }
+        public bool GRPCUseTLS { get; set; }
 
         /// <summary>
         /// In Consul 0.7 and later, checks that are associated with a service

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -227,6 +227,19 @@ namespace Consul
     /// </summary>
     public class AgentServiceCheck
     {
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string ID { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string Notes { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string DeregisterCriticalServiceAfter { get; set; }
+
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Script { get; set; }
 

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.6.1.1</VersionPrefix>
+    <VersionPrefix>1.6.1.2</VersionPrefix>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Consul</AssemblyName>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.6.1.2</VersionPrefix>
+    <VersionPrefix>1.6.1.3</VersionPrefix>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Consul</AssemblyName>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.6.1.3</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Consul</AssemblyName>


### PR DESCRIPTION
Added additional Consul HTTP API parameter to detail the service check registration.

Reference to <https://www.consul.io/docs/discovery/services> and this <https://www.consul.io/docs/discovery/checks> page of Consul's documentation.

We are going to use those options to allow specify distinct host http header and host address values.

Sample definition
```csharp
new AgentServiceCheck{
	HTTP = $"http://srv1.servers.contoso.com/weatherforecast",
	Timeout = TimeSpan.FromMilliseconds(100),
	Interval = TimeSpan.FromSeconds(1),
	Header = new Dictionary<string, List<string>>{ {"Host",new List<string>{"app.contoso.com"} } },
	Method = "GET",
}
```