### PR TITLE
Simplifying project files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,18 +40,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup .NET Core SDK v2.1.x
+      - name: Setup .NET Core SDK
+        if: runner.os != 'Windows'
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 2.1.x
-      - name: Setup .NET Core SDK v3.1.x
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x
-      - name: Setup .NET SDK v5.0.x
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 5.0.x
+          dotnet-version: 3.1.404
       - name: Download Consul
         shell: bash
         run: |
@@ -67,7 +60,7 @@ jobs:
         run: |
           cd Consul.Test
           ./consul agent -dev -config-file test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &
-          dotnet test --configuration=Release --logger GitHubActions --no-build -v=Normal
+          dotnet test --configuration=Release --no-build -v=Normal
       - name: Upload Consul logs
         if: failure()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup .NET Core SDK
-        if: runner.os != 'Windows'
+      - name: Setup .NET Core SDK v2.1.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.404
+          dotnet-version: 2.1.x
+      - name: Setup .NET Core SDK v3.1.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
+      - name: Setup .NET SDK v5.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
       - name: Download Consul
         shell: bash
         run: |
@@ -60,7 +67,7 @@ jobs:
         run: |
           cd Consul.Test
           ./consul agent -dev -config-file test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &
-          dotnet test --configuration=Release --no-build -v=Normal
+          dotnet test --configuration=Release --logger GitHubActions --no-build -v=Normal
       - name: Upload Consul logs
         if: failure()
         uses: actions/upload-artifact@v2

--- a/Consul.AspNetCore.Test/Consul.AspNetCore.Test.csproj
+++ b/Consul.AspNetCore.Test/Consul.AspNetCore.Test.csproj
@@ -2,21 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>Consul.AspNetCore.Test</AssemblyName>
-    <PackageId>Consul.AspNetCore.Test</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />

--- a/Consul.AspNetCore.Test/Consul.AspNetCore.Test.csproj
+++ b/Consul.AspNetCore.Test/Consul.AspNetCore.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />

--- a/Consul.AspNetCore/Consul.AspNetCore.csproj
+++ b/Consul.AspNetCore/Consul.AspNetCore.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <PackageId>Consul.AspNetCore</PackageId>
-    <AssemblyName>Consul.AspNetCore</AssemblyName>
     <PackageTags>Consul;service discovery;distributed locking;health checking</PackageTags>
     <PackageReleaseNotes>https://github.com/G-Research/consuldotnet/blob/master/CHANGELOG.md</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/G-Research/consuldotnet</PackageProjectUrl>
@@ -14,14 +12,7 @@
     <Authors>G-Research</Authors>
     <Description>Consul Service registration for ASP.NET Core</Description>
     <PackageOutputPath>../dist/consul.aspnetcore</PackageOutputPath>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PublicSign>true</PublicSign>
     <AssemblyOriginatorKeyFile>../assets/consuldotnet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/Consul.Test/ClientTest.cs
+++ b/Consul.Test/ClientTest.cs
@@ -78,7 +78,7 @@ namespace Consul.Test
             Environment.SetEnvironmentVariable("CONSUL_HTTP_SSL_VERIFY", string.Empty);
 
 
-#if !CORECLR
+#if !(NETSTANDARD || NETCOREAPP)
             Assert.True((client.HttpHandler as WebRequestHandler).ServerCertificateValidationCallback(null, null, null,
                 SslPolicyErrors.RemoteCertificateChainErrors));
             ServicePointManager.ServerCertificateValidationCallback = null;
@@ -205,7 +205,7 @@ namespace Consul.Test
 #pragma warning restore CS0618 // Type or member is obsolete
                 await client.KV.Put(new KVPair("kv/reuseconfig") { Flags = 1000 });
                 Assert.Equal<ulong>(1000, (await client.KV.Get("kv/reuseconfig")).Response.Flags);
-#if !CORECLR
+#if !(NETSTANDARD || NETCOREAPP)
                 Assert.True(client.HttpHandler.ServerCertificateValidationCallback(null, null, null,
                     SslPolicyErrors.RemoteCertificateChainErrors));
 #endif
@@ -220,7 +220,7 @@ namespace Consul.Test
 #pragma warning restore CS0618 // Type or member is obsolete
                 await client.KV.Put(new KVPair("kv/reuseconfig") { Flags = 2000 });
                 Assert.Equal<ulong>(2000, (await client.KV.Get("kv/reuseconfig")).Response.Flags);
-#if !CORECLR
+#if !(NETSTANDARD || NETCOREAPP)
                 Assert.Null(client.HttpHandler.ServerCertificateValidationCallback);
 #endif
             }
