### PR TITLE
Use ILRepack instead of ILMerge so .NET Framework builds the same on all platforms

### DIFF
--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -22,31 +22,29 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="ILMerge" Version="3.0.41" PrivateAssets="All" />
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+    <PackageReference Include="ILRepack" Version="2.0.18" PrivateAssets="All" />
     <PackageReference Update="Newtonsoft.Json" PrivateAssets="All" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <Target Name="ILMerge" AfterTargets="AfterBuild" Condition=" '$(TargetFramework)' == 'net461' And '$(OS)' == 'Windows_NT'">
+  <Target Name="ILRepack" AfterTargets="AfterBuild" Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <ItemGroup>
-      <BuildArtifacts Include="$(OutputPath)$(AssemblyName).*" />
-      <ArtifactsToMerge Include="$(OutputPath)Newtonsoft.Json.dll" />
+      <ArtifactsToMerge Include="Newtonsoft.Json.dll" />
     </ItemGroup>
     <PropertyGroup>
-      <IlmergeCommand>$(ILMergeConsolePath) /internalize /out:$(OutputPath)ILMerge\$(AssemblyName).dll</IlmergeCommand>
-      <IlmergeCommand>$(IlmergeCommand) /keyfile:$(AssemblyOriginatorKeyFile)</IlmergeCommand>
-      <IlmergeCommand>$(IlmergeCommand) $(OutputPath)$(AssemblyName).dll @(ArtifactsToMerge->'%(RelativeDir)%(filename)%(extension)', ' ')</IlmergeCommand>
+      <ILRepackCommand>$(ILRepack) /parallel /internalize /out:ILRepack/$(AssemblyName).dll</ILRepackCommand>
+      <ILRepackCommand>$(ILRepackCommand) /keyfile:$([System.IO.Path]::GetFullPath('$(AssemblyOriginatorKeyFile)'))</ILRepackCommand>
+      <ILRepackCommand>$(ILRepackCommand) $(AssemblyName).dll @(ArtifactsToMerge->'%(filename)%(extension)', ' ')</ILRepackCommand>
+      <ILRepackCommand Condition=" '$(OS)' != 'Windows_NT' ">mono $(ILRepackCommand)</ILRepackCommand>
     </PropertyGroup>
-    <MakeDir Directories="$(OutputPath)\ILMerge" />
-    <Exec Command="$(IlmergeCommand)" ContinueOnError="false" />
-    <Move SourceFiles="%(BuildArtifacts.RelativeDir)ILMerge\%(filename)%(extension)"
-          DestinationFiles="%(BuildArtifacts.RelativeDir)%(filename)%(extension)"
-          OverwriteReadOnlyFiles="true"/>
-    <Delete Files="@(ArtifactsToMerge)" />
-    <RemoveDir Directories="$(OutputPath)ILMerge" />
+    <MakeDir Directories="$(OutputPath)/ILRepack" />
+    <Exec WorkingDirectory="$(OutputPath)" Command="$(ILRepackCommand)" ContinueOnError="false" StandardOutputImportance="normal" />
+    <Move SourceFiles="$(OutputPath)ILRepack/$(AssemblyName).dll" DestinationFiles="$(OutputPath)$(AssemblyName).dll" OverwriteReadOnlyFiles="true" />
+    <RemoveDir Directories="$(OutputPath)ILRepack" />
+    <Message Importance="high" Text="Merged @(ArtifactsToMerge->'%(filename)%(extension)', ', ') into $(OutputPath)$(AssemblyName).dll" />
   </Target>
 
 </Project>


### PR DESCRIPTION
This PR enables merging `Newtonsoft.Json` into `Consul` on .NET Framework, even when building with `mono`.