### PR TITLE
Make the internal API less ambiguous

### DIFF
--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -405,7 +405,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public Task<WriteResult> ServiceRegister(AgentServiceRegistration service, CancellationToken ct = default(CancellationToken))
         {
-            return _client.Put("/v1/agent/service/register", service).Execute(ct);
+            return _client.Put("/v1/agent/service/register", service, null).Execute(ct);
         }
 
         /// <summary>
@@ -462,7 +462,7 @@ namespace Consul
                 Status = status.Status,
                 Output = output
             };
-            return _client.Put(string.Format("/v1/agent/check/update/{0}", checkID), u).Execute(ct);
+            return _client.Put(string.Format("/v1/agent/check/update/{0}", checkID), u, null).Execute(ct);
         }
 
         /// <summary>
@@ -489,7 +489,7 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public Task<WriteResult> CheckRegister(AgentCheckRegistration check, CancellationToken ct = default(CancellationToken))
         {
-            return _client.Put("/v1/agent/check/register", check).Execute(ct);
+            return _client.Put("/v1/agent/check/register", check, null).Execute(ct);
         }
 
         /// <summary>

--- a/Consul/AuthMethod.cs
+++ b/Consul/AuthMethod.cs
@@ -241,7 +241,7 @@ namespace Consul
         /// <returns>A write result</returns>
         public async Task<WriteResult> Logout(WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
         {
-            return await _client.Post($"/v1/acl/logout", writeOptions).Execute(ct);
+            return await _client.Post($"/v1/acl/logout", null, writeOptions).Execute(ct);
         }
     }
 

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -618,7 +618,7 @@ namespace Consul
             return new DeleteAcceptingRequest<TIn>(this, path, body, opts);
         }
 
-        internal PutReturningRequest<TOut> PutReturning<TOut>(string path, WriteOptions opts)
+        internal PutReturningRequest<TOut> PutReturning<TOut>(string path, WriteOptions opts = null)
         {
             return new PutReturningRequest<TOut>(this, path, opts);
         }

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -530,7 +530,7 @@ namespace Consul
         void ApplyConfig(ConsulClientConfiguration config, WebRequestHandler handler, HttpClient client)
 #else
         void ApplyConfig(ConsulClientConfiguration config, HttpClientHandler handler, HttpClient client)
-#endif        
+#endif
         {
 #pragma warning disable CS0618 // Type or member is obsolete
             if (config.HttpAuth != null)
@@ -595,67 +595,67 @@ namespace Consul
 
         internal GetRequest<TOut> Get<TOut>(string path, QueryOptions opts = null, IEncodable filter = null)
         {
-            return new GetRequest<TOut>(this, path, opts ?? QueryOptions.Default, filter);
+            return new GetRequest<TOut>(this, path, opts, filter);
         }
 
         internal GetRequest Get(string path, QueryOptions opts = null)
         {
-            return new GetRequest(this, path, opts ?? QueryOptions.Default);
+            return new GetRequest(this, path, opts);
         }
 
         internal DeleteReturnRequest<TOut> DeleteReturning<TOut>(string path, WriteOptions opts = null)
         {
-            return new DeleteReturnRequest<TOut>(this, path, opts ?? WriteOptions.Default);
+            return new DeleteReturnRequest<TOut>(this, path, opts);
         }
 
         internal DeleteRequest Delete(string path, WriteOptions opts = null)
         {
-            return new DeleteRequest(this, path, opts ?? WriteOptions.Default);
+            return new DeleteRequest(this, path, opts);
         }
 
-        internal DeleteAcceptingRequest<TIn> DeleteAccepting<TIn>(string path, TIn body, WriteOptions opts = null)
+        internal DeleteAcceptingRequest<TIn> DeleteAccepting<TIn>(string path, TIn body, WriteOptions opts)
         {
-            return new DeleteAcceptingRequest<TIn>(this, path, body, opts ?? WriteOptions.Default);
+            return new DeleteAcceptingRequest<TIn>(this, path, body, opts);
         }
 
-        internal PutReturningRequest<TOut> PutReturning<TOut>(string path, WriteOptions opts = null)
+        internal PutReturningRequest<TOut> PutReturning<TOut>(string path, WriteOptions opts)
         {
-            return new PutReturningRequest<TOut>(this, path, opts ?? WriteOptions.Default);
+            return new PutReturningRequest<TOut>(this, path, opts);
         }
 
-        internal PutRequest<TIn> Put<TIn>(string path, TIn body, WriteOptions opts = null)
+        internal PutRequest<TIn> Put<TIn>(string path, TIn body, WriteOptions opts)
         {
-            return new PutRequest<TIn>(this, path, body, opts ?? WriteOptions.Default);
+            return new PutRequest<TIn>(this, path, body, opts);
         }
 
         internal PutNothingRequest PutNothing(string path, WriteOptions opts = null)
         {
-            return new PutNothingRequest(this, path, opts ?? WriteOptions.Default);
+            return new PutNothingRequest(this, path, opts);
         }
 
-        internal PutRequest<TIn, TOut> Put<TIn, TOut>(string path, TIn body, WriteOptions opts = null)
+        internal PutRequest<TIn, TOut> Put<TIn, TOut>(string path, TIn body, WriteOptions opts)
         {
-            return new PutRequest<TIn, TOut>(this, path, body, opts ?? WriteOptions.Default);
+            return new PutRequest<TIn, TOut>(this, path, body, opts);
         }
 
         internal PostReturningRequest<TOut> PostReturning<TOut>(string path, WriteOptions opts = null)
         {
-            return new PostReturningRequest<TOut>(this, path, opts ?? WriteOptions.Default);
+            return new PostReturningRequest<TOut>(this, path, opts);
         }
 
-        internal PostRequest<TIn> Post<TIn>(string path, TIn body, WriteOptions opts = null)
+        internal PostRequest<TIn> Post<TIn>(string path, TIn body, WriteOptions opts)
         {
-            return new PostRequest<TIn>(this, path, body, opts ?? WriteOptions.Default);
+            return new PostRequest<TIn>(this, path, body, opts);
         }
 
-        internal PostRequest<TIn, TOut> Post<TIn, TOut>(string path, TIn body, WriteOptions opts = null)
+        internal PostRequest<TIn, TOut> Post<TIn, TOut>(string path, TIn body, WriteOptions opts)
         {
-            return new PostRequest<TIn, TOut>(this, path, body, opts ?? WriteOptions.Default);
+            return new PostRequest<TIn, TOut>(this, path, body, opts);
         }
 
         internal PostRequest Post(string path, string body, WriteOptions opts = null)
         {
-            return new PostRequest(this, path, body, opts ?? WriteOptions.Default);
+            return new PostRequest(this, path, body, opts);
         }
     }
 }

