### PR TITLE
Merge Newtonsoft.Json at build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,16 +55,6 @@ jobs:
           rm consul.zip
       - name: Build
         run: dotnet build --configuration=Release -p:TreatWarningsAsErrors=true
-      - name: Repack
-        if: runner.os == 'Windows'
-        run: |
-          cd Consul/bin/Release
-          mv net461 net461unmerged
-          cd net461unmerged
-          &$HOME/.nuget/packages/ilrepack/2.0.18/tools/ilrepack.exe /keyfile:${{ github.workspace }}/assets/consuldotnet.snk /parallel /internalize /out:../net461/Consul.dll Consul.dll Newtonsoft.Json.dll
-          cd ..
-          cp net461unmerged/Consul.pdb net461/
-          rm -r net461unmerged
       - name: Run tests
         shell: bash
         run: |

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -47,19 +47,21 @@
 
   <Target Name="ILMerge" AfterTargets="AfterBuild" Condition=" '$(TargetFramework)' == 'net461' ">
     <ItemGroup>
-      <BuildArtifacts Include="$(OutputPath)\$(AssemblyName).*" />
-      <ArtifactsToMerge Include="$(OutputPath)\Newtonsoft.Json.dll" />
+      <BuildArtifacts Include="$(OutputPath)$(AssemblyName).*" />
+      <ArtifactsToMerge Include="$(OutputPath)Newtonsoft.Json.dll" />
     </ItemGroup>
     <PropertyGroup>
-      <IlmergeCommand>$(ILMergeConsolePath) /out:$(OutputPath)\ILMerge\$(AssemblyName).dll</IlmergeCommand>
-      <IlmergeCommand>$(IlmergeCommand) /keyfile:../assets/consuldotnet.snk</IlmergeCommand>
-      <IlmergeCommand>$(IlmergeCommand) $(OutputPath)\$(AssemblyName).dll @(ArtifactsToMerge->'%(RelativeDir)%(filename)%(extension)', ' ')</IlmergeCommand>
+      <IlmergeCommand>$(ILMergeConsolePath) /internalize /out:$(OutputPath)ILMerge\$(AssemblyName).dll</IlmergeCommand>
+      <IlmergeCommand>$(IlmergeCommand) /keyfile:$(AssemblyOriginatorKeyFile)</IlmergeCommand>
+      <IlmergeCommand>$(IlmergeCommand) $(OutputPath)$(AssemblyName).dll @(ArtifactsToMerge->'%(RelativeDir)%(filename)%(extension)', ' ')</IlmergeCommand>
     </PropertyGroup>
     <MakeDir Directories="$(OutputPath)\ILMerge" />
     <Exec Command="$(IlmergeCommand)" ContinueOnError="false" />
-    <Move SourceFiles="%(BuildArtifacts.RelativeDir)\ILMerge\%(filename)%(extension)"
+    <Move SourceFiles="%(BuildArtifacts.RelativeDir)ILMerge\%(filename)%(extension)"
           DestinationFiles="%(BuildArtifacts.RelativeDir)%(filename)%(extension)"
           OverwriteReadOnlyFiles="true"/>
+    <Delete Files="$(ArtifactsToMerge)" />
+    <RemoveDir Directories="$(OutputPath)ILMerge" />
   </Target>
 
 </Project>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -27,7 +27,6 @@
     <AssemblyOriginatorKeyFile>../assets/consuldotnet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
@@ -60,7 +59,5 @@
     <Exec Command="$(IlmergeCommand)" ContinueOnError="false" />
     <Move SourceFiles="%(BuildArtifacts.RelativeDir)\ILMerge\%(filename)%(extension)" DestinationFiles="%(BuildArtifacts.RelativeDir)%(filename)%(extension)" OverwriteReadOnlyFiles="true"/>
   </Target>
-  <ItemGroup>
-    <DotNetCliToolReference Include="ILRepack" Version="2.0.18" />
-  </ItemGroup>
+
 </Project>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -60,7 +60,7 @@
     <Move SourceFiles="%(BuildArtifacts.RelativeDir)ILMerge\%(filename)%(extension)"
           DestinationFiles="%(BuildArtifacts.RelativeDir)%(filename)%(extension)"
           OverwriteReadOnlyFiles="true"/>
