### PR TITLE
Enable publishing pre-release versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,7 @@ jobs:
       - name: Create NuGet package
         if: runner.os == 'Windows'
         run: |
-          if ("${{ github.ref }}" -like "refs/tags/v*") {
-            $tag = "${{ github.ref }}".SubString(11)
-            $version = (Select-Xml -path Consul/Consul.csproj -XPath "/Project/PropertyGroup/VersionPrefix/text()").node.Value
-            if (-not ($tag -eq $version)) {
-              echo "There is a mismatch between the project version ($version) and the tag ($tag)"
-              exit 1
-            }
-          } else {
+          if (-not ("${{ github.ref }}" -like "refs/tags/v*")) {
             # WORKAROUND: Add letter prefix to ensure that MSBuild treats
             # the suffix as a string. e.g. '0313071' will fail as an invalid
             # version string, but 'G0313071' will succeeded. It looks like
@@ -85,25 +78,15 @@ jobs:
             $suffix = 'g' + $(git rev-parse --short HEAD)
             $params = "--version-suffix", $suffix
           }
+          
           dotnet pack --configuration=Release --no-build @params Consul/Consul.csproj
-      - name: Upload NuGet package artifact
-        if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v2
-        with:
-          name: nuget-package
-          path: dist/consul
-
-  # Publish NuGet package when a tag is pushed.
-  # Tests need to succeed on all platforms first, including having a tag name that matches the version number.
-  publish:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: build
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Download NuGet package artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: nuget-package
-          path: dist/consul
-      - name: Publish to NuGet
-        run: dotnet nuget push dist/consul/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          
+          if ("${{ github.ref }}" -like "refs/tags/v*") {
+            $tag = "${{ github.ref }}".SubString(11)
+            $version = "1.2.3.4"
+            if (-not ($tag -eq $version)) {
+              echo "There is a mismatch between the project version ($version) and the tag ($tag)"
+              exit 1
+            }
+          }
+       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,6 @@ jobs:
           if (-not ("${{ github.ref }}" -like "refs/tags/v*")) {
             $tag = "${{ github.ref }}".SubString(11)
             $version = "1.2.3.4"
-            if (-not ($tag -eq $version)) {
-              echo "There is a mismatch between the project version ($version) and the tag ($tag)"
-              exit 1
-            }
+            IF NOT EXIST dist/consul/Consul.$tag.nupkg echo "There is a mismatch between the project version ($version) and the tag ($tag) exit 1
           }
        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
             $expectedFile = "dist/consul/Consul.$tag.nupkg"
             if (-not (Test-Path -Path $expectedFile))
             {            
-                echo "Expected file $expectedFile doesn't exist
+                echo "Expected file $expectedFile doesn't exist"
                 exit 1
             }
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
             $suffix = 'g' + $(git rev-parse --short HEAD)
             $params = "--version-suffix", $suffix
           }
