### PR TITLE
Convert to System.Text.Json

### DIFF
--- a/Consul.Test/AgentTest.cs
+++ b/Consul.Test/AgentTest.cs
@@ -48,8 +48,8 @@ namespace Consul.Test
             var info = await _client.Agent.Self();
 
             Assert.NotNull(info);
-            Assert.False(string.IsNullOrEmpty(info.Response["Config"]["NodeName"]));
-            Assert.False(string.IsNullOrEmpty(info.Response["Member"]["Tags"]["bootstrap"].ToString()));
+            Assert.False(string.IsNullOrEmpty(info.Response["Config"]["NodeName"].GetString()));
+            Assert.False(string.IsNullOrEmpty(info.Response["Member"]["Tags"].GetProperty("bootstrap").GetString()));
         }
 
         [Fact]
@@ -398,7 +398,7 @@ namespace Consul.Test
         public async Task Agent_Join()
         {
             var info = await _client.Agent.Self();
-            await _client.Agent.Join(info.Response["DebugConfig"]["AdvertiseAddrLAN"], false);
+            await _client.Agent.Join(info.Response["DebugConfig"]["AdvertiseAddrLAN"].GetString(), false);
             // Success is not throwing an exception
         }
 
@@ -406,7 +406,7 @@ namespace Consul.Test
         public async Task Agent_ForceLeave()
         {
             var info = await _client.Agent.Self();
-            await _client.Agent.ForceLeave(info.Response["Config"]["NodeName"]);
+            await _client.Agent.ForceLeave(info.Response["Config"]["NodeName"].GetString());
             // Success is not throwing an exception
         }
 

