### PR TITLE
Adding new API fields to get ready for the v1.6.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Added `Type` field to the `AgentCheck` and `HealthCheck` structures  
 * Added the possibility to specify more http request options and meta-data when registrating service checks. 
   It is now possible to specify the http Header(s) (`Headers`), `Method` and `Body` to be used for a given service check.
   A given service check might also now have an identifier (`ID`), `Name` and a description (`Notes`) associated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* Added `Type` field to the `AgentCheck` and `HealthCheck` structures  
+* Added the `Type` field to the `AgentCheck` and `HealthCheck` structures  
 * Added the possibility to specify more http request options and meta-data when registrating service checks. 
   It is now possible to specify the http Header(s) (`Headers`), `Method` and `Body` to be used for a given service check.
   A given service check might also now have an identifier (`ID`), `Name` and a description (`Notes`) associated.

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -132,6 +132,7 @@ namespace Consul
         public string Output { get; set; }
         public string ServiceID { get; set; }
         public string ServiceName { get; set; }
+        public string Type { get; set; }
     }
 
     /// <summary>

--- a/Consul/Health.cs
+++ b/Consul/Health.cs
@@ -130,6 +130,7 @@ namespace Consul
         public string Output { get; set; }
         public string ServiceID { get; set; }
         public string ServiceName { get; set; }
+        public string Type { get; set; }
     }
 
     public static class HealthCheckExtension


### PR DESCRIPTION
`Type` field was added to consul between  `v1.6.1` and `v1.6.9`.