--- a/Consul/KV.cs
+++ b/Consul/KV.cs
@@ -519,7 +519,7 @@ namespace Consul
         public Task<WriteResult<bool>> Release(KVPair p, WriteOptions q, CancellationToken ct = default(CancellationToken))
         {
             p.Validate();
-            var req = _client.Put<object, bool>(string.Format("/v1/kv/{0}", p.Key.TrimStart('/')), q);
+            var req = _client.Put<object, bool>(string.Format("/v1/kv/{0}", p.Key.TrimStart('/')), null, q);
             if (p.Flags > 0)
             {
                 req.Params["flags"] = p.Flags.ToString();
@@ -540,14 +540,14 @@ namespace Consul
         /// If there are more non-KV operations in the future we may break out a new
         /// transaction API client, but it will be easy to keep this KV-specific variant
         /// supported.
-        /// 
+        ///
         /// Even though this is generally a write operation, we take a QueryOptions input
         /// and return a QueryMeta output. If the transaction contains only read ops, then
         /// Consul will fast-path it to a different endpoint internally which supports
         /// consistency controls, but not blocking. If there are write operations then
         /// the request will always be routed through raft and any consistency settings
         /// will be ignored.
-        /// 
+        ///
         /// // If there is a problem making the transaction request then an error will be
         /// returned. Otherwise, the ok value will be true if the transaction succeeded
         /// or false if it was rolled back. The response is a structured return value which
@@ -578,14 +578,14 @@ namespace Consul
         /// If there are more non-KV operations in the future we may break out a new
         /// transaction API client, but it will be easy to keep this KV-specific variant
         /// supported.
-        /// 
+        ///
         /// Even though this is generally a write operation, we take a QueryOptions input
         /// and return a QueryMeta output. If the transaction contains only read ops, then
         /// Consul will fast-path it to a different endpoint internally which supports
         /// consistency controls, but not blocking. If there are write operations then
         /// the request will always be routed through raft and any consistency settings
         /// will be ignored.
-        /// 
+        ///
         /// // If there is a problem making the transaction request then an error will be
         /// returned. Otherwise, the ok value will be true if the transaction succeeded
         /// or false if it was rolled back. The response is a structured return value which

--- a/Consul/Session.cs
+++ b/Consul/Session.cs
@@ -356,7 +356,7 @@ namespace Consul
         /// <returns>A write result containing the result of the session destruction</returns>
         public Task<WriteResult<bool>> Destroy(string id, WriteOptions q, CancellationToken ct = default(CancellationToken))
         {
-            return _client.Put<object, bool>(string.Format("/v1/session/destroy/{0}", id), q).Execute(ct);
+            return _client.Put<object, bool>(string.Format("/v1/session/destroy/{0}", id), null, q).Execute(ct);
         }
 
         /// <summary>
@@ -439,7 +439,7 @@ namespace Consul
         /// <returns>An updated session entry</returns>
         public async Task<WriteResult<SessionEntry>> Renew(string id, WriteOptions q, CancellationToken ct = default(CancellationToken))
         {
-            var res = await _client.Put<object, SessionEntry[]>(string.Format("/v1/session/renew/{0}", id), q).Execute(ct).ConfigureAwait(false);
+            var res = await _client.Put<object, SessionEntry[]>(string.Format("/v1/session/renew/{0}", id), null, q).Execute(ct).ConfigureAwait(false);
             if (res.StatusCode == HttpStatusCode.NotFound)
             {
                 throw new SessionExpiredException(string.Format("Session expired: {0}", id));


### PR DESCRIPTION
Optional argument after generic argument can lead to mistakes, e.g. https://github.com/G-Research/consuldotnet/pull/76.
It is better to make the internal API less ambiguous to avoid such mistakes in the future. 