### PR TITLE
Fix Consul.AspNetCore NuGet package publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
   publish:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build
-    runs-on: windows-2019
+    runs-on: ubuntu-18.04
     steps:
       - name: Download NuGet package artifact
         uses: actions/download-artifact@v2
@@ -110,5 +110,4 @@ jobs:
           name: nuget-package
           path: dist/consul
       - name: Publish to NuGet
-        shell: bash
         run: dotnet nuget push dist/consul/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/consul.aspnetcore.yml
+++ b/.github/workflows/consul.aspnetcore.yml
@@ -59,7 +59,7 @@ jobs:
   publish:
     if: startsWith(github.ref, 'refs/tags/Consul.AspNetCore_v')
     needs: build
-    runs-on: windows-2019
+    runs-on: ubuntu-18.04
     steps:
       - name: Consul | AspNetCore | Package | Artifact | Download
         uses: actions/download-artifact@v2


### PR DESCRIPTION
This PR fixes the publication of the `Consul.AspNetCore` NuGet package by making the shell do the globbing to find the package, like we already did for the main package. As there was no reason to publish the package with Windows specifically, we switch both publication jobs to Linux, which uses `bash` by default.