### PR TITLE
Fix NuGet package publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: nuget-package
-          path: dist
+          path: dist/consul
       - name: Publish to NuGet
         shell: bash
         run: dotnet nuget push dist/consul/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/consul.aspnetcore.yml
+++ b/.github/workflows/consul.aspnetcore.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Consul | AspNetCore | Package | Artifact | Download
         uses: actions/download-artifact@v2
         with:
-          name: nuget-package
-          path: dist
+          name: nuget-aspnetcore-package
+          path: dist/consul.aspnetcore
 
       - name: Consul | AspNetCore | Package | Publish
         run: dotnet nuget push dist/consul.aspnetcore/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
This PR fixes the path used to download the nuget artifact so it matches the one used to upload it.

This unfortunately got broken in #46.