### PR TITLE
Use fixed OS version in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
   # Enforces the consistency of code formatting using `.editorconfig` and the `dotnet-format` tool.
   check-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-18.04, windows-2019, macos-10.15]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -101,7 +101,7 @@ jobs:
   publish:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Download NuGet package artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/consul.aspnetcore.yml
+++ b/.github/workflows/consul.aspnetcore.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     name: Consul | AspNetCore
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - name: Consul | AspNetCore | Checkout
@@ -59,7 +59,7 @@ jobs:
   publish:
     if: startsWith(github.ref, 'refs/tags/Consul.AspNetCore_v')
     needs: build
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Consul | AspNetCore | Package | Artifact | Download
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Using a fixed OS version avoids warnings when the `latest` label will soon change, as is the case for `ubuntu-latest` currently. It also ensures more reproducibility in terms of CI.