### PR TITLE
Fix the flakiness of Agent_Monitor test

### DIFF
--- a/Consul.Test/AgentTest.cs
+++ b/Consul.Test/AgentTest.cs
@@ -504,7 +504,7 @@ namespace Consul.Test
                     Assert.True(false, "Failed to finish reading logs in time");
                 }
 
-                await logsTask;
+                await task;
             }
         }
     }

--- a/Consul.Test/AgentTest.cs
+++ b/Consul.Test/AgentTest.cs
@@ -479,7 +479,6 @@ namespace Consul.Test
             using (var logs = await _client.Agent.Monitor(LogLevel.Trace))
             {
                 var counter = 0;
-                var timeoutTask = Task.Delay(TimeSpan.FromMinutes(1));
                 var logsTask = Task.Run(async () =>
                 {
                     // to get some logs
@@ -498,13 +497,7 @@ namespace Consul.Test
                     }
                 });
 
-                var task = await Task.WhenAny(new[] { timeoutTask, logsTask });
-                if (task == timeoutTask)
-                {
-                    Assert.True(false, "Failed to finish reading logs in time");
-                }
-
-                await task;
+                await TimeoutUtils.WithTimeout(logsTask);
             }
         }
     }


### PR DESCRIPTION
By default the `ContinueWith` runs the continuation regardless of the reason for completing the preceding task, whether it completed normally or was cancelled via cancellation token. As a result even when `logsTask` completed sooner, the `timeoutTask` was completing immediately after it due to usage of cancellation token. It was a race condition, because `Task.WhenAny` could select either task.

After this change there is no race condition anymore.