@@ -264,7 +264,7 @@ namespace Consul.Test
                 Assert.Equal(TimeSpan.FromSeconds(30), c.HttpClient.Timeout);
             }
 
-#if !CORECLR
+#if !NETSTANDARD || NETCOREAPP
             using (var c = new ConsulClient(cfgAction,
                 (client) => { client.Timeout = TimeSpan.FromSeconds(30); },
                 (handler) => { handler.Proxy = new WebProxy("127.0.0.1", 8080); }))

--- a/Consul.Test/ClientTest.cs
+++ b/Consul.Test/ClientTest.cs
@@ -264,7 +264,7 @@ namespace Consul.Test
                 Assert.Equal(TimeSpan.FromSeconds(30), c.HttpClient.Timeout);
             }
 
-#if !NETSTANDARD || NETCOREAPP
+#if !(NETSTANDARD || NETCOREAPP)
             using (var c = new ConsulClient(cfgAction,
                 (client) => { client.Timeout = TimeSpan.FromSeconds(30); },
                 (handler) => { handler.Proxy = new WebProxy("127.0.0.1", 8080); }))

--- a/Consul.Test/ClientTest.cs
+++ b/Consul.Test/ClientTest.cs
@@ -78,7 +78,7 @@ namespace Consul.Test
             Environment.SetEnvironmentVariable("CONSUL_HTTP_SSL_VERIFY", string.Empty);
 
 
-#if !CORECLR
+#if !NETCOREAPP
             Assert.True((client.HttpHandler as WebRequestHandler).ServerCertificateValidationCallback(null, null, null,
                 SslPolicyErrors.RemoteCertificateChainErrors));
             ServicePointManager.ServerCertificateValidationCallback = null;
@@ -205,7 +205,7 @@ namespace Consul.Test
 #pragma warning restore CS0618 // Type or member is obsolete
                 await client.KV.Put(new KVPair("kv/reuseconfig") { Flags = 1000 });
                 Assert.Equal<ulong>(1000, (await client.KV.Get("kv/reuseconfig")).Response.Flags);
-#if !CORECLR
+#if !NETCOREAPP
                 Assert.True(client.HttpHandler.ServerCertificateValidationCallback(null, null, null,
                     SslPolicyErrors.RemoteCertificateChainErrors));
 #endif
@@ -220,7 +220,7 @@ namespace Consul.Test
 #pragma warning restore CS0618 // Type or member is obsolete
                 await client.KV.Put(new KVPair("kv/reuseconfig") { Flags = 2000 });
                 Assert.Equal<ulong>(2000, (await client.KV.Get("kv/reuseconfig")).Response.Flags);
-#if !CORECLR
+#if !NETCOREAPP
                 Assert.Null(client.HttpHandler.ServerCertificateValidationCallback);
 #endif
             }
@@ -264,7 +264,7 @@ namespace Consul.Test
                 Assert.Equal(TimeSpan.FromSeconds(30), c.HttpClient.Timeout);
             }
 
-#if !CORECLR
+#if !NETCOREAPP
             using (var c = new ConsulClient(cfgAction,
                 (client) => { client.Timeout = TimeSpan.FromSeconds(30); },
                 (handler) => { handler.Proxy = new WebProxy("127.0.0.1", 8080); }))

--- a/Consul.Test/ClientTest.cs
+++ b/Consul.Test/ClientTest.cs
@@ -78,7 +78,7 @@ namespace Consul.Test
             Environment.SetEnvironmentVariable("CONSUL_HTTP_SSL_VERIFY", string.Empty);
 
 
-#if !NETCOREAPP
+#if !CORECLR
             Assert.True((client.HttpHandler as WebRequestHandler).ServerCertificateValidationCallback(null, null, null,
                 SslPolicyErrors.RemoteCertificateChainErrors));
             ServicePointManager.ServerCertificateValidationCallback = null;
@@ -205,7 +205,7 @@ namespace Consul.Test
 #pragma warning restore CS0618 // Type or member is obsolete
                 await client.KV.Put(new KVPair("kv/reuseconfig") { Flags = 1000 });
                 Assert.Equal<ulong>(1000, (await client.KV.Get("kv/reuseconfig")).Response.Flags);
-#if !NETCOREAPP
+#if !CORECLR
                 Assert.True(client.HttpHandler.ServerCertificateValidationCallback(null, null, null,
                     SslPolicyErrors.RemoteCertificateChainErrors));
 #endif
@@ -220,7 +220,7 @@ namespace Consul.Test
 #pragma warning restore CS0618 // Type or member is obsolete
                 await client.KV.Put(new KVPair("kv/reuseconfig") { Flags = 2000 });
                 Assert.Equal<ulong>(2000, (await client.KV.Get("kv/reuseconfig")).Response.Flags);
