### PR TITLE
Fix recent CI issues

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -3,7 +3,6 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This PR ~~deletes the obsolete `NuGet.config` file that was adding the `dotnet-core` feed from myget.org~~ removes the obsolete `dotnet-core` feed from myget.org from the `NuGet.config` file.

This fixes recent CI issues like this one: https://github.com/G-Research/consuldotnet/pull/70/checks?check_run_id=2203971524.

~~It also resets the NuGet sources on Windows runners to workaround an issue where `dotnet restore` can [sometimes fail](https://github.com/G-Research/consuldotnet/runs/2204304465).~~