--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -46,7 +46,7 @@ namespace Consul.Test
         public async Task Health_GetLocalNode()
         {
             var info = await _client.Agent.Self();
-            var checks = await _client.Health.Node((string)info.Response["Config"]["NodeName"]);
+            var checks = await _client.Health.Node(info.Response["Config"]["NodeName"].GetString());
 
             Assert.NotEqual((ulong)0, checks.LastIndex);
             Assert.NotEmpty(checks.Response);

--- a/Consul/ACL.cs
+++ b/Consul/ACL.cs
@@ -18,9 +18,10 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Consul
 {
@@ -79,23 +80,14 @@ namespace Consul
     }
 
     [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-    public class ACLTypeConverter : JsonConverter
+    public class ACLTypeConverter : JsonConverter<ACLType>
     {
-#pragma warning disable CS0809 // Obsolete member 'ACLType.Equals(object)' overrides non-obsolete member
+#pragma warning disable CS0809
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-#pragma warning restore CS0809 // Obsolete member 'ACLType.Equals(object)' overrides non-obsolete member
+        public override ACLType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+#pragma warning restore CS0809
         {
-            serializer.Serialize(writer, ((ACLType)value).Type);
-        }
-
-#pragma warning disable CS0809 // Obsolete member 'ACLType.Equals(object)' overrides non-obsolete member
-        [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
-            JsonSerializer serializer)
-#pragma warning restore CS0809 // Obsolete member 'ACLType.Equals(object)' overrides non-obsolete member
-        {
-            var type = (string)serializer.Deserialize(reader, typeof(string));
+            var type = reader.GetString();
             switch (type)
             {
                 case "client":
@@ -103,21 +95,17 @@ namespace Consul
                 case "management":
                     return ACLType.Management;
                 default:
-                    throw new ArgumentOutOfRangeException("serializer", type,
+                    throw new ArgumentOutOfRangeException(nameof(reader), type,
                         "Unknown ACL token type value found during deserialization");
             }
         }
 
-#pragma warning disable CS0809 // Obsolete member 'ACLType.Equals(object)' overrides non-obsolete member
+#pragma warning disable CS0809
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public override bool CanConvert(Type objectType)
-#pragma warning restore CS0809 // Obsolete member 'ACLType.Equals(object)' overrides non-obsolete member
+        public override void Write(Utf8JsonWriter writer, ACLType value, JsonSerializerOptions options)
+#pragma warning restore CS0809
         {
-            if (objectType == typeof(ACLType))
-            {
-                return true;
-            }
-            return false;
+            writer.WriteStringValue(value.Type);
         }
     }
 
@@ -138,7 +126,7 @@ namespace Consul
 
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
         [JsonConverter(typeof(ACLTypeConverter))]
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public ACLType Type { get; set; }
 
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
@@ -191,12 +179,6 @@ namespace Consul
             _client = c;
         }
 
-        private class ACLCreationResult
-        {
-            [JsonProperty]
-            internal string ID { get; set; }
-        }
-
         /// <summary>
         /// [Deprecated] Create is used to generate a new token with the given parameters
         /// </summary>
@@ -217,8 +199,8 @@ namespace Consul
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
         public async Task<WriteResult<string>> Create(ACLEntry acl, WriteOptions q, CancellationToken ct = default(CancellationToken))
         {
-            var res = await _client.Put<ACLEntry, ACLCreationResult>("/v1/acl/create", acl, q).Execute(ct).ConfigureAwait(false);
-            return new WriteResult<string>(res, res.Response.ID);
+            var res = await _client.Put<ACLEntry, JsonElement>("/v1/acl/create", acl, q).Execute(ct).ConfigureAwait(false);
+            return new WriteResult<string>(res, res.Response.GetProperty("ID").GetString());
         }
 
         /// <summary>
@@ -287,8 +269,8 @@ namespace Consul
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
         public async Task<WriteResult<string>> Clone(string id, WriteOptions q, CancellationToken ct = default(CancellationToken))
         {
-            var res = await _client.PutReturning<ACLCreationResult>(string.Format("/v1/acl/clone/{0}", id), q).Execute(ct).ConfigureAwait(false);
-            return new WriteResult<string>(res, res.Response.ID);
+            var res = await _client.PutReturning<JsonElement>(string.Format("/v1/acl/clone/{0}", id), q).Execute(ct).ConfigureAwait(false);
+            return new WriteResult<string>(res, res.Response.GetProperty("ID").GetString());
         }
 
         /// <summary>

--- a/Consul/ACLReplication.cs
+++ b/Consul/ACLReplication.cs
@@ -17,9 +17,10 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Consul
 {

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -21,9 +21,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+
 
 namespace Consul
 {
@@ -80,18 +82,11 @@ namespace Consul
     /// <summary>
     /// TLS Status Convertor (to and from JSON)
     /// </summary>
-    public class TTLStatusConverter : JsonConverter
+    public class TTLStatusConverter : JsonConverter<TTLStatus>
     {
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override TTLStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            serializer.Serialize(writer, ((TTLStatus)value).Status);
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
-            JsonSerializer serializer)
-        {
-            var status = (string)serializer.Deserialize(reader, typeof(string));
-            switch (status)
+            switch (reader.GetString())
             {
                 case "pass":
                     return TTLStatus.Pass;
@@ -110,9 +105,9 @@ namespace Consul
             }
         }
 
-        public override bool CanConvert(Type objectType)
+        public override void Write(Utf8JsonWriter writer, TTLStatus value, JsonSerializerOptions options)
         {
-            return objectType == typeof(TTLStatus);
+            writer.WriteStringValue(value.Status);
         }
     }
 
@@ -177,31 +172,31 @@ namespace Consul
     /// </summary>
     public class AgentServiceRegistration
     {
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string ID { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Name { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string[] Tags { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public int Port { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Address { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool EnableTagOverride { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public AgentServiceCheck Check { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public AgentServiceCheck[] Checks { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public IDictionary<string, string> Meta { get; set; }
     }
 
@@ -210,7 +205,7 @@ namespace Consul
     /// </summary>
     public class AgentCheckRegistration : AgentServiceCheck
     {
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string ServiceID { get; set; }
     }
 
@@ -219,66 +214,65 @@ namespace Consul
     /// </summary>
     public class AgentServiceCheck
     {
-
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string ID { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Name { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Notes { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Script { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string[] Args { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string DockerContainerID { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Shell { get; set; } // Only supported for Docker.
 
         [JsonConverter(typeof(DurationTimespanConverter))]
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public TimeSpan? Interval { get; set; }
 
         [JsonConverter(typeof(DurationTimespanConverter))]
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public TimeSpan? Timeout { get; set; }
 
         [JsonConverter(typeof(DurationTimespanConverter))]
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public TimeSpan? TTL { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string HTTP { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public Dictionary<string, List<string>> Header { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Method { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Body { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string TCP { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [JsonConverter(typeof(HealthStatusConverter))]
         public HealthStatus Status { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool TLSSkipVerify { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string GRPC { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool GRPCUseTLS { get; set; }
 
         /// <summary>
@@ -290,7 +284,7 @@ namespace Consul
         /// automatically be deregistered.
         /// </summary>
         [JsonConverter(typeof(DurationTimespanConverter))]
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public TimeSpan? DeregisterCriticalServiceAfter { get; set; }
     }
 
@@ -330,9 +324,9 @@ namespace Consul
         /// Self is used to query the agent we are speaking to for information about itself
         /// </summary>
         /// <returns>A somewhat dynamic object representing the various data elements in Self</returns>
-        public Task<QueryResult<Dictionary<string, Dictionary<string, dynamic>>>> Self(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<Dictionary<string, Dictionary<string, JsonElement>>>> Self(CancellationToken ct = default(CancellationToken))
         {
-            return _client.Get<Dictionary<string, Dictionary<string, dynamic>>>("/v1/agent/self").Execute(ct);
+            return _client.Get<Dictionary<string, Dictionary<string, JsonElement>>>("/v1/agent/self").Execute(ct);
         }
 
         /// <summary>
@@ -358,7 +352,7 @@ namespace Consul
                 {
                     if (_nodeName == null)
                     {
-                        _nodeName = (await Self(ct)).Response["Config"]["NodeName"];
+                        _nodeName = (await Self(ct)).Response["Config"]["NodeName"].GetString();
                     }
                 }
             }

--- a/Consul/AuthMethod.cs
+++ b/Consul/AuthMethod.cs
@@ -18,9 +18,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Consul
 {
@@ -31,9 +32,9 @@ namespace Consul
     {
         public string Name { get; set; }
         public string Type { get; set; }
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Description { get; set; }
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public Dictionary<string, string> Config { get; set; }
 
         public bool ShouldSerializeCreateIndex()
@@ -79,9 +80,9 @@ namespace Consul
 
         private class AuthMethodActionResult : AuthMethodEntry
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public ulong CreateIndex { get; set; }
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public ulong ModifyIndex { get; set; }
         }
 

--- a/Consul/Catalog.cs
+++ b/Consul/Catalog.cs
@@ -18,9 +18,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Consul
 {
@@ -28,7 +29,7 @@ namespace Consul
     {
         // Cannot be "Node" as in the Go API because in C#, properties cannot
         // have the same name as their enclosing class.
-        [JsonProperty(PropertyName = "Node")]
+        [JsonPropertyName("Node")]
         public string Name { get; set; }
         public string Address { get; set; }
         public Dictionary<string, string> TaggedAddresses { get; set; }

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -22,7 +22,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Cryptography.X509Certificates;
-using Newtonsoft.Json;
+using System.Text.Json;
 #if !(CORECLR || PORTABLE || PORTABLE40)
 using System.Security.Permissions;
 using System.Runtime.Serialization;
@@ -369,8 +369,6 @@ namespace Consul
 #endif
         public ConsulClientConfiguration Config { get { return ConfigContainer.Config; } }
 
-        internal readonly JsonSerializer serializer = new JsonSerializer();
-
         #region New style config with Actions
         /// <summary>
         /// Initializes a new Consul client with a default configuration that connects to 127.0.0.1:8500.
@@ -529,7 +527,7 @@ namespace Consul
         void ApplyConfig(ConsulClientConfiguration config, WebRequestHandler handler, HttpClient client)
 #else
         void ApplyConfig(ConsulClientConfiguration config, HttpClientHandler handler, HttpClient client)
-#endif        
+#endif
         {
 #pragma warning disable CS0618 // Type or member is obsolete
             if (config.HttpAuth != null)

--- a/Consul/Client_DeleteRequests.cs
+++ b/Consul/Client_DeleteRequests.cs
@@ -79,9 +79,9 @@ namespace Consul
                 }
             }
 
-            if (response.IsSuccessStatusCode)
+            if (response.IsSuccessStatusCode && response.Content.Headers.ContentLength.GetValueOrDefault(0) > 0)
             {
-                result.Response = Deserialize<TOut>(ResponseStream);
+                result.Response = await Deserialize<TOut>(ResponseStream);
             }
 
             result.RequestTime = timer.Elapsed;

--- a/Consul/Client_GetRequests.cs
+++ b/Consul/Client_GetRequests.cs
@@ -80,9 +80,9 @@ namespace Consul
                 }
             }
 
-            if (response.IsSuccessStatusCode)
+            if (response.IsSuccessStatusCode && response.Content.Headers.ContentLength.GetValueOrDefault(0) > 0)
             {
-                result.Response = Deserialize<TOut>(ResponseStream);
+                result.Response = await Deserialize<TOut>(ResponseStream);
             }
 
             result.RequestTime = timer.Elapsed;

--- a/Consul/Client_PostRequests.cs
+++ b/Consul/Client_PostRequests.cs
@@ -84,9 +84,9 @@ namespace Consul
                 }
             }
 
-            if (response.IsSuccessStatusCode)
+            if (response.IsSuccessStatusCode && response.Content.Headers.ContentLength.GetValueOrDefault(0) > 0)
             {
-                result.Response = Deserialize<TOut>(ResponseStream);
+                result.Response = await Deserialize<TOut>(ResponseStream);
             }
 
             result.RequestTime = timer.Elapsed;
@@ -284,9 +284,9 @@ namespace Consul
                 }
             }
 
-            if (response.IsSuccessStatusCode)
+            if (response.IsSuccessStatusCode && response.Content.Headers.ContentLength.GetValueOrDefault(0) > 0)
             {
-                result.Response = Deserialize<TOut>(ResponseStream);
+                result.Response = await Deserialize<TOut>(ResponseStream);
             }
 
             result.RequestTime = timer.Elapsed;

--- a/Consul/Client_PutRequests.cs
+++ b/Consul/Client_PutRequests.cs
@@ -79,9 +79,9 @@ namespace Consul
                 }
             }
 
-            if (response.IsSuccessStatusCode)
+            if (response.IsSuccessStatusCode && response.Content.Headers.ContentLength.GetValueOrDefault(0) > 0)
             {
-                result.Response = Deserialize<TOut>(ResponseStream);
+                result.Response = await Deserialize<TOut>(ResponseStream);
             }
 
             result.RequestTime = timer.Elapsed;
@@ -343,8 +343,8 @@ namespace Consul
             ResponseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode && (
-                (response.StatusCode != HttpStatusCode.NotFound && typeof(TOut) != typeof(TxnResponse)) ||
-                (response.StatusCode != HttpStatusCode.Conflict && typeof(TOut) == typeof(TxnResponse))))
+                (response.StatusCode != HttpStatusCode.NotFound && typeof(TOut) != typeof(KVTxnResponse)) ||
+                (response.StatusCode != HttpStatusCode.Conflict && typeof(TOut) == typeof(KVTxnResponse))))
             {
                 if (ResponseStream == null)
                 {
@@ -360,9 +360,9 @@ namespace Consul
 
             if (response.IsSuccessStatusCode ||
                 // Special case for KV txn operations
-                (response.StatusCode == HttpStatusCode.Conflict && typeof(TOut) == typeof(TxnResponse)))
+                (response.StatusCode == HttpStatusCode.Conflict && typeof(TOut) == typeof(KVTxnResponse)))
             {
-                result.Response = Deserialize<TOut>(ResponseStream);
+                result.Response = await Deserialize<TOut>(ResponseStream);
             }
 
             result.RequestTime = timer.Elapsed;

--- a/Consul/Client_Request.cs
+++ b/Consul/Client_Request.cs
@@ -21,7 +21,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+
 #if !(CORECLR || PORTABLE || PORTABLE40)
     using System.Security.Permissions;
     using System.Runtime.Serialization;
@@ -106,20 +108,14 @@ namespace Consul
             return builder.Uri;
         }
 
-        protected TOut Deserialize<TOut>(Stream stream)
+        protected ValueTask<TOut> Deserialize<TOut>(Stream stream)
         {
-            using (var reader = new StreamReader(stream))
-            {
-                using (var jsonReader = new JsonTextReader(reader))
-                {
-                    return Client.serializer.Deserialize<TOut>(jsonReader);
-                }
-            }
+            return JsonSerializer.DeserializeAsync<TOut>(stream);
         }
 
         protected byte[] Serialize(object value)
         {
-            return System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(value));
+            return System.Text.Encoding.UTF8.GetBytes(JsonSerializer.Serialize(value));
         }
     }
 }

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -29,39 +29,17 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="ILMerge" Version="3.0.41" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" PrivateAssets="All" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="5.0.1" />
+  </ItemGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
-
-  <Target Name="ILMerge" AfterTargets="AfterBuild" Condition=" '$(TargetFramework)' == 'net461' ">
-    <ItemGroup>
-      <BuildArtifacts Include="$(OutputPath)$(AssemblyName).*" />
-      <ArtifactsToMerge Include="$(OutputPath)Newtonsoft.Json.dll" />
-    </ItemGroup>
-    <PropertyGroup>
-      <IlmergeCommand>$(ILMergeConsolePath) /internalize /out:$(OutputPath)ILMerge\$(AssemblyName).dll</IlmergeCommand>
-      <IlmergeCommand>$(IlmergeCommand) /keyfile:$(AssemblyOriginatorKeyFile)</IlmergeCommand>
-      <IlmergeCommand>$(IlmergeCommand) $(OutputPath)$(AssemblyName).dll @(ArtifactsToMerge->'%(RelativeDir)%(filename)%(extension)', ' ')</IlmergeCommand>
-    </PropertyGroup>
-    <MakeDir Directories="$(OutputPath)\ILMerge" />
-    <Exec Command="$(IlmergeCommand)" ContinueOnError="false" />
-    <Move SourceFiles="%(BuildArtifacts.RelativeDir)ILMerge\%(filename)%(extension)"
-          DestinationFiles="%(BuildArtifacts.RelativeDir)%(filename)%(extension)"
-          OverwriteReadOnlyFiles="true"/>
-    <Delete Files="@(ArtifactsToMerge)" />
-    <RemoveDir Directories="$(OutputPath)ILMerge" />
-  </Target>
-
 </Project>

--- a/Consul/Health.cs
+++ b/Consul/Health.cs
@@ -18,9 +18,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Consul
 {
@@ -82,18 +83,16 @@ namespace Consul
         }
     }
 
-    public class HealthStatusConverter : JsonConverter
+    public class HealthStatusConverter : JsonConverter<HealthStatus>
     {
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override bool CanConvert(Type objectType)
         {
-            serializer.Serialize(writer, ((HealthStatus)value).Status);
+            return objectType == typeof(HealthStatus);
         }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
-            JsonSerializer serializer)
+        public override HealthStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var status = (string)serializer.Deserialize(reader, typeof(string));
-            switch (status)
+            switch (reader.GetString())
             {
                 case "passing":
                     return HealthStatus.Passing;
@@ -106,13 +105,9 @@ namespace Consul
             }
         }
 
-        public override bool CanConvert(Type objectType)
+        public override void Write(Utf8JsonWriter writer, HealthStatus value, JsonSerializerOptions options)
         {
-            if (objectType == typeof(HealthStatus))
-            {
-                return true;
-            }
-            return false;
+            writer.WriteStringValue(value.Status);
         }
     }
 

--- a/Consul/Interfaces/IAgentEndpoint.cs
+++ b/Consul/Interfaces/IAgentEndpoint.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -44,7 +45,7 @@ namespace Consul
         string NodeName { get; }
         Task<string> GetNodeName(CancellationToken ct = default(CancellationToken));
         Task PassTTL(string checkID, string note, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<Dictionary<string, Dictionary<string, dynamic>>>> Self(CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<Dictionary<string, Dictionary<string, JsonElement>>>> Self(CancellationToken ct = default(CancellationToken));
         Task<WriteResult> ServiceDeregister(string serviceID, CancellationToken ct = default(CancellationToken));
         Task<WriteResult> ServiceRegister(AgentServiceRegistration service, CancellationToken ct = default(CancellationToken));
         Task<QueryResult<Dictionary<string, AgentService>>> Services(CancellationToken ct = default(CancellationToken));

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -19,9 +19,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Consul
 {
@@ -115,15 +116,6 @@ namespace Consul
         }
 
         /// <summary>
-        /// KeyringRequest is used for performing Keyring operations
-        /// </summary>
-        private class KeyringRequest
-        {
-            [JsonProperty]
-            internal string Key { get; set; }
-        }
-
-        /// <summary>
         /// RaftGetConfiguration is used to query the current Raft peer set.
         /// </summary>
         public Task<QueryResult<RaftConfiguration>> RaftGetConfiguration(CancellationToken ct = default(CancellationToken))
@@ -179,7 +171,7 @@ namespace Consul
         /// </summary>
         public Task<WriteResult> KeyringInstall(string key, WriteOptions q, CancellationToken ct = default(CancellationToken))
         {
-            return _client.Post("/v1/operator/keyring", new KeyringRequest() { Key = key }, q).Execute(ct);
+            return _client.Post("/v1/operator/keyring", new { Key = key }, q).Execute(ct);
         }
 
         /// <summary>
@@ -211,7 +203,7 @@ namespace Consul
         /// </summary>
         public Task<WriteResult> KeyringRemove(string key, WriteOptions q, CancellationToken ct = default(CancellationToken))
         {
-            return _client.DeleteAccepting("/v1/operator/keyring", new KeyringRequest() { Key = key }, q).Execute(ct);
+            return _client.DeleteAccepting("/v1/operator/keyring", new { Key = key }, q).Execute(ct);
         }
 
         /// <summary>
@@ -227,7 +219,7 @@ namespace Consul
         /// </summary>
         public Task<WriteResult> KeyringUse(string key, WriteOptions q, CancellationToken ct = default(CancellationToken))
         {
-            return _client.Put("/v1/operator/keyring", new KeyringRequest() { Key = key }, q).Execute(ct);
+            return _client.Put("/v1/operator/keyring", new { Key = key }, q).Execute(ct);
         }
     }
 

--- a/Consul/Policy.cs
+++ b/Consul/Policy.cs
@@ -17,9 +17,10 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Consul
 {
@@ -54,7 +55,7 @@ namespace Consul
         public string Name { get; set; }
         public string Description { get; set; }
         public string Rules { get; set; }
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string[] Datacenters { get; set; }
 
         public bool ShouldSerializeCreateIndex()

--- a/Consul/Role.cs
+++ b/Consul/Role.cs
@@ -17,9 +17,10 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Consul
 {
@@ -53,9 +54,9 @@ namespace Consul
         public string ID { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public PolicyLink[] Policies { get; set; }
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public ServiceIdentity[] ServiceIdentities { get; set; }
 
         public bool ShouldSerializeCreateIndex()

--- a/Consul/Semaphore.cs
+++ b/Consul/Semaphore.cs
@@ -21,9 +21,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+
 #if !(CORECLR || PORTABLE || PORTABLE40)
 using System.Security.Permissions;
 using System.Runtime.Serialization;
@@ -202,7 +204,6 @@ namespace Consul
         {
             private int _limit;
 
-            [JsonProperty]
             internal int Limit
             {
                 get { return _limit; }
@@ -219,12 +220,26 @@ namespace Consul
                 }
             }
 
-            [JsonProperty]
             internal Dictionary<string, bool> Holders { get; set; }
 
             internal SemaphoreLock()
             {
                 Holders = new Dictionary<string, bool>();
+            }
+
+            internal SemaphoreLock(JsonDocument json)
+            {
+                Limit = json.RootElement.GetProperty("Limit").GetInt32();
+                Holders = new Dictionary<string, bool>();
+                foreach (var holder in json.RootElement.GetProperty("Holders").EnumerateObject())
+                {
+                    Holders.Add(holder.Name, holder.Value.GetBoolean());
+                }
+            }
+
+            internal string ToJson()
+            {
+                return JsonSerializer.Serialize(new { Limit, Holders });
             }
         }
 
@@ -710,7 +725,10 @@ namespace Consul
                 return new SemaphoreLock() { Limit = Opts.Limit };
             }
 
-            return JsonConvert.DeserializeObject<SemaphoreLock>(Encoding.UTF8.GetString(pair.Value));
+            using (var holderJson = JsonDocument.Parse(Encoding.UTF8.GetString(pair.Value)))
+            {
+                return new SemaphoreLock(holderJson);
+            }
         }
 
         /// <summary>
@@ -721,7 +739,7 @@ namespace Consul
         /// <returns>A K/V pair with the lock data encoded in the Value field</returns>
         private KVPair EncodeLock(SemaphoreLock l, ulong oldIndex)
         {
-            var jsonValue = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(l));
+            var jsonValue = Encoding.UTF8.GetBytes(l.ToJson());
 
             return new KVPair(string.Join("/", Opts.Prefix, DefaultSemaphoreKey))
             {

--- a/Consul/Token.cs
+++ b/Consul/Token.cs
@@ -18,9 +18,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Consul
 {
@@ -29,19 +30,19 @@ namespace Consul
     /// </summary>
     public class TokenEntry
     {
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string AccessorID { get; set; }
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string SecretID { get; set; }
         public string Description { get; set; }
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public PolicyLink[] Policies { get; set; }
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public RoleLink[] Roles { get; set; }
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public ServiceIdentity[] ServiceIdentities { get; set; }
         public bool Local { get; set; }
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string AuthMethod { get; set; }
 
 
@@ -104,13 +105,13 @@ namespace Consul
 
         private class TokenActionResult : TokenEntry
         {
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public DateTime? CreateTime { get; set; }
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public string Hash { get; set; }
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public ulong CreateIndex { get; set; }
-            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public ulong ModifyIndex { get; set; }
         }
 


### PR DESCRIPTION
Convert all uses of Newtonsoft.Json to System.Text.Json

Closes #43

This converts the library to use System.Text.Json instead of Newtonsoft.Json to remove the dependency on that. All tests pass locally, but this is such a fundamental change that there may be unseen issues. This may also cause another problem: would System.Text.Json need to be ILMerged like Newtonsoft.Json? The original reason that it was being ilmerged was to stop dependency issues between common libraries, but I'm not sure if .net still has this problem with the new JSON libs.

There is also a breaking change in here: All references to `dynamic` are gone (it was used in the agent `Self` API) as compilation was failing due to needing the Microsoft.CSharp library referenced. Instead, raw `JsonElement`s are being returned instead where `dynamic` was being used.