-#if !NETCOREAPP
+#if !CORECLR
                 Assert.Null(client.HttpHandler.ServerCertificateValidationCallback);
 #endif
             }
@@ -264,7 +264,7 @@ namespace Consul.Test
                 Assert.Equal(TimeSpan.FromSeconds(30), c.HttpClient.Timeout);
             }
 
-#if !NETCOREAPP
+#if !CORECLR
             using (var c = new ConsulClient(cfgAction,
                 (client) => { client.Timeout = TimeSpan.FromSeconds(30); },
                 (handler) => { handler.Proxy = new WebProxy("127.0.0.1", 8080); }))

--- a/Consul.Test/Consul.Test.csproj
+++ b/Consul.Test/Consul.Test.csproj
@@ -3,17 +3,11 @@
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp2.1;netcoreapp3.1;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
-    <AssemblyName>Consul.Test</AssemblyName>
-    <PackageId>Consul.Test</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PublicSign>true</PublicSign>
+    <AssemblyOriginatorKeyFile>../assets/consuldotnet.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
@@ -30,21 +24,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <PublicSign>true</PublicSign>
-    <AssemblyOriginatorKeyFile>../assets/consuldotnet.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Consul.Test/Consul.Test.csproj
+++ b/Consul.Test/Consul.Test.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp2.1;netcoreapp3.1;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PublicSign>true</PublicSign>
     <AssemblyOriginatorKeyFile>../assets/consuldotnet.snk</AssemblyOriginatorKeyFile>

--- a/Consul.Test/Consul.Test.csproj
+++ b/Consul.Test/Consul.Test.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
@@ -31,7 +31,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -269,7 +269,7 @@ namespace Consul
         {
             internal readonly bool skipClientDispose;
             internal readonly HttpClient HttpClient;
-#if NETSTANDARD
+#if CORECLR
             internal readonly HttpClientHandler HttpHandler;
 #else
             internal readonly WebRequestHandler HttpHandler;
@@ -279,7 +279,7 @@ namespace Consul
             public ConsulClientConfigurationContainer()
             {
                 Config = new ConsulClientConfiguration();
-#if NETSTANDARD
+#if CORECLR
                 HttpHandler = new HttpClientHandler();
 #else
                 HttpHandler = new WebRequestHandler();
@@ -301,7 +301,7 @@ namespace Consul
             public ConsulClientConfigurationContainer(ConsulClientConfiguration config)
             {
                 Config = config;
-#if NETSTANDARD
+#if CORECLR
                 HttpHandler = new HttpClientHandler();
 #else
                 HttpHandler = new WebRequestHandler();
@@ -363,7 +363,7 @@ namespace Consul
         private ConsulClientConfigurationContainer ConfigContainer;
 
         internal HttpClient HttpClient { get { return ConfigContainer.HttpClient; } }
-#if NETSTANDARD
+#if CORECLR
         internal HttpClientHandler HttpHandler { get { return ConfigContainer.HttpHandler; } }
 #else
         internal WebRequestHandler HttpHandler { get { return ConfigContainer.HttpHandler; } }
@@ -402,7 +402,7 @@ namespace Consul
         /// <param name="configOverride">The Action to modify the default configuration with</param>
         /// <param name="clientOverride">The Action to modify the HttpClient with</param>
         /// <param name="handlerOverride">The Action to modify the WebRequestHandler with</param>
-#if !NETSTANDARD
+#if !CORECLR
         public ConsulClient(Action<ConsulClientConfiguration> configOverride, Action<HttpClient> clientOverride, Action<WebRequestHandler> handlerOverride)
 #else
         public ConsulClient(Action<ConsulClientConfiguration> configOverride, Action<HttpClient> clientOverride, Action<HttpClientHandler> handlerOverride)
@@ -526,7 +526,7 @@ namespace Consul
             ApplyConfig(sender as ConsulClientConfiguration, HttpHandler, HttpClient);
 
         }
-#if !NETSTANDARD
+#if !CORECLR
         void ApplyConfig(ConsulClientConfiguration config, WebRequestHandler handler, HttpClient client)
 #else
         void ApplyConfig(ConsulClientConfiguration config, HttpClientHandler handler, HttpClient client)
@@ -559,7 +559,7 @@ namespace Consul
                 }
             }
 #endif
