### PR TITLE
Fix lock and semaphore timeouts

### DIFF
--- a/Consul.Test/AgentTest.cs
+++ b/Consul.Test/AgentTest.cs
@@ -479,8 +479,6 @@ namespace Consul.Test
             using (var logs = await _client.Agent.Monitor(LogLevel.Trace))
             {
                 var counter = 0;
-                var successToken = new CancellationTokenSource();
-                var timeoutTask = Task.Delay(TimeSpan.FromMinutes(1), successToken.Token).ContinueWith(x => Assert.True(false, "Failed to finish reading logs in time"));
                 var logsTask = Task.Run(async () =>
                 {
                     // to get some logs
@@ -494,13 +492,12 @@ namespace Consul.Test
                         counter++;
                         if (counter > 5)
                         {
-                            successToken.Cancel();
                             break;
                         }
                     }
                 });
 
-                await await Task.WhenAny(new[] { timeoutTask, logsTask });
+                await TimeoutUtils.WithTimeout(logsTask);
             }
         }
     }

--- a/Consul/Lock.cs
+++ b/Consul/Lock.cs
@@ -252,7 +252,7 @@ namespace Consul
 
                     var qOpts = new QueryOptions()
                     {
-                        WaitTime = Opts.LockWaitTime,
+                        WaitTime = Opts.LockWaitTime
                     };
 
                     var attempts = 0;

--- a/Consul/Lock.cs
+++ b/Consul/Lock.cs
@@ -17,6 +17,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -251,23 +252,24 @@ namespace Consul
 
                     var qOpts = new QueryOptions()
                     {
-                        WaitTime = Opts.LockWaitTime
+                        WaitTime = Opts.LockWaitTime,
                     };
 
                     var attempts = 0;
-                    var start = DateTime.UtcNow;
+                    var sw = Stopwatch.StartNew();
 
                     while (!ct.IsCancellationRequested)
                     {
                         if (attempts > 0 && Opts.LockTryOnce)
                         {
-                            var elapsed = DateTime.UtcNow.Subtract(start);
-                            if (elapsed > qOpts.WaitTime)
+                            var elapsed = sw.Elapsed;
+                            if (elapsed > Opts.LockWaitTime)
                             {
                                 DisposeCancellationTokenSource();
                                 throw new LockMaxAttemptsReachedException("LockTryOnce is set and the lock is already held or lock delay is in effect");
                             }
-                            qOpts.WaitTime -= elapsed;
+
+                            qOpts.WaitTime = Opts.LockWaitTime - elapsed;
                         }
 
                         attempts++;

--- a/Consul/Lock.cs
+++ b/Consul/Lock.cs
@@ -268,7 +268,6 @@ namespace Consul
                                 DisposeCancellationTokenSource();
                                 throw new LockMaxAttemptsReachedException("LockTryOnce is set and the lock is already held or lock delay is in effect");
                             }
-
                             qOpts.WaitTime = Opts.LockWaitTime - elapsed;
                         }
 

--- a/Consul/Semaphore.cs
+++ b/Consul/Semaphore.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -360,19 +361,19 @@ namespace Consul
                     };
 
                     var attempts = 0;
-                    var start = DateTime.UtcNow;
+                    var sw = Stopwatch.StartNew();
 
                     while (!ct.IsCancellationRequested)
                     {
                         if (attempts > 0 && Opts.SemaphoreTryOnce)
                         {
-                            var elapsed = DateTime.UtcNow.Subtract(start);
-                            if (elapsed > qOpts.WaitTime)
+                            var elapsed = sw.Elapsed;
+                            if (elapsed > Opts.SemaphoreWaitTime)
                             {
                                 DisposeCancellationTokenSource();
                                 throw new SemaphoreMaxAttemptsReachedException("SemaphoreTryOnce is set and the semaphore is already at maximum capacity");
                             }
-                            qOpts.WaitTime -= elapsed;
+                            qOpts.WaitTime = Opts.SemaphoreWaitTime - elapsed;
                         }
 
                         attempts++;


### PR DESCRIPTION
The logic for calculating the `WaitTime` was broken.
I think that this bug was inherited from go library. It is fixed there already (https://github.com/hashicorp/consul/commit/9043966efdab6e8e12c73772de070e25c4a50bc1)