### PR TITLE
Added service and node filtering abilities into QueryOptions

### DIFF
--- a/Consul.Test/FilterTests.cs
+++ b/Consul.Test/FilterTests.cs
@@ -1,0 +1,338 @@
+// -----------------------------------------------------------------------
+//  <copyright file="FilterTests.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"),
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Consul.Filtering;
+using Xunit;
+using S = Consul.Filtering.Selectors;
+
+namespace Consul.Test
+{
+    public class FilterTests : IDisposable
+    {
+        private ConsulClient _client;
+
+        public FilterTests()
+        {
+            _client = new ConsulClient(c =>
+            {
+                c.Token = TestHelper.MasterToken;
+                c.Address = TestHelper.HttpUri;
+            });
+        }
+
+        public void Dispose()
+        {
+            _client.Dispose();
+        }
+
+        private static void CheckEncoded(string expected, IEncodable expression) =>
+            Assert.Equal(expected, expression.Encode());
+
+        private class TestFilter : Filter
+        {
+            public static TestFilter Instance { get; } = new TestFilter();
+
+            public override string Encode() => "Test";
+        }
+
+        private class TestSelector : Selector, IEqualsApplicableConstraint, IContainsApplicableConstraint
+        {
+            public static TestSelector Instance { get; } = new TestSelector();
+
+            public override string Encode() => "Test";
+        }
+
+        private static class ServiceConstants
+        {
+            public static readonly string NodeName = "nodeName";
+            public static readonly string ServiceId = "serviceId";
+            public static readonly string Address = "1.1.1.1";
+            public static readonly int Port = 1234;
+            public static readonly string ServiceName = "serviceName";
+            public static readonly string MetaName = "Environment";
+            public static readonly string MetaValue = "dev1";
+            public static readonly string Tag = "well-behaved";
+            public static readonly Dictionary<string, string> Meta = new Dictionary<string, string> { { MetaName, MetaValue } };
+        }
+
+        private async Task<ServiceEntry[]> CreateAndFindServiceByFilterOnAgent(Filter filter)
+        {
+            await _client.Agent.ServiceRegister(new AgentServiceRegistration
+            {
+                ID = ServiceConstants.ServiceId,
+                Address = ServiceConstants.Address,
+                Port = ServiceConstants.Port,
+                Meta = ServiceConstants.Meta,
+                Name = ServiceConstants.ServiceName,
+                Tags = new[] { ServiceConstants.Tag },
+                EnableTagOverride = false,
+            });
+
+            var queryResult = await _client.Health.Service(ServiceConstants.ServiceName, null, passingOnly: false, q: QueryOptions.Default, filter: filter);
+
+            await _client.Agent.ServiceDeregister(ServiceConstants.ServiceId);
+
+            return queryResult.Response;
+        }
+
+        [Fact]
+        public async Task Filter_Service_PerfectMatch()
+        {
+            var filter = S.Service.Id == ServiceConstants.ServiceId
+                & !S.Service.Meta.IsEmpty()
+                & S.Service.Meta[ServiceConstants.MetaName] == ServiceConstants.MetaValue
+                & !S.Service.Tags.IsEmpty()
+                & S.Service.Tags.Contains(ServiceConstants.Tag);
+
+            var result = await CreateAndFindServiceByFilterOnAgent(filter);
+
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public async Task Filter_Service_OtherId()
+        {
+            var filter = S.Service.Id == "other id";
+
+            var result = await CreateAndFindServiceByFilterOnAgent(filter);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task Filter_Service_EmptyMeta()
+        {
+            var filter = S.Service.Meta.IsEmpty();
+
+            var result = await CreateAndFindServiceByFilterOnAgent(filter);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task Filter_Service_ContainsOtherMeta()
+        {
+            var filter = S.Service.Meta[ServiceConstants.MetaName] == "other value";
+
+            var result = await CreateAndFindServiceByFilterOnAgent(filter);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task Filter_Service_EmptyTags()
+        {
+            var filter = S.Service.Tags.IsEmpty();
+
+            var result = await CreateAndFindServiceByFilterOnAgent(filter);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task Filter_Service_ContainsOtherTag()
+        {
+            var filter = S.Service.Tags.Contains("other tag");
+
+            var result = await CreateAndFindServiceByFilterOnAgent(filter);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Filter_CompositeTest()
+        {
+            var filter = S.Service.Meta.IsEmpty() | S.Service.Meta["instance_type"] == "t2.medium" | S.Service.Tags.Contains("primary") & S.Service.Id == "53A4BE6C";
+
+            var expected = @"((Service.Meta is empty or Service.Meta.instance_type == ""t2.medium"") or (Service.Tags contains ""primary"" and Service.ID == ""53A4BE6C""))";
+
+            CheckEncoded(expected, filter);
+        }
+
+        [Fact]
+        public void Filter_MetaSelector()
+        {
+            CheckEncoded("Meta", new MetaSelector(null));
+        }
+
+        [Fact]
+        public void Filter_MetaSelector_IsEmpty()
+        {
+            CheckEncoded("Meta is empty", new MetaSelector(null).IsEmpty());
+        }
+
+        [Fact]
+        public void Filter_MetaSelector_Indexate()
+        {
+            CheckEncoded("Meta.field", new MetaSelector(null)["field"]);
+        }
+
+        [Fact]
+        public void Filter_Selectors_Service()
+        {
+            CheckEncoded("Service", S.Service);
+        }
+
+        [Fact]
+        public void Filter_ServiceMetaEntrySelector()
+        {
+            CheckEncoded("A.B", new ServiceMetaEntrySelector("A", "B"));
+        }
+
+        [Fact]
+        public void Filter_ServiceMetaEntrySelector_Contains()
+        {
+            CheckEncoded("A.B contains \"C\"", new ServiceMetaEntrySelector("A", "B").Contains("C"));
+        }
+
+        [Fact]
+        public void Filter_ServiceMetaEntrySelector_Eq()
+        {
+            CheckEncoded("A.B == \"C\"", new ServiceMetaEntrySelector("A", "B") == "C");
+        }
+
+        [Fact]
+        public void Filter_ServiceMetaEntrySelector_NotEq()
+        {
+            CheckEncoded("A.B != \"C\"", new ServiceMetaEntrySelector("A", "B") != "C");
+        }
+
+        [Fact]
+        public void Filter_ServiceSelector_Id()
+        {
+            CheckEncoded("Service.ID", new ServiceSelector().Id);
+        }
+
+        [Fact]
+        public void Filter_ServiceSelector_Tags()
+        {
+            CheckEncoded("Service.Tags", new ServiceSelector().Tags);
+        }
+
+        [Fact]
+        public void Filter_ServiceSelector_Meta()
+        {
+            CheckEncoded("Service.Meta", new ServiceSelector().Meta);
+        }
+
+        [Fact]
+        public void Filter_StringFieldSelector()
+        {
+            CheckEncoded("A.B", new StringFieldSelector("A", "B"));
+        }
+
+        [Fact]
+        public void Filter_StringFieldSelector_IsEmpty()
+        {
+            CheckEncoded("A.B is empty", new StringFieldSelector("A", "B").IsEmpty());
+        }
+
+        [Fact]
+        public void Filter_StringFieldSelector_Contains()
+        {
+            CheckEncoded("A.B contains \"C\"", new StringFieldSelector("A", "B").Contains("C"));
+        }
+
+        [Fact]
+        public void Filter_StringFieldSelector_Eq()
+        {
+            CheckEncoded("A.B == \"C\"", new StringFieldSelector("A", "B") == "C");
+        }
+
+        [Fact]
+        public void Filter_StringFieldSelector_NotEq()
+        {
+            CheckEncoded("A.B != \"C\"", new StringFieldSelector("A", "B") != "C");
+        }
+
+        [Fact]
+        public void Filter_TagsSelector()
+        {
+            CheckEncoded("A.Tags", new TagsSelector("A"));
+        }
+
+        [Fact]
+        public void Filter_TagsSelector_IsEmpty()
+        {
+            CheckEncoded("A.Tags is empty", new TagsSelector("A").IsEmpty());
+        }
+
+        [Fact]
+        public void Filter_TagsSelector_Contains()
+        {
+            CheckEncoded("A.Tags contains \"B\"", new TagsSelector("A").Contains("B"));
+        }
+
+        [Fact]
+        public void Filter_Filter_And()
+        {
+            CheckEncoded("(Test and Test)", TestFilter.Instance & TestFilter.Instance);
+        }
+
+        [Fact]
+        public void Filter_Filter_Or()
+        {
+            CheckEncoded("(Test or Test)", TestFilter.Instance | TestFilter.Instance);
+        }
+
+        [Fact]
+        public void Filter_Filter_Not()
+        {
+            CheckEncoded("not Test", !TestFilter.Instance);
+        }
+
+        [Fact]
+        public void Filter_Filters_And()
+        {
+            CheckEncoded("(Test and Test)", Filters.And(TestFilter.Instance, TestFilter.Instance));
+        }
+
+        [Fact]
+        public void Filter_Filters_Or()
+        {
+            CheckEncoded("(Test or Test)", Filters.Or(TestFilter.Instance, TestFilter.Instance));
+        }
+
+        [Fact]
+        public void Filter_Filters_Not()
+        {
+            CheckEncoded("not Test", Filters.Not(TestFilter.Instance));
+        }
+
+        [Fact]
+        public void Filter_Filters_Contains()
+        {
+            CheckEncoded("Test contains \"A\"", Filters.Contains(TestSelector.Instance, "A"));
+        }
+
+        [Fact]
+        public void Filter_Filters_Eq()
+        {
+            CheckEncoded("Test == \"A\"", Filters.Eq(TestSelector.Instance, "A"));
+        }
+
+        [Fact]
+        public void Filter_Filters_NotEq()
+        {
+            CheckEncoded("Test != \"A\"", Filters.NotEq(TestSelector.Instance, "A"));
+        }
+    }
+}

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -22,6 +22,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Cryptography.X509Certificates;
+using Consul.Filtering;
 using Newtonsoft.Json;
 #if !(CORECLR || PORTABLE || PORTABLE40)
 using System.Security.Permissions;
@@ -592,9 +593,9 @@ namespace Consul
             }
         }
 
-        internal GetRequest<TOut> Get<TOut>(string path, QueryOptions opts = null)
+        internal GetRequest<TOut> Get<TOut>(string path, QueryOptions opts = null, IEncodable filter = null)
         {
-            return new GetRequest<TOut>(this, path, opts ?? QueryOptions.Default);
+            return new GetRequest<TOut>(this, path, opts ?? QueryOptions.Default, filter);
         }
 
         internal GetRequest Get(string path, QueryOptions opts = null)

--- a/Consul/Client_GetRequests.cs
+++ b/Consul/Client_GetRequests.cs
@@ -23,6 +23,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Consul.Filtering;
 #if !(CORECLR || PORTABLE || PORTABLE40)
     using System.Security.Permissions;
     using System.Runtime.Serialization;
@@ -38,13 +39,16 @@ namespace Consul
     {
         public QueryOptions Options { get; set; }
 
-        public GetRequest(ConsulClient client, string url, QueryOptions options = null) : base(client, url, HttpMethod.Get)
+        public IEncodable Filter { get; set; }
+
+        public GetRequest(ConsulClient client, string url, QueryOptions options = null, IEncodable filter = null) : base(client, url, HttpMethod.Get)
         {
             if (string.IsNullOrEmpty(url))
             {
                 throw new ArgumentException(nameof(url));
             }
             Options = options ?? QueryOptions.Default;
+            Filter = filter;
         }
 
         /// <summary>
@@ -126,6 +130,11 @@ namespace Consul
 
         protected override void ApplyOptions(ConsulClientConfiguration clientConfig)
         {
+            if (Filter != null)
+            {
+                Params["filter"] = Filter.Encode();
+            }
+
             if (Options == QueryOptions.Default)
             {
                 return;

--- a/Consul/Filtering/Constraints.cs
+++ b/Consul/Filtering/Constraints.cs
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Constaints.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"),
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+namespace Consul.Filtering
+{
+    internal interface IEmptyApplicableConstraint
+    {
+    }
+
+    internal interface IEqualsApplicableConstraint
+    {
+    }
+
+    internal interface IContainsApplicableConstraint
+    {
+    }
+}

--- a/Consul/Filtering/Filter.cs
+++ b/Consul/Filtering/Filter.cs
@@ -1,0 +1,95 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Filter.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+namespace Consul.Filtering
+{
+    // todo generalize to allow usage for nodes filtering (marker class as a generic parameter?)
+    public abstract class Filter : IEncodable
+    {
+        public abstract string Encode();
+
+        public static Filter operator &(Filter left, Filter right) =>
+            Filters.And(left, right);
+
+        public static Filter operator |(Filter left, Filter right) =>
+            Filters.Or(left, right);
+
+        public static Filter operator !(Filter filter) =>
+            Filters.Not(filter);
+
+        protected static string Quote(string s) => '"' + s.Replace(@"\", @"\\").Replace(@"""", @"\""") + '"'; // todo escape better?
+    }
+
+    internal sealed class AndFilter : Filter
+    {
+        public Filter LeftFilter { get; set; }
+        public Filter RightFilter { get; set; }
+
+        public override string Encode() => $"({LeftFilter.Encode()} and {RightFilter.Encode()})";
+    }
+
+    internal sealed class OrFilter : Filter
+    {
+        public Filter LeftFilter { get; set; }
+        public Filter RightFilter { get; set; }
+
+        public override string Encode() => $"({LeftFilter.Encode()} or {RightFilter.Encode()})";
+    }
+
+    internal sealed class NotFilter : Filter
+    {
+        public Filter Filter { get; set; }
+
+        public override string Encode() => $"not {Filter.Encode()}";
+    }
+
+    internal sealed class EmptyFilter<TSelector> : Filter
+        where TSelector : Selector, IEmptyApplicableConstraint
+    {
+        public TSelector Selector { get; set; }
+
+        public override string Encode() => $"{Selector.Encode()} is empty";
+    }
+
+    internal sealed class ContainsFilter<TSelector> : Filter
+        where TSelector : Selector, IContainsApplicableConstraint
+    {
+        public TSelector Selector { get; set; }
+        public string Value { get; set; }
+
+        public override string Encode() => $"{Selector.Encode()} contains {Quote(Value)}";
+    }
+
+    internal sealed class EqualsFilter<TSelector> : Filter
+        where TSelector : Selector, IEqualsApplicableConstraint
+    {
+        public TSelector Selector { get; set; }
+        public string Value { get; set; }
+
+        public override string Encode() => $"{Selector.Encode()} == {Quote(Value)}";
+    }
+
+    internal sealed class NotEqualsFilter<TSelector> : Filter
+        where TSelector : Selector, IEqualsApplicableConstraint
+    {
+        public TSelector Selector { get; set; }
+        public string Value { get; set; }
+
+        public override string Encode() => $"{Selector.Encode()} != {Quote(Value)}";
+    }
+}

--- a/Consul/Filtering/Filters.cs
+++ b/Consul/Filtering/Filters.cs
@@ -1,0 +1,67 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Filters.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+namespace Consul.Filtering
+{
+    public static class Filters
+    {
+        internal static Filter And(Filter left, Filter right) => new AndFilter
+        {
+            LeftFilter = left,
+            RightFilter = right,
+        };
+
+        internal static Filter Or(Filter left, Filter right) => new OrFilter
+        {
+            LeftFilter = left,
+            RightFilter = right,
+        };
+
+        internal static Filter Not(Filter filter) => new NotFilter
+        {
+            Filter = filter,
+        };
+
+        internal static Filter Empty<TSelector>(TSelector selector)
+            where TSelector : Selector, IEmptyApplicableConstraint => new EmptyFilter<TSelector>
+            {
+                Selector = selector,
+            };
+
+        internal static Filter Contains<TSelector>(TSelector selector, string value)
+            where TSelector : Selector, IContainsApplicableConstraint => new ContainsFilter<TSelector>
+            {
+                Selector = selector,
+                Value = value,
+            };
+
+        internal static Filter Eq<TSelector>(TSelector selector, string value)
+            where TSelector : Selector, IEqualsApplicableConstraint => new EqualsFilter<TSelector>
+            {
+                Selector = selector,
+                Value = value,
+            };
+
+        internal static Filter NotEq<TSelector>(TSelector selector, string value)
+            where TSelector : Selector, IEqualsApplicableConstraint => new NotEqualsFilter<TSelector>
+            {
+                Selector = selector,
+                Value = value,
+            };
+    }
+}

--- a/Consul/Filtering/IEncodable.cs
+++ b/Consul/Filtering/IEncodable.cs
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------
+//  <copyright file="IEncodable.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"),
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+namespace Consul.Filtering
+{
+    public interface IEncodable
+    {
+        string Encode();
+    }
+}

--- a/Consul/Filtering/Selectors/MetaSelector.cs
+++ b/Consul/Filtering/Selectors/MetaSelector.cs
@@ -1,0 +1,38 @@
+// -----------------------------------------------------------------------
+//  <copyright file="MetaSelector.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+namespace Consul.Filtering
+{
+    public sealed class MetaSelector : Selector, IEmptyApplicableConstraint
+    {
+        private static readonly string Self = "Meta";
+
+        public string Prefix { get; }
+
+        public MetaSelector(string prefix)
+        {
+            Prefix = prefix;
+        }
+
+        public override string Encode() => Combine(Prefix, Self);
+
+        public ServiceMetaEntrySelector this[string name] => new ServiceMetaEntrySelector(Encode(), name);
+
+        public Filter IsEmpty() => Filters.Empty(this);
+    }
+}

--- a/Consul/Filtering/Selectors/NodeSelector.cs
+++ b/Consul/Filtering/Selectors/NodeSelector.cs
@@ -1,0 +1,31 @@
+// -----------------------------------------------------------------------
+//  <copyright file="NodeSelector.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+namespace Consul.Filtering
+{
+    public sealed class NodeSelector : Selector
+    {
+        private static readonly string Self = "Node";
+
+        public StringFieldSelector Id { get; } = new StringFieldSelector(Self, "ID");
+        public StringFieldSelector Node { get; } = new StringFieldSelector(Self, "Node");
+        public MetaSelector Meta { get; } = new MetaSelector(Self);
+
+        public override string Encode() => Self;
+    }
+}

--- a/Consul/Filtering/Selectors/Selector.cs
+++ b/Consul/Filtering/Selectors/Selector.cs
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Selector.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+namespace Consul.Filtering
+{
+    public abstract class Selector : IEncodable
+    {
+        public abstract string Encode();
+
+        protected static string Combine(string prefix, string self) =>
+            string.IsNullOrEmpty(prefix) ? self : $"{prefix}.{self}";
+    }
+}

--- a/Consul/Filtering/Selectors/Selectors.cs
+++ b/Consul/Filtering/Selectors/Selectors.cs
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Selectors.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+namespace Consul.Filtering
+{
+    public static class Selectors
+    {
+        public static ServiceSelector Service { get; } = new ServiceSelector();
+    }
+}

--- a/Consul/Filtering/Selectors/ServiceMetaEntrySelector.cs
+++ b/Consul/Filtering/Selectors/ServiceMetaEntrySelector.cs
@@ -1,0 +1,42 @@
+// -----------------------------------------------------------------------
+//  <copyright file="ServiceMetaEntrySelector.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+#pragma warning disable CS0660 // Type defines operator == or operator != but does not override Object.Equals(object o)
+#pragma warning disable CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
+namespace Consul.Filtering
+{
+    public sealed class ServiceMetaEntrySelector : Selector, IEqualsApplicableConstraint, IEmptyApplicableConstraint, IContainsApplicableConstraint
+    {
+        public string Prefix { get; }
+        public string Name { get; }
+
+        public ServiceMetaEntrySelector(string prefix, string name)
+        {
+            Prefix = prefix;
+            Name = name;
+        }
+
+        public override string Encode() => Combine(Prefix, Name);
+
+        public Filter Contains(string value) => Filters.Contains(this, value);
+        public static Filter operator ==(ServiceMetaEntrySelector selector, string value) => Filters.Eq(selector, value);
+        public static Filter operator !=(ServiceMetaEntrySelector selector, string value) => Filters.NotEq(selector, value);
+    }
+}
+#pragma warning restore CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
+#pragma warning restore CS0660 // Type defines operator == or operator != but does not override Object.Equals(object o)

--- a/Consul/Filtering/Selectors/ServiceSelector.cs
+++ b/Consul/Filtering/Selectors/ServiceSelector.cs
@@ -1,0 +1,35 @@
+// -----------------------------------------------------------------------
+//  <copyright file="ServiceSelector.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+#pragma warning disable CS0660 // Type defines operator == or operator != but does not override Object.Equals(object o)
+#pragma warning disable CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
+namespace Consul.Filtering
+{
+    public sealed class ServiceSelector : Selector
+    {
+        private static readonly string Self = "Service";
+
+        public StringFieldSelector Id { get; } = new StringFieldSelector(Self, "ID");
+        public TagsSelector Tags { get; } = new TagsSelector(Self);
+        public MetaSelector Meta { get; } = new MetaSelector(Self);
+
+        public override string Encode() => Self;
+    }
+}
+#pragma warning restore CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
+#pragma warning restore CS0660 // Type defines operator == or operator != but does not override Object.Equals(object o)

--- a/Consul/Filtering/Selectors/StringFieldSelector.cs
+++ b/Consul/Filtering/Selectors/StringFieldSelector.cs
@@ -1,0 +1,43 @@
+// -----------------------------------------------------------------------
+//  <copyright file="StringFieldSelector.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+#pragma warning disable CS0660 // Type defines operator == or operator != but does not override Object.Equals(object o)
+#pragma warning disable CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
+namespace Consul.Filtering
+{
+    public sealed class StringFieldSelector : Selector, IEqualsApplicableConstraint, IEmptyApplicableConstraint, IContainsApplicableConstraint
+    {
+        public string Prefix { get; }
+        public string Name { get; }
+
+        public StringFieldSelector(string prefix, string name)
+        {
+            Prefix = prefix;
+            Name = name;
+        }
+
+        public override string Encode() => Combine(Prefix, Name);
+
+        public Filter IsEmpty() => Filters.Empty(this);
+        public Filter Contains(string value) => Filters.Contains(this, value);
+        public static Filter operator ==(StringFieldSelector selector, string value) => Filters.Eq(selector, value);
+        public static Filter operator !=(StringFieldSelector selector, string value) => Filters.NotEq(selector, value);
+    }
+}
+#pragma warning restore CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
+#pragma warning restore CS0660 // Type defines operator == or operator != but does not override Object.Equals(object o)

--- a/Consul/Filtering/Selectors/TagsSelector.cs
+++ b/Consul/Filtering/Selectors/TagsSelector.cs
@@ -1,0 +1,37 @@
+// -----------------------------------------------------------------------
+//  <copyright file="TagsSelector.cs" company="G-Research Limited">
+//    Copyright 2020 G-Research Limited
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+namespace Consul.Filtering
+{
+    public sealed class TagsSelector : Selector, IEmptyApplicableConstraint, IContainsApplicableConstraint
+    {
+        private static readonly string Self = "Tags";
+
+        public string Prefix { get; }
+
+        public TagsSelector(string prefix)
+        {
+            Prefix = prefix;
+        }
+
+        public override string Encode() => Combine(Prefix, Self);
+
+        public Filter IsEmpty() => Filters.Empty(this);
+        public Filter Contains(string value) => Filters.Contains(this, value);
+    }
+}

--- a/Consul/Health.cs
+++ b/Consul/Health.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Consul.Filtering;
 using Newtonsoft.Json;
 
 namespace Consul
@@ -291,6 +292,30 @@ namespace Consul
         public Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, CancellationToken ct = default(CancellationToken))
         {
             var req = _client.Get<ServiceEntry[]>(string.Format("/v1/health/service/{0}", service), q);
+            if (!string.IsNullOrEmpty(tag))
+            {
+                req.Params["tag"] = tag;
+            }
+            if (passingOnly)
+            {
+                req.Params["passing"] = "1";
+            }
+            return req.Execute(ct);
+        }
+
+        /// <summary>
+        /// Service is used to query health information along with service info for a given service. It can optionally do server-side filtering on a tag or nodes with passing health checks only.
+        /// </summary>
+        /// <param name="service">The service ID</param>
+        /// <param name="tag">The service member tag</param>
+        /// <param name="passingOnly">Only return if the health check is in the Passing state</param>
+        /// <param name="q">Customized query options</param>
+        /// <param name="filter">Specifies the expression used to filter the queries results prior to returning the data</param>
+        /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
+        /// <returns>A query result containing the service members matching the provided service ID, tag, and health status, or a query result with a null response if no service members matched the filters provided</returns>
+        public Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, Filter filter, CancellationToken ct = default(CancellationToken))
+        {
+            var req = _client.Get<ServiceEntry[]>(string.Format("/v1/health/service/{0}", service), q, filter);
             if (!string.IsNullOrEmpty(tag))
             {
                 req.Params["tag"] = tag;

--- a/Consul/Interfaces/IHealthEndpoint.cs
+++ b/Consul/Interfaces/IHealthEndpoint.cs
@@ -19,6 +19,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Consul.Filtering;
 
 namespace Consul
 {
@@ -35,6 +36,7 @@ namespace Consul
         Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, CancellationToken ct = default(CancellationToken));
         Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, CancellationToken ct = default(CancellationToken));
         Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, Filter filter, CancellationToken ct = default(CancellationToken));
         Task<QueryResult<HealthCheck[]>> State(HealthStatus status, CancellationToken ct = default(CancellationToken));
         Task<QueryResult<HealthCheck[]>> State(HealthStatus status, QueryOptions q, CancellationToken ct = default(CancellationToken));
     }


### PR DESCRIPTION
Added [server-side filtering support](https://www.consul.io/api-docs/features/filtering) as an eDSL

This implementation supports filtering by the following components:
- Service
  - ID
  - Tags
  - Meta

With the following operations:
- and
- or
- not
- ==
- !=
- contains
- is empty

For Health.Service

whenever they are applicable to the listed components

Functionally satisfies #26