### PR TITLE
Update GitHubActionsTestLogger to 1.2.0 & fix HttpConnectionLimit issue

### DIFF
--- a/Consul.Test/BaseFixture.cs
+++ b/Consul.Test/BaseFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -9,6 +10,14 @@ namespace Consul.Test
     {
         protected ConsulClient _client;
         private static bool _ready;
+
+        static BaseFixture()
+        {
+            // Some Consul object (e.g. semaphores) use multiple http connections,
+            // but on .NETFramework the default limit is sometimes very low (2) so we need to bump it to higher value.
+            // E.g. https://github.com/microsoft/referencesource/blob/5697c29004a34d80acdaf5742d7e699022c64ecd/System.Web/HttpRuntime.cs#L1200
+            ServicePointManager.DefaultConnectionLimit = int.MaxValue;
+        }
 
         public BaseFixture()
         {

--- a/Consul.Test/Consul.Test.csproj
+++ b/Consul.Test/Consul.Test.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies Condition="'$(TargetFramework)' == 'netcoreapp2.1'" >true</CopyLocalLockFileAssemblies>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PublicSign>true</PublicSign>
@@ -22,10 +21,10 @@
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
There was a problem with updating `GitHubActionsTestLogger` to latest version because some `.NETFramework` tests were failing.
It turned out that that problem is caused by the value of `ServicePointManager.DefaultConnectionLimit`. If it was too low then some tests were unable to complete successfully as some required HttpConenctions couldn't be established.
Now we can run .NETFramework tests on all OS platforms