### PR TITLE
Fix version suffix for unreleased nuget packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,12 @@ jobs:
               exit 1
             }
           } else {
-            $params = "--version-suffix", $(git rev-parse --short HEAD)
+            # WORKAROUND: Add letter prefix to ensure that MSBuild treats
+            # the suffix as a string. e.g. '0313071' will fail as an invalid
+            # version string, but 'G0313071' will succeeded. It looks like
+            # the parser does not like numbers with a leading zero.
+            $suffix = 'g' + $(git rev-parse --short HEAD)
+            $params = "--version-suffix", $suffix
           }
           dotnet pack --configuration=Release --no-build @params Consul/Consul.csproj
       - name: Upload NuGet package artifact

--- a/.github/workflows/consul.aspnetcore.yml
+++ b/.github/workflows/consul.aspnetcore.yml
@@ -39,7 +39,12 @@ jobs:
               exit 1
             }
           } else {
-            $params = "--version-suffix", $(git rev-parse --short HEAD)
+            # WORKAROUND: Add letter prefix to ensure that MSBuild treats
+            # the suffix as a string. e.g. '0313071' will fail as an invalid
+            # version string, but 'G0313071' will succeeded. It looks like
+            # the parser does not like numbers with a leading zero.
+            $suffix = 'g' + $(git rev-parse --short HEAD)
+            $params = "--version-suffix", $suffix
           }
           dotnet pack -c=Release --no-build @params Consul.AspNetCore/Consul.AspNetCore.csproj
 


### PR DESCRIPTION
When creating nuget packages, the CI pipeline will use the short commit id as as version suffix. There seems to be an issue when the commit id is purely numeric, and begins with leading zero. To workaround the issue, we use an alphabetic character prefix to convince the packager that our suffix is really a string.

Credits to @MoFtZ who fixed it in [ILGPU](https://github.com/m4rs-mt/ILGPU) in https://github.com/m4rs-mt/ILGPU/pull/340