-#if !NETSTANDARD
+#if !CORECLR
 #pragma warning disable CS0618 // Type or member is obsolete
             if (config.DisableServerCertificateValidation)
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -269,7 +269,7 @@ namespace Consul
         {
             internal readonly bool skipClientDispose;
             internal readonly HttpClient HttpClient;
-#if CORECLR
+#if NETSTANDARD
             internal readonly HttpClientHandler HttpHandler;
 #else
             internal readonly WebRequestHandler HttpHandler;
@@ -279,7 +279,7 @@ namespace Consul
             public ConsulClientConfigurationContainer()
             {
                 Config = new ConsulClientConfiguration();
-#if CORECLR
+#if NETSTANDARD
                 HttpHandler = new HttpClientHandler();
 #else
                 HttpHandler = new WebRequestHandler();
@@ -301,7 +301,7 @@ namespace Consul
             public ConsulClientConfigurationContainer(ConsulClientConfiguration config)
             {
                 Config = config;
-#if CORECLR
+#if NETSTANDARD
                 HttpHandler = new HttpClientHandler();
 #else
                 HttpHandler = new WebRequestHandler();
@@ -363,7 +363,7 @@ namespace Consul
         private ConsulClientConfigurationContainer ConfigContainer;
 
         internal HttpClient HttpClient { get { return ConfigContainer.HttpClient; } }
-#if CORECLR
+#if NETSTANDARD
         internal HttpClientHandler HttpHandler { get { return ConfigContainer.HttpHandler; } }
 #else
         internal WebRequestHandler HttpHandler { get { return ConfigContainer.HttpHandler; } }
@@ -402,7 +402,7 @@ namespace Consul
         /// <param name="configOverride">The Action to modify the default configuration with</param>
         /// <param name="clientOverride">The Action to modify the HttpClient with</param>
         /// <param name="handlerOverride">The Action to modify the WebRequestHandler with</param>
-#if !CORECLR
+#if !NETSTANDARD
         public ConsulClient(Action<ConsulClientConfiguration> configOverride, Action<HttpClient> clientOverride, Action<WebRequestHandler> handlerOverride)
 #else
         public ConsulClient(Action<ConsulClientConfiguration> configOverride, Action<HttpClient> clientOverride, Action<HttpClientHandler> handlerOverride)
@@ -526,7 +526,7 @@ namespace Consul
             ApplyConfig(sender as ConsulClientConfiguration, HttpHandler, HttpClient);
 
         }
-#if !CORECLR
+#if !NETSTANDARD
         void ApplyConfig(ConsulClientConfiguration config, WebRequestHandler handler, HttpClient client)
 #else
         void ApplyConfig(ConsulClientConfiguration config, HttpClientHandler handler, HttpClient client)
@@ -559,7 +559,7 @@ namespace Consul
                 }
             }
 #endif
-#if !CORECLR
+#if !NETSTANDARD
 #pragma warning disable CS0618 // Type or member is obsolete
             if (config.DisableServerCertificateValidation)
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -398,7 +398,7 @@ namespace Consul
         /// <param name="configOverride">The Action to modify the default configuration with</param>
         /// <param name="clientOverride">The Action to modify the HttpClient with</param>
         /// <param name="handlerOverride">The Action to modify the WebRequestHandler with</param>
-#if !NETSTANDARD || NETCOREAPP
+#if !(NETSTANDARD || NETCOREAPP)
         public ConsulClient(Action<ConsulClientConfiguration> configOverride, Action<HttpClient> clientOverride, Action<WebRequestHandler> handlerOverride)
 #else
         public ConsulClient(Action<ConsulClientConfiguration> configOverride, Action<HttpClient> clientOverride, Action<HttpClientHandler> handlerOverride)
@@ -522,7 +522,7 @@ namespace Consul
             ApplyConfig(sender as ConsulClientConfiguration, HttpHandler, HttpClient);
 
         }
-#if !NETSTANDARD || NETCOREAPP
+#if !(NETSTANDARD || NETCOREAPP)
         void ApplyConfig(ConsulClientConfiguration config, WebRequestHandler handler, HttpClient client)
 #else
         void ApplyConfig(ConsulClientConfiguration config, HttpClientHandler handler, HttpClient client)
@@ -555,7 +555,7 @@ namespace Consul
                 }
             }
 #endif
-#if !NETSTANDARD || NETCOREAPP
+#if !(NETSTANDARD || NETCOREAPP)
 #pragma warning disable CS0618 // Type or member is obsolete
             if (config.DisableServerCertificateValidation)
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -24,7 +24,7 @@ using System.Net.Http.Headers;
 using System.Security.Cryptography.X509Certificates;
 using Consul.Filtering;
 using Newtonsoft.Json;
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
 using System.Security.Permissions;
 using System.Runtime.Serialization;
 #endif
@@ -47,7 +47,7 @@ namespace Consul
 
         internal bool ClientCertificateSupported { get { return _clientCertSupport.Value; } }
 
