### PR TITLE
Tests: Add Newtonsoft.Json reference to fix test run for net461

### DIFF
--- a/Consul.Test/Consul.Test.csproj
+++ b/Consul.Test/Consul.Test.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="3.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />


### PR DESCRIPTION
Considered using https://github.com/ravibpatel/ILRepack.Lib.MSBuild.Task instead but it'd mean we count on it being maintained in the future, and we'd need to handle binding redirects.

This is a workaround until we remove the ILRepack step altogether.

Closes https://github.com/G-Research/consuldotnet/issues/69