### PR TITLE
Add information to the readme about versioning and the release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Changelog
 
-## 1.7.0
+## Unreleased
 * Added the possibility to specify more http request options and meta-data when registrating service checks. 
   It is now possible to specify the http Header(s) (`Headers`), `Method` and `Body` to be used for a given service check.
   A given service check might also now have an identifier (`ID`), `Name` and a description (`Notes`) associated.
-  Details on the Consul's HTTP API can be found here <https://www.consul.io/api/agent/check>
-
-* Increased minor version and align with NuGet versioning best-practices <https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-basics>
 
 ## 1.6.1.1
 * Fix issue #9 preventing use of the library with .NET Framework

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>1.6.1.1</VersionPrefix>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Consul</AssemblyName>

--- a/README.md
+++ b/README.md
@@ -191,3 +191,16 @@ best-effort basis. It should compile and run happily on Mono but this is not as
 heavily tested as Microsoft .NET stacks. If you have any issues using the Nuget
 package or compiling this code with .NET, .NET Core, or Mono, please file a
 Github issue with details of the problem.
+
+## Versioning
+
+The version number indicates which version of Consul is supported in terms of API features.
+Since Consul has already a version that consists of three numbers (e.g. 1.6.1), the fourth number is necessary to indicate patch releases of Consul.NET.
+
+Please note that NuGet normalizes version numbers, by omitting zero in the fourth part of the version number.
+For example version `1.6.1.0` is going to be normalised to `1.6.1`. Because of the normalisation process versions and tags with zero in the fourth part should be avoided.
+
+## Release process
+
+Before making a new release the version in the [csproj](../Consul/Consul.csproj), in the [README](README.md), in the [CI pipeline](../.github/workflows/ci.yml) and in the [CHANGELOG](CHANGELOG.md) files should be updated.
+The new versions can be released using the [releases](https://github.com/G-Research/consuldotnet/releases) page.

--- a/README.md
+++ b/README.md
@@ -202,5 +202,5 @@ For example version `1.6.1.0` is going to be normalised to `1.6.1`. So to avoid 
 
 ## Release process
 
-Before making a new release the version in the [csproj](../Consul/Consul.csproj), in the [README](README.md), in the [CI pipeline](../.github/workflows/ci.yml) and in the [CHANGELOG](CHANGELOG.md) files should be updated.
+Before making a new release the version in the [csproj](Consul/Consul.csproj), in the [README](README.md), in the [CI pipeline](../.github/workflows/ci.yml) and in the [CHANGELOG](CHANGELOG.md) files should be updated.
 The new versions can be released using the [releases](https://github.com/G-Research/consuldotnet/releases) page.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The version number indicates which version of Consul is supported in terms of AP
 Since Consul has already a version that consists of three numbers (e.g. 1.6.1), the fourth number is necessary to indicate patch releases of Consul.NET.
 
 Please note that NuGet normalizes version numbers, by omitting zero in the fourth part of the version number.
-For example version `1.6.1.0` is going to be normalised to `1.6.1`. Because of the normalisation process versions and tags with zero in the fourth part should be avoided.
+For example version `1.6.1.0` is going to be normalised to `1.6.1`. So to avoid problems, versions and tags with zero in the fourth part should be avoided and explicit three part version should be used instead.
 
 ## Release process
 

--- a/README.md
+++ b/README.md
@@ -202,5 +202,5 @@ For example version `1.6.1.0` is going to be normalised to `1.6.1`. So to avoid 
 
 ## Release process
 
-Before making a new release the version in the [csproj](Consul/Consul.csproj), in the [README](README.md), in the [CI pipeline](../.github/workflows/ci.yml) and in the [CHANGELOG](CHANGELOG.md) files should be updated.
+Before making a new release the version in the [csproj](Consul/Consul.csproj), in the [README](README.md), in the [CI pipeline](.github/workflows/ci.yml) and in the [CHANGELOG](CHANGELOG.md) files should be updated.
 The new versions can be released using the [releases](https://github.com/G-Research/consuldotnet/releases) page.


### PR DESCRIPTION
- Reverting the version back to the `v1.6.1.1` (The `v1.7.0` wasn't published to NuGet.org)
- Adding information to the README file about versioning and the release process of Consul.NET