-#if CORECLR
+#if NETSTANDARD || NETCOREAPP
         [Obsolete("Use of DisableServerCertificateValidation should be converted to setting the HttpHandler's ServerCertificateCustomValidationCallback in the ConsulClient constructor" +
             "This property will be removed in a future release.", false)]
 #else
@@ -81,7 +81,7 @@ namespace Consul
         /// Credentials to use for access to the HTTP API.
         /// This is only needed if an authenticating service exists in front of Consul; Token is used for ACL authentication by Consul.
         /// </summary>
-#if CORECLR
+#if NETSTANDARD || NETCOREAPP
         [Obsolete("Use of HttpAuth should be converted to setting the HttpHandler's Credential property in the ConsulClient constructor" +
             "This property will be removed in a future release.", false)]
 #else
@@ -108,7 +108,7 @@ namespace Consul
         /// <exception cref="PlatformNotSupportedException">Setting this property will throw a PlatformNotSupportedException on Mono</exception>
 #if __MonoCS__
         [Obsolete("Client Certificates are not implemented in Mono", true)]
-#elif CORECLR
+#elif NETSTANDARD || NETCOREAPP
         [Obsolete("Use of ClientCertificate should be converted to adding to the HttpHandler's ClientCertificates list in the ConsulClient constructor." +
             "This property will be removed in a future release.", false)]
 #else
@@ -269,7 +269,7 @@ namespace Consul
         {
             internal readonly bool skipClientDispose;
             internal readonly HttpClient HttpClient;
-#if CORECLR
+#if NETSTANDARD || NETCOREAPP
             internal readonly HttpClientHandler HttpHandler;
 #else
             internal readonly WebRequestHandler HttpHandler;
@@ -279,7 +279,7 @@ namespace Consul
             public ConsulClientConfigurationContainer()
             {
                 Config = new ConsulClientConfiguration();
-#if CORECLR
+#if NETSTANDARD || NETCOREAPP
                 HttpHandler = new HttpClientHandler();
 #else
                 HttpHandler = new WebRequestHandler();
@@ -301,7 +301,7 @@ namespace Consul
             public ConsulClientConfigurationContainer(ConsulClientConfiguration config)
             {
                 Config = config;
-#if CORECLR
+#if NETSTANDARD || NETCOREAPP
                 HttpHandler = new HttpClientHandler();
 #else
                 HttpHandler = new WebRequestHandler();
@@ -363,7 +363,7 @@ namespace Consul
         private ConsulClientConfigurationContainer ConfigContainer;
 
         internal HttpClient HttpClient { get { return ConfigContainer.HttpClient; } }
-#if CORECLR
+#if NETSTANDARD || NETCOREAPP
         internal HttpClientHandler HttpHandler { get { return ConfigContainer.HttpHandler; } }
 #else
         internal WebRequestHandler HttpHandler { get { return ConfigContainer.HttpHandler; } }
@@ -402,7 +402,7 @@ namespace Consul
         /// <param name="configOverride">The Action to modify the default configuration with</param>
         /// <param name="clientOverride">The Action to modify the HttpClient with</param>
         /// <param name="handlerOverride">The Action to modify the WebRequestHandler with</param>
-#if !CORECLR
+#if !NETSTANDARD || NETCOREAPP
         public ConsulClient(Action<ConsulClientConfiguration> configOverride, Action<HttpClient> clientOverride, Action<WebRequestHandler> handlerOverride)
 #else
         public ConsulClient(Action<ConsulClientConfiguration> configOverride, Action<HttpClient> clientOverride, Action<HttpClientHandler> handlerOverride)
@@ -526,7 +526,7 @@ namespace Consul
             ApplyConfig(sender as ConsulClientConfiguration, HttpHandler, HttpClient);
 
         }
-#if !CORECLR
+#if !NETSTANDARD || NETCOREAPP
         void ApplyConfig(ConsulClientConfiguration config, WebRequestHandler handler, HttpClient client)
 #else
         void ApplyConfig(ConsulClientConfiguration config, HttpClientHandler handler, HttpClient client)
@@ -559,7 +559,7 @@ namespace Consul
                 }
             }
 #endif
-#if !CORECLR
+#if !NETSTANDARD || NETCOREAPP
 #pragma warning disable CS0618 // Type or member is obsolete
             if (config.DisableServerCertificateValidation)
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -24,10 +24,6 @@ using System.Net.Http.Headers;
 using System.Security.Cryptography.X509Certificates;
 using Consul.Filtering;
 using Newtonsoft.Json;
