### PR TITLE
Fix the flakiness of the Event_FireList test by using blocking queries

### DIFF
--- a/Consul.Test/EventTest.cs
+++ b/Consul.Test/EventTest.cs
@@ -18,6 +18,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -44,21 +45,15 @@ namespace Consul.Test
         [Fact]
         public async Task Event_FireList()
         {
-            var userEvent = new UserEvent()
-            {
-                Name = "foo"
-            };
-
+            var previousIndex = (await _client.Event.List()).LastIndex;
+            var userEvent = new UserEvent() {Name = "foo"};
             var res = await _client.Event.Fire(userEvent);
-
-            await Task.Delay(1000);
-
             Assert.NotEqual(TimeSpan.Zero, res.RequestTime);
             Assert.False(string.IsNullOrEmpty(res.Response));
 
-            var events = await _client.Event.List();
+            var events = await _client.Event.List("foo", new QueryOptions {WaitIndex = previousIndex});
             Assert.NotEmpty(events.Response);
-            Assert.Equal(res.Response, events.Response[events.Response.Length - 1].ID);
+            Assert.Equal(res.Response, events.Response.Last().ID);
             Assert.Equal(_client.Event.IDToIndex(res.Response), events.LastIndex);
         }
     }

--- a/Consul.Test/EventTest.cs
+++ b/Consul.Test/EventTest.cs
@@ -45,13 +45,13 @@ namespace Consul.Test
         [Fact]
         public async Task Event_FireList()
         {
-            var previousIndex = (await _client.Event.List()).LastIndex;
+            var currentIndex = (await _client.Event.List()).LastIndex;
             var userEvent = new UserEvent() {Name = "foo"};
             var res = await _client.Event.Fire(userEvent);
             Assert.NotEqual(TimeSpan.Zero, res.RequestTime);
             Assert.False(string.IsNullOrEmpty(res.Response));
 
-            var events = await _client.Event.List("foo", new QueryOptions {WaitIndex = previousIndex});
+            var events = await _client.Event.List(userEvent.Name, new QueryOptions {WaitIndex = currentIndex});
             Assert.NotEmpty(events.Response);
             Assert.Equal(res.Response, events.Response.Last().ID);
             Assert.Equal(_client.Event.IDToIndex(res.Response), events.LastIndex);

--- a/Consul.Test/EventTest.cs
+++ b/Consul.Test/EventTest.cs
@@ -46,12 +46,12 @@ namespace Consul.Test
         public async Task Event_FireList()
         {
             var currentIndex = (await _client.Event.List()).LastIndex;
-            var userEvent = new UserEvent() {Name = "foo"};
+            var userEvent = new UserEvent() { Name = "foo" };
             var res = await _client.Event.Fire(userEvent);
             Assert.NotEqual(TimeSpan.Zero, res.RequestTime);
             Assert.False(string.IsNullOrEmpty(res.Response));
 
-            var events = await _client.Event.List(userEvent.Name, new QueryOptions {WaitIndex = currentIndex});
+            var events = await _client.Event.List(userEvent.Name, new QueryOptions { WaitIndex = currentIndex });
             Assert.NotEmpty(events.Response);
             Assert.Equal(res.Response, events.Response.Last().ID);
             Assert.Equal(_client.Event.IDToIndex(res.Response), events.LastIndex);

--- a/Consul.Test/EventTest.cs
+++ b/Consul.Test/EventTest.cs
@@ -18,7 +18,6 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -45,14 +44,14 @@ namespace Consul.Test
         [Fact]
         public async Task Event_FireList()
         {
-            var userevent = new UserEvent()
+            var userEvent = new UserEvent()
             {
                 Name = "foo"
             };
 
-            var res = await _client.Event.Fire(userevent);
+            var res = await _client.Event.Fire(userEvent);
 
-            await Task.Delay(100);
+            await Task.Delay(1000);
 
             Assert.NotEqual(TimeSpan.Zero, res.RequestTime);
             Assert.False(string.IsNullOrEmpty(res.Response));


### PR DESCRIPTION
Fixes the flakiness of the `Event_FireList` by usage of Consul blocking queries feature. 