### PR TITLE
Prepare for a new release - update the changelog and version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  CONSUL_VERSION: 1.6.1
+  CONSUL_VERSION: 1.6.10
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## Unreleased
 
 ## 1.6.1.2
-* Add GRPC and GRPCUseTLS to the agent servce check parameters (#22)
+* Add GRPC and GRPCUseTLS to the agent service check parameters (#22)
 * Compatibility with Consul 1.7.x - RoleLink & PolicyLink (#31)
-* Added the possibility to specify more http request options and meta-data when registrating service checks (#39) 
+* Added the possibility to specify more http request options and meta-data when registering service checks (#39) 
   It is now possible to specify the http Header(s) (`Headers`), `Method` and `Body` to be used for a given service check.
   A given service check might also now have an identifier (`ID`), `Name` and a description (`Notes`) associated.
 * Added the `Type` field to the `AgentCheck` and `HealthCheck` structures (#42)   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.6.1.2
+## 1.6.10.1
 * Add GRPC and GRPCUseTLS to the agent service check parameters (#22)
 * Compatibility with Consul 1.7.x - RoleLink & PolicyLink (#31)
 * Added the possibility to specify more http request options and meta-data when registering service checks (#39) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
 # Changelog
 
 ## Unreleased
-* Added the `Type` field to the `AgentCheck` and `HealthCheck` structures  
-* Added the possibility to specify more http request options and meta-data when registrating service checks. 
+
+## 1.6.1.2
+* Add GRPC and GRPCUseTLS to the agent servce check parameters (#22)
+* Compatibility with Consul 1.7.x - RoleLink & PolicyLink (#31)
+* Added the possibility to specify more http request options and meta-data when registrating service checks (#39) 
   It is now possible to specify the http Header(s) (`Headers`), `Method` and `Body` to be used for a given service check.
   A given service check might also now have an identifier (`ID`), `Name` and a description (`Notes`) associated.
-* Fix issue #24 removing constructor's Obsolete attribute for HttpClient injection
+* Added the `Type` field to the `AgentCheck` and `HealthCheck` structures (#42)   
+* Fix issue #24 removing constructor's Obsolete attribute for HttpClient injection (#32)
+* Added asp net core integration - Consul.AspNetCore (#17)(#45)
+* Fixed lock and semaphore timeouts logic (#64)
+* Added service and node filtering abilities into Health.Service (#70)
+* Fixed NRE in Lock (#66)
+* Lock: Forward user cancellation token downstream (#67)
+* Pass WriteOptions parameter to correct parameter of Put(...) (#76)(#77)
 
 ## 1.6.1.1
 * Fix issue #9 preventing use of the library with .NET Framework

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fixed NRE in Lock (#66)
 * Lock: Forward user cancellation token downstream (#67)
 * Pass WriteOptions parameter to correct parameter of Put(...) (#76)(#77)
+* Update consul to v1.6.10 (#78)
 
 ## 1.6.1.1
 * Fix issue #9 preventing use of the library with .NET Framework

--- a/Consul.AspNetCore/Consul.AspNetCore.csproj
+++ b/Consul.AspNetCore/Consul.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <Version>1.0.0</Version>
     <PackageId>Consul.AspNetCore</PackageId>
     <AssemblyName>Consul.AspNetCore</AssemblyName>
     <PackageTags>Consul;service discovery;distributed locking;health checking</PackageTags>

--- a/Consul.AspNetCore/Consul.AspNetCore.csproj
+++ b/Consul.AspNetCore/Consul.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.0</Version>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <PackageId>Consul.AspNetCore</PackageId>
     <AssemblyName>Consul.AspNetCore</AssemblyName>
     <PackageTags>Consul;service discovery;distributed locking;health checking</PackageTags>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.6.1.1</VersionPrefix>
+    <Version>1.6.1.2-rc1</Version>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Consul</AssemblyName>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.6.1.2-rc1</Version>
+    <VersionPrefix>1.6.1.2</VersionPrefix>
+    <VersionSuffix>rc1</VersionSuffix>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Consul</AssemblyName>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.6.1.2</VersionPrefix>
+    <VersionPrefix>1.6.10.1</VersionPrefix>
     <VersionSuffix>rc1</VersionSuffix>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![CI](https://github.com/G-Research/consuldotnet/workflows/CI/badge.svg)
 [![](https://img.shields.io/nuget/v/consul)](https://www.nuget.org/packages/Consul/)
 
-* Consul API: [v1.6.1](https://github.com/hashicorp/consul/tree/v1.6.1/api)
+* Consul API: [v1.6.10](https://github.com/hashicorp/consul/tree/v1.6.10/api)
 * .NET: >= 4.6.1 - .NET Core: >= 2.0.0
 
 Consul.NET is a .NET port of the Go Consul API, but reworked to use .NET


### PR DESCRIPTION
- I've run `git log --pretty=oneline v1.6.1.1..master` to see what changes were made since last release.
- ~~I've-- switched from `VersionPrefix` to `Version` as we want to be able to specify pre-release version (with pre-release suffix)~~
- Updated Consul from `v1.6.1` to `v1.6.10`