-#if !(NETSTANDARD || NETCOREAPP)
-using System.Security.Permissions;
-using System.Runtime.Serialization;
-#endif
 
 namespace Consul
 {

--- a/Consul/Client_DeleteRequests.cs
+++ b/Consul/Client_DeleteRequests.cs
@@ -22,10 +22,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-#if !(NETSTANDARD || NETCOREAPP)
-    using System.Security.Permissions;
-    using System.Runtime.Serialization;
-# endif
 
 namespace Consul
 {

--- a/Consul/Client_DeleteRequests.cs
+++ b/Consul/Client_DeleteRequests.cs
@@ -22,7 +22,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     using System.Security.Permissions;
     using System.Runtime.Serialization;
 # endif

--- a/Consul/Client_Exceptions.cs
+++ b/Consul/Client_Exceptions.cs
@@ -18,7 +18,7 @@
 
 using System;
 using System.Net;
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     using System.Security.Permissions;
     using System.Runtime.Serialization;
 #endif
@@ -28,7 +28,7 @@ namespace Consul
     /// <summary>
     /// Represents errors that occur while sending data to or fetching data from the Consul agent.
     /// </summary>
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class ConsulRequestException : Exception
@@ -37,7 +37,7 @@ namespace Consul
         public ConsulRequestException() { }
         public ConsulRequestException(string message, HttpStatusCode statusCode) : base(message) { StatusCode = statusCode; }
         public ConsulRequestException(string message, HttpStatusCode statusCode, Exception inner) : base(message, inner) { StatusCode = statusCode; }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected ConsulRequestException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }
@@ -55,7 +55,7 @@ namespace Consul
     /// <summary>
     /// Represents errors that occur during initalization of the Consul client's configuration.
     /// </summary>
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class ConsulConfigurationException : Exception
@@ -63,7 +63,7 @@ namespace Consul
         public ConsulConfigurationException() { }
         public ConsulConfigurationException(string message) : base(message) { }
         public ConsulConfigurationException(string message, Exception inner) : base(message, inner) { }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected ConsulConfigurationException(
           System.Runtime.Serialization.SerializationInfo info,
           System.Runtime.Serialization.StreamingContext context) : base(info, context) { }

--- a/Consul/Client_GetRequests.cs
+++ b/Consul/Client_GetRequests.cs
@@ -24,7 +24,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Consul.Filtering;
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     using System.Security.Permissions;
     using System.Runtime.Serialization;
 #endif

--- a/Consul/Client_GetRequests.cs
+++ b/Consul/Client_GetRequests.cs
@@ -24,10 +24,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Consul.Filtering;
-#if !(NETSTANDARD || NETCOREAPP)
-    using System.Security.Permissions;
-    using System.Runtime.Serialization;
-#endif
 
 namespace Consul
 {

--- a/Consul/Client_Options.cs
+++ b/Consul/Client_Options.cs
@@ -17,7 +17,7 @@
 // -----------------------------------------------------------------------
 
 using System;
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     using System.Security.Permissions;
     using System.Runtime.Serialization;
 #endif

--- a/Consul/Client_PostRequests.cs
+++ b/Consul/Client_PostRequests.cs
@@ -23,10 +23,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-#if !(NETSTANDARD || NETCOREAPP)
-    using System.Security.Permissions;
-    using System.Runtime.Serialization;
-#endif
 
 namespace Consul
 {

--- a/Consul/Client_PostRequests.cs
+++ b/Consul/Client_PostRequests.cs
@@ -23,7 +23,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     using System.Security.Permissions;
     using System.Runtime.Serialization;
 #endif

--- a/Consul/Client_PutRequests.cs
+++ b/Consul/Client_PutRequests.cs
@@ -22,7 +22,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     using System.Security.Permissions;
     using System.Runtime.Serialization;
 #endif

--- a/Consul/Client_PutRequests.cs
+++ b/Consul/Client_PutRequests.cs
@@ -22,10 +22,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-#if !(NETSTANDARD || NETCOREAPP)
-    using System.Security.Permissions;
-    using System.Runtime.Serialization;
-#endif
 
 namespace Consul
 {

--- a/Consul/Client_Request.cs
+++ b/Consul/Client_Request.cs
@@ -22,7 +22,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using Newtonsoft.Json;
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     using System.Security.Permissions;
     using System.Runtime.Serialization;
 #endif

--- a/Consul/Client_Request.cs
+++ b/Consul/Client_Request.cs
@@ -22,10 +22,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using Newtonsoft.Json;
-#if !(NETSTANDARD || NETCOREAPP)
-    using System.Security.Permissions;
-    using System.Runtime.Serialization;
-#endif
 
 namespace Consul
 {

--- a/Consul/Client_Results.cs
+++ b/Consul/Client_Results.cs
@@ -18,7 +18,7 @@
 
 using System;
 using System.Net;
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     using System.Security.Permissions;
     using System.Runtime.Serialization;
 #endif

--- a/Consul/Client_Results.cs
+++ b/Consul/Client_Results.cs
@@ -18,10 +18,6 @@
 
 using System;
 using System.Net;
-#if !(NETSTANDARD || NETCOREAPP)
-    using System.Security.Permissions;
-    using System.Runtime.Serialization;
-#endif
 
 namespace Consul
 {

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -4,8 +4,6 @@
     <VersionPrefix>1.6.10.1</VersionPrefix>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
-    <AssemblyName>Consul</AssemblyName>
-    <PackageId>Consul</PackageId>
     <PackageTags>Consul;service discovery;distributed locking;health checking</PackageTags>
     <PackageReleaseNotes>https://github.com/G-Research/consuldotnet/blob/master/CHANGELOG.md</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/G-Research/consuldotnet</PackageProjectUrl>
@@ -15,37 +13,25 @@
     <Authors>PlayFab,G-Research</Authors>
     <Description>Consul.NET is a .NET client library for the Consul HTTP API</Description>
     <PackageOutputPath>../dist/consul</PackageOutputPath>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PublicSign>true</PublicSign>
     <AssemblyOriginatorKeyFile>../assets/consuldotnet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="ILMerge" Version="3.0.41" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" PrivateAssets="All" />
+    <PackageReference Update="Newtonsoft.Json" PrivateAssets="All" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
-  </PropertyGroup>
-
-  <Target Name="ILMerge" AfterTargets="AfterBuild" Condition=" '$(TargetFramework)' == 'net461' ">
+  <Target Name="ILMerge" AfterTargets="AfterBuild" Condition=" '$(TargetFramework)' == 'net461' And '$(OS)' == 'Windows_NT'">
     <ItemGroup>
       <BuildArtifacts Include="$(OutputPath)$(AssemblyName).*" />
       <ArtifactsToMerge Include="$(OutputPath)Newtonsoft.Json.dll" />

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -31,7 +31,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <Target Name="ILMerge" AfterTargets="AfterBuild" Condition=" '$(TargetFramework)' == 'net461' And '$(OS)' == 'Windows_NT'">
+  <Target Name="ILMerge" AfterTargets="AfterBuild" Condition=" '$(TargetFramework)' == 'net461' ">
     <ItemGroup>
       <BuildArtifacts Include="$(OutputPath)$(AssemblyName).*" />
       <ArtifactsToMerge Include="$(OutputPath)Newtonsoft.Json.dll" />

--- a/Consul/GlobalSuppressions.cs
+++ b/Consul/GlobalSuppressions.cs
@@ -16,17 +16,17 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Scope = "member", Target = "Consul.ConsulClientConfiguration.#.ctor()")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Scope = "type", Target = "Consul.AsyncLock")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Scope = "member", Target = "Consul.ConsulRequest.#Deserialize`1(System.IO.Stream)")]
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 //
-// To add a suppression to this file, right-click the message in the 
-// Code Analysis results, point to "Suppress Message", and click 
+// To add a suppression to this file, right-click the message in the
+// Code Analysis results, point to "Suppress Message", and click
 // "In Suppression File".
 // You do not need to add suppressions to this file manually.
 #endif

--- a/Consul/KV.cs
+++ b/Consul/KV.cs
@@ -230,7 +230,7 @@ namespace Consul
     /// <summary>
     /// Indicates that the key pair data is invalid
     /// </summary>
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class InvalidKeyPairException : Exception
@@ -238,7 +238,7 @@ namespace Consul
         public InvalidKeyPairException() { }
         public InvalidKeyPairException(string message) : base(message) { }
         public InvalidKeyPairException(string message, Exception inner) : base(message, inner) { }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected InvalidKeyPairException(
           System.Runtime.Serialization.SerializationInfo info,
           System.Runtime.Serialization.StreamingContext context) : base(info, context)

--- a/Consul/Lock.cs
+++ b/Consul/Lock.cs
@@ -24,7 +24,7 @@ using System.Threading.Tasks;
 
 namespace Consul
 {
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class LockHeldException : Exception
@@ -42,13 +42,13 @@ namespace Consul
             : base(message, inner)
         {
         }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected LockHeldException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }
 #endif
     }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class LockNotHeldException : Exception
@@ -66,13 +66,13 @@ namespace Consul
             : base(message, inner)
         {
         }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected LockNotHeldException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }
 #endif
     }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class LockInUseException : Exception
