### PR TITLE
Lock: Forward user cancellation token downstream

### DIFF
--- a/Consul.Test/SemaphoreTest.cs
+++ b/Consul.Test/SemaphoreTest.cs
@@ -386,7 +386,7 @@ namespace Consul.Test
         }
 
         [Fact]
-        public async Task Cancelling_A_Token_When_Acquiring_A_Lock_Should_Throw_LockNotHeldException()
+        public async Task Cancelling_A_Token_When_Acquiring_A_Lock_Should_Throw_TaskCanceledException()
         {
             var keyName = Path.GetTempFileName();
 
@@ -408,11 +408,11 @@ namespace Consul.Test
                 LockWaitTime = TimeSpan.FromSeconds(LockWaitTimeSeconds)
             });
 
-            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
-
             await distributedLock2.Acquire(); // Become "Master" with another instance first
 
-            await Assert.ThrowsAsync<LockNotHeldException>(async () => await distributedLock.Acquire(cts.Token));
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await distributedLock.Acquire(cts.Token));
 
             await distributedLock2.Release();
             await distributedLock2.Destroy();

--- a/Consul.Test/SemaphoreTest.cs
+++ b/Consul.Test/SemaphoreTest.cs
@@ -388,7 +388,7 @@ namespace Consul.Test
         [Fact]
         public async Task Cancelling_A_Token_When_Acquiring_A_Lock_Should_Throw_TaskCanceledException()
         {
-            var keyName = Path.GetTempFileName();
+            var keyName = Path.GetRandomFileName();
 
             var masterClient = new ConsulClient(c =>
             {
@@ -422,7 +422,7 @@ namespace Consul.Test
         [Fact]
         public async Task Cancelling_A_Token_When_Acquiring_A_Lock_Respects_The_Token()
         {
-            var keyName = Path.GetTempFileName();
+            var keyName = Path.GetRandomFileName();
 
             var masterInstanceClient = new ConsulClient(c =>
             {

--- a/Consul/Lock.cs
+++ b/Consul/Lock.cs
@@ -275,7 +275,7 @@ namespace Consul
 
                         QueryResult<KVPair> pair;
 
-                        pair = await _client.KV.Get(Opts.Key, qOpts).ConfigureAwait(false);
+                        pair = await _client.KV.Get(Opts.Key, qOpts, ct).ConfigureAwait(false);
 
                         if (pair.Response != null)
                         {
@@ -327,7 +327,7 @@ namespace Consul
 
                         // Failed to get the lock, determine why by querying for the key again
                         qOpts.WaitIndex = 0;
-                        pair = await _client.KV.Get(Opts.Key, qOpts).ConfigureAwait(false);
+                        pair = await _client.KV.Get(Opts.Key, qOpts, ct).ConfigureAwait(false);
 
                         // If the session is not null, this means that a wait can safely happen using a long poll
                         if (pair.Response != null && pair.Response.Session != null)


### PR DESCRIPTION
This is based on https://github.com/G-Research/consuldotnet/pull/66 for now, otherwise it throws the null ref as well. 

So once https://github.com/G-Research/consuldotnet/pull/66 is merged, I will rebase and cleanup this.

Partial fix for https://github.com/G-Research/consuldotnet/issues/65