-    <Delete Files="$(ArtifactsToMerge)" />
+    <Delete Files="@(ArtifactsToMerge)" />
     <RemoveDir Directories="$(OutputPath)ILMerge" />
   </Target>
 

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -45,7 +45,7 @@
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 
-  <Target Name="ILMerge" AfterTargets="Build" Condition=" '$(TargetFramework)' == 'net461' ">
+  <Target Name="ILMerge" AfterTargets="AfterBuild" Condition=" '$(TargetFramework)' == 'net461' ">
     <ItemGroup>
       <BuildArtifacts Include="$(OutputPath)\$(AssemblyName).*" />
       <ArtifactsToMerge Include="$(OutputPath)\Newtonsoft.Json.dll" />
@@ -57,7 +57,9 @@
     </PropertyGroup>
     <MakeDir Directories="$(OutputPath)\ILMerge" />
     <Exec Command="$(IlmergeCommand)" ContinueOnError="false" />
-    <Move SourceFiles="%(BuildArtifacts.RelativeDir)\ILMerge\%(filename)%(extension)" DestinationFiles="%(BuildArtifacts.RelativeDir)%(filename)%(extension)" OverwriteReadOnlyFiles="true"/>
+    <Move SourceFiles="%(BuildArtifacts.RelativeDir)\ILMerge\%(filename)%(extension)"
+          DestinationFiles="%(BuildArtifacts.RelativeDir)%(filename)%(extension)"
+          OverwriteReadOnlyFiles="true"/>
   </Target>
 
 </Project>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="ILMerge" Version="3.0.41" />
+    <PackageReference Include="ILMerge" Version="3.0.41" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" PrivateAssets="All" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -52,7 +52,7 @@
     </ItemGroup>
     <PropertyGroup>
       <IlmergeCommand>$(ILMergeConsolePath) /out:$(OutputPath)\ILMerge\$(AssemblyName).dll</IlmergeCommand>
-      <IlmergeCommand>$(IlmergeCommand) /delaysign /keyfile:../assets/consuldotnet.snk</IlmergeCommand>
+      <IlmergeCommand>$(IlmergeCommand) /keyfile:../assets/consuldotnet.snk</IlmergeCommand>
       <IlmergeCommand>$(IlmergeCommand) $(OutputPath)\$(AssemblyName).dll @(ArtifactsToMerge->'%(RelativeDir)%(filename)%(extension)', ' ')</IlmergeCommand>
     </PropertyGroup>
     <MakeDir Directories="$(OutputPath)\ILMerge" />

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -27,6 +27,7 @@
     <AssemblyOriginatorKeyFile>../assets/consuldotnet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
@@ -34,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="ILMerge" Version="3.0.41" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" PrivateAssets="All" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
@@ -44,6 +46,20 @@
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 
+  <Target Name="ILMerge" AfterTargets="Build" Condition=" '$(TargetFramework)' == 'net461' ">
+    <ItemGroup>
+      <BuildArtifacts Include="$(OutputPath)\$(AssemblyName).*" />
+      <ArtifactsToMerge Include="$(OutputPath)\Newtonsoft.Json.dll" />
+    </ItemGroup>
+    <PropertyGroup>
+      <IlmergeCommand>$(ILMergeConsolePath) /out:$(OutputPath)\ILMerge\$(AssemblyName).dll</IlmergeCommand>
+      <IlmergeCommand>$(IlmergeCommand) /delaysign /keyfile:../assets/consuldotnet.snk</IlmergeCommand>
+      <IlmergeCommand>$(IlmergeCommand) $(OutputPath)\$(AssemblyName).dll @(ArtifactsToMerge->'%(RelativeDir)%(filename)%(extension)', ' ')</IlmergeCommand>
+    </PropertyGroup>
+    <MakeDir Directories="$(OutputPath)\ILMerge" />
+    <Exec Command="$(IlmergeCommand)" ContinueOnError="false" />
+    <Move SourceFiles="%(BuildArtifacts.RelativeDir)\ILMerge\%(filename)%(extension)" DestinationFiles="%(BuildArtifacts.RelativeDir)%(filename)%(extension)" OverwriteReadOnlyFiles="true"/>
+  </Target>
   <ItemGroup>
     <DotNetCliToolReference Include="ILRepack" Version="2.0.18" />
   </ItemGroup>


### PR DESCRIPTION
Fixes the https://github.com/G-Research/consuldotnet/issues/69
Before this change the `Newtonsoft.Json` dependency was merged into the main `consul` assembly only in the CI pipeline but not when it was built locally. After this change the merge step will run for all local builds so there is no need to run in in the CI pipeline anymore. It is alternative approach to the one proposed in the https://github.com/G-Research/consuldotnet/pull/71.
