### PR TITLE
Introduce BaseFixture to try to fix intermittent test failures

### DIFF
--- a/Consul.Test/ACLReplicationTest.cs
+++ b/Consul.Test/ACLReplicationTest.cs
@@ -23,24 +23,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class ACLReplicationTest : IDisposable
+    public class ACLReplicationTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public ACLReplicationTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [SkippableFact]
         public async Task ACLReplication_GetStatus()
         {

--- a/Consul.Test/ACLTest.cs
+++ b/Consul.Test/ACLTest.cs
@@ -24,24 +24,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class ACLTest : IDisposable
+    public class ACLTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public ACLTest()
-        {
-            _client = new ConsulClient(c =>
-              {
-                  c.Token = TestHelper.MasterToken;
-                  c.Address = TestHelper.HttpUri;
-              });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [SkippableFact]
         public async Task ACL_CreateDestroyLegacyToken()
         {

--- a/Consul.Test/AgentTest.cs
+++ b/Consul.Test/AgentTest.cs
@@ -18,30 +18,13 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Consul.Test
 {
-    public class AgentTest : IDisposable
+    public class AgentTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public AgentTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [Fact]
         public async Task Agent_GetSelf()
         {

--- a/Consul.Test/AuthMethodTest.cs
+++ b/Consul.Test/AuthMethodTest.cs
@@ -23,24 +23,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class AuthMethodTest : IDisposable
+    public class AuthMethodTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public AuthMethodTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [SkippableFact]
         public async Task AuthMethod_CreateDelete()
         {

--- a/Consul.Test/BaseFixture.cs
+++ b/Consul.Test/BaseFixture.cs
@@ -49,7 +49,7 @@ namespace Consul.Test
                             _ready = true;
                         }
                     }
-                    catch(OperationCanceledException)
+                    catch (OperationCanceledException)
                     {
                         break;
                     }

--- a/Consul.Test/BaseFixture.cs
+++ b/Consul.Test/BaseFixture.cs
@@ -1,0 +1,50 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Consul.Test
+{
+    public class BaseFixture : IAsyncLifetime
+    {
+        protected ConsulClient _client;
+
+        public BaseFixture()
+        {
+            _client = new ConsulClient(c =>
+            {
+                c.Token = TestHelper.MasterToken;
+                c.Address = TestHelper.HttpUri;
+            });
+        }
+
+        public Task DisposeAsync()
+        {
+            _client.Dispose();
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// With parallel testing on the CI, sometimes the tests start before the consul server finished properly initializing
+        /// This aims to workaround it in a not so elegant way. https://github.com/hashicorp/consul/issues/819
+        /// </summary>
+        /// <returns></returns>
+        public async Task InitializeAsync()
+        {
+            bool ready = false;
+
+            while (!ready)
+            {
+                try
+                {
+                    var leader = await _client.Status.Leader();
+                    if (!string.IsNullOrEmpty(leader))
+                    {
+                        ready = true;
+                    }
+                }
+                catch
+                {
+                }
+            }
+        }
+    }
+}

--- a/Consul.Test/BaseFixture.cs
+++ b/Consul.Test/BaseFixture.cs
@@ -30,36 +30,30 @@ namespace Consul.Test
         /// This aims to workaround it in a not so elegant way. https://github.com/hashicorp/consul/issues/819
         /// </summary>
         /// <returns></returns>
-        public Task InitializeAsync()
+        public async Task InitializeAsync()
         {
-            if (_ready) return Task.CompletedTask;
+            if (_ready) return;
 
             var cancelToken = new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token;
 
-            var initialize = Task.Run(async () =>
+            await Task.Run(async () =>
             {
                 while (!_ready)
                 {
+                    cancelToken.ThrowIfCancellationRequested();
                     try
                     {
-                        cancelToken.ThrowIfCancellationRequested();
                         var leader = await _client.Status.Leader();
                         if (!string.IsNullOrEmpty(leader))
                         {
                             _ready = true;
                         }
                     }
-                    catch (OperationCanceledException)
-                    {
-                        break;
-                    }
                     catch
                     {
                     }
                 }
             }, cancelToken);
-
-            return initialize;
         }
     }
 }

--- a/Consul.Test/BaseFixture.cs
+++ b/Consul.Test/BaseFixture.cs
@@ -6,6 +6,7 @@ namespace Consul.Test
     public class BaseFixture : IAsyncLifetime
     {
         protected ConsulClient _client;
+        private static bool _ready;
 
         public BaseFixture()
         {
@@ -29,16 +30,14 @@ namespace Consul.Test
         /// <returns></returns>
         public async Task InitializeAsync()
         {
-            bool ready = false;
-
-            while (!ready)
+            while (!_ready)
             {
                 try
                 {
                     var leader = await _client.Status.Leader();
                     if (!string.IsNullOrEmpty(leader))
                     {
-                        ready = true;
+                        _ready = true;
                     }
                 }
                 catch

--- a/Consul.Test/CatalogTest.cs
+++ b/Consul.Test/CatalogTest.cs
@@ -23,24 +23,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class CatalogTest : IDisposable
+    public class CatalogTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public CatalogTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [Fact]
         public async Task Catalog_GetDatacenters()
         {

--- a/Consul.Test/ClientTest.cs
+++ b/Consul.Test/ClientTest.cs
@@ -18,7 +18,6 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -29,24 +28,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class ClientTest : IDisposable
+    public class ClientTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public ClientTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [Fact]
         public void Client_DefaultConfig_env()
         {

--- a/Consul.Test/CoordinateTest.cs
+++ b/Consul.Test/CoordinateTest.cs
@@ -23,24 +23,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class CoordinateTest : IDisposable
+    public class CoordinateTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public CoordinateTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [Fact]
         public async Task Coordinate_GetDatacenters()
         {

--- a/Consul.Test/EventTest.cs
+++ b/Consul.Test/EventTest.cs
@@ -24,24 +24,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class EventTest : IDisposable
+    public class EventTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public EventTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [Fact]
         public async Task Event_FireList()
         {

--- a/Consul.Test/FilterTests.cs
+++ b/Consul.Test/FilterTests.cs
@@ -25,24 +25,8 @@ using S = Consul.Filtering.Selectors;
 
 namespace Consul.Test
 {
-    public class FilterTests : IDisposable
+    public class FilterTests : BaseFixture
     {
-        private ConsulClient _client;
-
-        public FilterTests()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         private static void CheckEncoded(string expected, IEncodable expression) =>
             Assert.Equal(expected, expression.Encode());
 

--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -24,24 +24,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class HealthTest : IDisposable
+    public class HealthTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public HealthTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [Fact]
         public async Task Health_GetLocalNode()
         {

--- a/Consul.Test/KVTest.cs
+++ b/Consul.Test/KVTest.cs
@@ -27,24 +27,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class KVTest : IDisposable
+    public class KVTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public KVTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         private static readonly Random Random = new Random();
 
         internal static string GenerateTestKeyName()

--- a/Consul.Test/LockTest.cs
+++ b/Consul.Test/LockTest.cs
@@ -29,24 +29,8 @@ namespace Consul.Test
     // These tests are slow, so we put them into separate collection so they can run in parallel to other tests.
     [Trait("speed", "slow")]
     [Collection("LockTest")]
-    public class LockTest : IDisposable
+    public class LockTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public LockTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [Fact]
         public async Task Lock_AcquireRelease()
         {

--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -17,32 +17,13 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Consul.Test
 {
-    public class OperatorTest : IDisposable
+    public class OperatorTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public OperatorTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [Fact]
         public async Task Operator_GetRaftGetConfiguration()
         {

--- a/Consul.Test/PolicyTest.cs
+++ b/Consul.Test/PolicyTest.cs
@@ -22,24 +22,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class PolicyTest : IDisposable
+    public class PolicyTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public PolicyTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [SkippableFact]
         public async Task Policy_CreateDelete()
         {

--- a/Consul.Test/PreparedQueryTest.cs
+++ b/Consul.Test/PreparedQueryTest.cs
@@ -17,32 +17,14 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Consul.Test
 {
-    public class PreparedQueryTest : IDisposable
+    public class PreparedQueryTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public PreparedQueryTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [Fact]
         public async Task PreparedQuery_Test()
         {

--- a/Consul.Test/RoleTest.cs
+++ b/Consul.Test/RoleTest.cs
@@ -22,24 +22,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class RoleTest : IDisposable
+    public class RoleTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public RoleTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [SkippableFact]
         public async Task Role_CreateDelete()
         {

--- a/Consul.Test/SemaphoreTest.cs
+++ b/Consul.Test/SemaphoreTest.cs
@@ -30,25 +30,10 @@ namespace Consul.Test
     // These tests are slow, so we put them into separate collection so they can run in parallel to other tests.
     [Trait("speed", "slow")]
     [Collection("SemaphoreTest")]
-    public class SemaphoreTest : IDisposable
+    public class SemaphoreTest : BaseFixture
     {
-        private ConsulClient _client;
         const int DefaultSessionTTLSeconds = 10;
         const int LockWaitTimeSeconds = 15;
-
-        public SemaphoreTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
 
         [Fact]
         public async Task Semaphore_BadLimit()

--- a/Consul.Test/SessionTest.cs
+++ b/Consul.Test/SessionTest.cs
@@ -25,24 +25,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class SessionTest : IDisposable
+    public class SessionTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public SessionTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [Fact]
         public async Task Session_CreateDestroy()
         {

--- a/Consul.Test/SnapshotTest.cs
+++ b/Consul.Test/SnapshotTest.cs
@@ -17,7 +17,6 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -29,24 +28,8 @@ namespace Consul.Test
     /// Snapshot tests mutate global state of the consul client so we avoid running them in parallel with other tests.
     /// </summary>
     [Collection(nameof(ExclusiveCollection))]
-    public class SnapshotTest : IDisposable
+    public class SnapshotTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public SnapshotTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [Fact]
         public async Task Snapshot_TakeRestore()
         {

--- a/Consul.Test/StatusTest.cs
+++ b/Consul.Test/StatusTest.cs
@@ -17,30 +17,13 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using System;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Consul.Test
 {
-    public class StatusTest : IDisposable
+    public class StatusTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public StatusTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [Fact]
         public async Task Status_Leader()
         {

--- a/Consul.Test/TokenTest.cs
+++ b/Consul.Test/TokenTest.cs
@@ -22,24 +22,8 @@ using Xunit;
 
 namespace Consul.Test
 {
-    public class TokenTest : IDisposable
+    public class TokenTest : BaseFixture
     {
-        private ConsulClient _client;
-
-        public TokenTest()
-        {
-            _client = new ConsulClient(c =>
-            {
-                c.Token = TestHelper.MasterToken;
-                c.Address = TestHelper.HttpUri;
-            });
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
-        }
-
         [SkippableFact]
         public async Task Token_CreateDelete()
         {


### PR DESCRIPTION
sometimes Consul does not initialize fast enough when running parallel tests on the CI. This not elegant workaround aims to address that.

This PR needs to be merged before https://github.com/G-Research/consuldotnet/pull/80