### PR TITLE
Remove pre-release suffix

### DIFF
--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <VersionPrefix>1.6.10.1</VersionPrefix>
-    <VersionSuffix>rc1</VersionSuffix>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Consul</AssemblyName>


### PR DESCRIPTION
Removing `VersionSuffix`  to make stable release.
I've confirmed the ABI compatibility of versions `1.6.1.1` and `1.6.10.1-rc1` in ways:
- by using [PublicApiGenerator](https://github.com/PublicApiGenerator/PublicApiGenerator)
- by checking out `v1.6.1.1` and referencing version `1.6.10.1-rc1` from the `Consul.Test` and running all tests successfully