@@ -90,13 +90,13 @@ namespace Consul
             : base(message, inner)
         {
         }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected LockInUseException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }
 #endif
     }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class LockConflictException : Exception
@@ -114,13 +114,13 @@ namespace Consul
             : base(message, inner)
         {
         }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected LockConflictException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }
 #endif
     }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class LockMaxAttemptsReachedException : Exception
@@ -128,7 +128,7 @@ namespace Consul
         public LockMaxAttemptsReachedException() { }
         public LockMaxAttemptsReachedException(string message) : base(message) { }
         public LockMaxAttemptsReachedException(string message, Exception inner) : base(message, inner) { }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected LockMaxAttemptsReachedException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }

--- a/Consul/Properties/AssemblyInfo.cs
+++ b/Consul/Properties/AssemblyInfo.cs
@@ -1,8 +1,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Consul.NET")]
@@ -14,27 +13,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-#if !CORECLR
-[assembly: Guid("1eb4b74d-0bac-4d14-872e-00cf455ccd53")]
-#endif
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.1.1")]
-[assembly: AssemblyFileVersion("1.6.1.1")]
 [assembly: InternalsVisibleTo("Consul.Test, PublicKey=" +
     "002400000480000094000000060200000024000052534131000400000100010045f6337bf03a95" +
     "218f1e0b4e70bb91f8ee49fcb58593d78c1008ee646cfcf785ea60bd0b1dde6f5f92ead738e2bd" +

--- a/Consul/Semaphore.cs
+++ b/Consul/Semaphore.cs
@@ -24,14 +24,14 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
 using System.Security.Permissions;
 using System.Runtime.Serialization;
 #endif
 
 namespace Consul
 {
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class SemaphoreLimitConflictException : Exception
@@ -57,7 +57,7 @@ namespace Consul
             LocalLimit = localLimit;
         }
 
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected SemaphoreLimitConflictException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }
@@ -73,7 +73,7 @@ namespace Consul
 #endif
     }
 
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class SemaphoreHeldException : Exception
@@ -91,14 +91,14 @@ namespace Consul
             : base(message, inner)
         {
         }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected SemaphoreHeldException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }
 #endif
     }
 
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class SemaphoreNotHeldException : Exception
@@ -116,14 +116,14 @@ namespace Consul
             : base(message, inner)
         {
         }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected SemaphoreNotHeldException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }
 #endif
     }
 
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class SemaphoreInUseException : Exception
@@ -142,7 +142,7 @@ namespace Consul
         {
         }
 
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected SemaphoreInUseException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }
@@ -150,7 +150,7 @@ namespace Consul
 
     }
 
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class SemaphoreConflictException : Exception
@@ -168,14 +168,14 @@ namespace Consul
             : base(message, inner)
         {
         }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected SemaphoreConflictException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }
 #endif
     }
 
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class SemaphoreMaxAttemptsReachedException : Exception
@@ -183,7 +183,7 @@ namespace Consul
         public SemaphoreMaxAttemptsReachedException() { }
         public SemaphoreMaxAttemptsReachedException(string message) : base(message) { }
         public SemaphoreMaxAttemptsReachedException(string message, Exception inner) : base(message, inner) { }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected SemaphoreMaxAttemptsReachedException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }

