### PR TITLE
Use directory.build.props to centralize configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           dotnet-version: 5.0.x
       - name: Build
-        run: dotnet build Consul.AspNetCore.Test --configuration=Release -p:TreatWarningsAsErrors=true --framework=${{ matrix.framework }}
+        run: dotnet build Consul.AspNetCore.Test --configuration=Release --framework=${{ matrix.framework }}
       - name: Run tests
         shell: bash
         run: dotnet test Consul.AspNetCore.Test --configuration=Release --logger "GitHubActions;report-warnings=false" --no-build -v=Normal --framework=${{ matrix.framework }}
@@ -85,7 +85,7 @@ jobs:
           unzip consul.zip
           rm consul.zip
       - name: Build
-        run: dotnet build Consul.Test --configuration=Release -p:TreatWarningsAsErrors=true --framework=${{ matrix.framework }}
+        run: dotnet build Consul.Test --configuration=Release --framework=${{ matrix.framework }}
       - name: Run tests
         shell: bash
         run: |

--- a/Consul.AspNetCore.Test/Consul.AspNetCore.Test.csproj
+++ b/Consul.AspNetCore.Test/Consul.AspNetCore.Test.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Consul.AspNetCore/Consul.AspNetCore.csproj
+++ b/Consul.AspNetCore/Consul.AspNetCore.csproj
@@ -2,21 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <VersionPrefix>1.6.10.2</VersionPrefix>
-    <PackageTags>Consul;service discovery;distributed locking;health checking</PackageTags>
-    <PackageReleaseNotes>https://github.com/G-Research/consuldotnet/blob/master/CHANGELOG.md</PackageReleaseNotes>
-    <PackageProjectUrl>https://github.com/G-Research/consuldotnet</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/G-Research/consuldotnet</RepositoryUrl>
-    <Authors>G-Research</Authors>
+    <PackageTags>$(PackageTags);aspnetcore;asp</PackageTags>
     <Description>Consul Service registration for ASP.NET Core</Description>
     <PackageOutputPath>../dist/consul.aspnetcore</PackageOutputPath>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <PublicSign>true</PublicSign>
-    <AssemblyOriginatorKeyFile>../assets/consuldotnet.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Consul.Test/Consul.Test.csproj
+++ b/Consul.Test/Consul.Test.csproj
@@ -3,10 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies Condition="'$(TargetFramework)' == 'netcoreapp2.1'" >true</CopyLocalLockFileAssemblies>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <PublicSign>true</PublicSign>
-    <AssemblyOriginatorKeyFile>../assets/consuldotnet.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -1,21 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.6.10.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <PackageTags>Consul;service discovery;distributed locking;health checking</PackageTags>
-    <PackageReleaseNotes>https://github.com/G-Research/consuldotnet/blob/master/CHANGELOG.md</PackageReleaseNotes>
-    <PackageProjectUrl>https://github.com/G-Research/consuldotnet</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/G-Research/consuldotnet</RepositoryUrl>
-    <Authors>PlayFab,G-Research</Authors>
+    <Authors>PlayFab,$(Authors)</Authors>
     <Description>Consul.NET is a .NET client library for the Consul HTTP API</Description>
     <PackageOutputPath>../dist/consul</PackageOutputPath>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <PublicSign>true</PublicSign>
-    <AssemblyOriginatorKeyFile>../assets/consuldotnet.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.6.10.2</VersionPrefix>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PackageTags>Consul;service discovery;distributed locking;health checking</PackageTags>
+    <PackageReleaseNotes>https://github.com/G-Research/consuldotnet/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/G-Research/consuldotnet</PackageProjectUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/G-Research/consuldotnet</RepositoryUrl>
+    <Authors>G-Research</Authors>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PublicSign>true</PublicSign>
+    <AssemblyOriginatorKeyFile>../assets/consuldotnet.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
No functional change, except for adding `TreatWarningsAsErrors` to local dev and not only CI.

Existing work from https://github.com/G-Research/consuldotnet/pull/80

