### PR TITLE
Bump version to 1.6.10.2

### DIFF
--- a/Consul.AspNetCore/Consul.AspNetCore.csproj
+++ b/Consul.AspNetCore/Consul.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <VersionPrefix>1.6.10.1</VersionPrefix>
+    <VersionPrefix>1.6.10.2</VersionPrefix>
     <PackageTags>Consul;service discovery;distributed locking;health checking</PackageTags>
     <PackageReleaseNotes>https://github.com/G-Research/consuldotnet/blob/master/CHANGELOG.md</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/G-Research/consuldotnet</PackageProjectUrl>

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.6.10.1</VersionPrefix>
+    <VersionPrefix>1.6.10.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <PackageTags>Consul;service discovery;distributed locking;health checking</PackageTags>
     <PackageReleaseNotes>https://github.com/G-Research/consuldotnet/blob/master/CHANGELOG.md</PackageReleaseNotes>


### PR DESCRIPTION
Prerequisite to #95.

This should always be done as a post-release action so that preview builds have a higher version than stable builds.