--- a/Consul/Session.cs
+++ b/Consul/Session.cs
@@ -89,7 +89,7 @@ namespace Consul
         }
     }
 
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class SessionExpiredException : Exception
@@ -97,7 +97,7 @@ namespace Consul
         public SessionExpiredException() { }
         public SessionExpiredException(string message) : base(message) { }
         public SessionExpiredException(string message, Exception inner) : base(message, inner) { }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected SessionExpiredException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }
@@ -105,7 +105,7 @@ namespace Consul
 
     }
 
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
     [Serializable]
 #endif
     public class SessionCreationException : Exception
@@ -113,7 +113,7 @@ namespace Consul
         public SessionCreationException() { }
         public SessionCreationException(string message) : base(message) { }
         public SessionCreationException(string message, Exception inner) : base(message, inner) { }
-#if !(CORECLR || PORTABLE || PORTABLE40)
+#if !(NETSTANDARD || NETCOREAPP)
         protected SessionCreationException(
           SerializationInfo info,
           StreamingContext context) : base(info, context) { }


### PR DESCRIPTION
While reviewing the https://github.com/G-Research/consuldotnet/pull/80, I've realised that we can simplify our project files:
- `AssemblyName` and `PackageId` are automatically inferred from the project file name
- `Generate*` can be replaced with single `GenerateAssemblyInfo`
- There is no need to define `CORECLR` constant because `NETSTANDARD` and `NETCOREAPP` are already available
