### PR TITLE
Publish preview versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
   # Tests need to succeed for all components and on all platforms first,
   # including having a tag name that matches the version number.
   publish:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}
     needs: package
     runs-on: windows-2019
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,26 @@ jobs:
       with:
         path: dist/*.nupkg
 
+  # Publish NuGet package to the preview feed when there is a push to master.
+  # Tests need to succeed for all components and on all platforms first.
+  publish-preview:
+    if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/master' }}
+    needs: package
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Download NuGet package artifact
+        uses: actions/download-artifact@v2
+        with:
+          path: dist
+      - name: Publish to NuGet
+        run: |
+          dotnet nuget push "dist/Consul.*.nupkg" --api-key ${{ secrets.FEEDZIO_API_KEY }} --source https://f.feedz.io/consuldotnet/preview/nuget/index.json
+          dotnet nuget push "dist/Consul.AspNetCore.*.nupkg" --api-key ${{ secrets.FEEDZIO_API_KEY }} --source https://f.feedz.io/consuldotnet/preview/nuget/index.json
+
   # Publish NuGet package when a tag is pushed.
   # Tests need to succeed for all components and on all platforms first,
   # including having a tag name that matches the version number.
-  publish:
+  publish-release:
     if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}
     needs: package
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
   publish:
     if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}
     needs: package
-    runs-on: windows-2019
+    runs-on: ubuntu-18.04
     steps:
       - name: Download NuGet package artifact
         uses: actions/download-artifact@v2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![CI](https://github.com/G-Research/consuldotnet/workflows/CI/badge.svg)
 [![](https://img.shields.io/nuget/v/consul)](https://www.nuget.org/packages/Consul/)
+[![](https://img.shields.io/feedz/vpre/consuldotnet/preview/consul)](#preview-versions)
 
 * Consul API: [v1.6.10](https://github.com/hashicorp/consul/tree/v1.6.10/api)
 * .NET: >= 4.6.1 - .NET Core: >= 2.0.0
@@ -200,6 +201,19 @@ Since Consul has already a version that consists of three numbers (e.g. 1.6.1), 
 
 Please note that NuGet normalizes version numbers, by omitting zero in the fourth part of the version number.
 For example version `1.6.1.0` is going to be normalised to `1.6.1`. So to avoid problems, versions and tags with zero in the fourth part should be avoided and explicit three part version should be used instead.
+
+## Preview versions
+
+Preview builds (aka 'nightly' builds) are distributed using https://feedz.io/ for now. To pull preview versions into your project, use the following `NuGet.config` file:
+
+```
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="consuldotnet-preview" value="https://f.feedz.io/consuldotnet/preview/nuget/index.json" />
+  </packageSources>
+</configuration>
+```
 
 ## Release process
 


### PR DESCRIPTION
This PR enables publishing preview versions to a separate feed whenever we push to `master`.

Pre-requisites:
- [x] Create feed on feedz.io
- [x] Create API key and add it as a secret
- [x] #98 (_not_ tag it!) - see below

We should probably bump the version number (say, to 1.6.10.2) so that any new preview version would get published with a higher version number than our latest stable release.

Fixes #68.