### PR TITLE
Run the check-format job only once per PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
 
   # Enforces the consistency of code formatting using `.editorconfig` and the `dotnet-format` tool.
   check-format:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout


### PR DESCRIPTION
A condition is added to the `check-format` CI job to prevent it from running twice when a PR is opened from a branch in the same repo. This makes it aligned to what we do for the `build` job.