-          
+
           dotnet pack --configuration=Release --no-build @params Consul/Consul.csproj
 
           if ("${{ github.ref }}" -like "refs/tags/v*") {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,11 @@ jobs:
           if (-not ("${{ github.ref }}" -like "refs/tags/v*")) {
             $tag = "${{ github.ref }}".SubString(11)
             $version = "1.2.3.4"
-            IF NOT EXIST dist/consul/Consul.$tag.nupkg echo "There is a mismatch between the project version ($version) and the tag ($tag) exit 1
+            $expectedFile = "dist/consul/Consul.$tag.nupkg"
+            if (-not (Test-Path -Path $expectedFile))
+            {            
+                echo "Expected file $expectedFile doesn't exist
+                exit 1
+            }
           }
        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        os: [windows-2019]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -55,12 +55,6 @@ jobs:
           rm consul.zip
       - name: Build
         run: dotnet build --configuration=Release -p:TreatWarningsAsErrors=true
-      - name: Run tests
-        shell: bash
-        run: |
-          cd Consul.Test
-          ./consul agent -dev -config-file test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &
-          dotnet test --configuration=Release --no-build -v=Normal
       - name: Upload Consul logs
         if: failure()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,7 @@ jobs:
             $tag = "${{ github.ref }}".SubString(11)
             $expectedFile = "dist/consul/Consul.$tag.nupkg"
             # Check whether the tag and the package version match together
-            if (-not (Test-Path -Path $expectedFile))
-            {            
+            if (-not (Test-Path -Path $expectedFile)) {
                 echo "Expected file $expectedFile doesn't exist"
                 exit 1
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [ubuntu-18.04, windows-2019, macos-10.15]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -55,6 +55,12 @@ jobs:
           rm consul.zip
       - name: Build
         run: dotnet build --configuration=Release -p:TreatWarningsAsErrors=true
+      - name: Run tests
+        shell: bash
+        run: |
+          cd Consul.Test
+          ./consul agent -dev -config-file test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &
+          dotnet test --configuration=Release --no-build -v=Normal
       - name: Upload Consul logs
         if: failure()
         uses: actions/upload-artifact@v2
@@ -74,7 +80,7 @@ jobs:
           }
           
           dotnet pack --configuration=Release --no-build @params Consul/Consul.csproj
-          
+
           if ("${{ github.ref }}" -like "refs/tags/v*") {
             $tag = "${{ github.ref }}".SubString(11)
             $expectedFile = "dist/consul/Consul.$tag.nupkg"
@@ -84,4 +90,25 @@ jobs:
                 exit 1
             }
           }
-       
+
+      - name: Upload NuGet package artifact
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v2
+        with:
+          name: nuget-package
+          path: dist/consul
+
+  # Publish NuGet package when a tag is pushed.
+  # Tests need to succeed on all platforms first, including having a tag name that matches the version number.
+  publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Download NuGet package artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: nuget-package
+          path: dist/consul
+      - name: Publish to NuGet
+        run: dotnet nuget push dist/consul/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           
           dotnet pack --configuration=Release --no-build @params Consul/Consul.csproj
           
-          if ("${{ github.ref }}" -like "refs/tags/v*") {
+          if (-not ("${{ github.ref }}" -like "refs/tags/v*")) {
             $tag = "${{ github.ref }}".SubString(11)
             $version = "1.2.3.4"
             if (-not ($tag -eq $version)) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           if ("${{ github.ref }}" -like "refs/tags/v*") {
             $tag = "${{ github.ref }}".SubString(11)
             $expectedFile = "dist/consul/Consul.$tag.nupkg"
+            # Check whether the tag and the package version match together
             if (-not (Test-Path -Path $expectedFile))
             {            
                 echo "Expected file $expectedFile doesn't exist"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,9 @@ jobs:
           
           dotnet pack --configuration=Release --no-build @params Consul/Consul.csproj
           
-          if (-not ("${{ github.ref }}" -like "refs/tags/v*")) {
+          if ("${{ github.ref }}" -like "refs/tags/v*")) {
             $tag = "${{ github.ref }}".SubString(11)
-            $version = "1.2.3.4"
-            $expectedFile = "dist/consul/Consul.$tag.nupkg"
+            $expectedFile = "dist/consul/Consul.$version.nupkg"
             if (-not (Test-Path -Path $expectedFile))
             {            
                 echo "Expected file $expectedFile doesn't exist"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           
           dotnet pack --configuration=Release --no-build @params Consul/Consul.csproj
           
-          if ("${{ github.ref }}" -like "refs/tags/v*")) {
+          if ("${{ github.ref }}" -like "refs/tags/v*") {
             $tag = "${{ github.ref }}".SubString(11)
             $expectedFile = "dist/consul/Consul.$version.nupkg"
             if (-not (Test-Path -Path $expectedFile))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           
           if ("${{ github.ref }}" -like "refs/tags/v*") {
             $tag = "${{ github.ref }}".SubString(11)
-            $expectedFile = "dist/consul/Consul.$version.nupkg"
+            $expectedFile = "dist/consul/Consul.$tag.nupkg"
             if (-not (Test-Path -Path $expectedFile))
             {            
                 echo "Expected file $expectedFile doesn't exist"


### PR DESCRIPTION
Previously, the script was checking the version of a NuGet package by reading the `VersionPrefix` property from a project file. 
Unfortunately, this approach didn't work when we wanted to use `VersionSuffix` property to define pre-release versions.

With this change we firstly build the NuGet package and only then we compare its actual version and the expected version derived from the tag.