### PR TITLE
Fix package publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Create NuGet package
+    - name: Create NuGet packages
       run: |
         if (-not ("${{ github.ref }}" -like "refs/tags/v*")) {
           # WORKAROUND: Add letter prefix to ensure that MSBuild treats
@@ -132,28 +132,30 @@ jobs:
                 exit 1
             }
         }
-    - name: Upload NuGet package artifact
+    - name: Upload NuGet package artifacts
       uses: actions/upload-artifact@v2
       with:
+        name: nuget-packages
         path: dist/*.nupkg
 
-  # Publish NuGet package to the preview feed when there is a push to master.
+  # Publish NuGet packages to the preview feed when there is a push to master.
   # Tests need to succeed for all components and on all platforms first.
   publish-preview:
     if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/master' }}
     needs: package
     runs-on: ubuntu-18.04
     steps:
-      - name: Download NuGet package artifact
+      - name: Download NuGet package artifacts
         uses: actions/download-artifact@v2
         with:
+          name: nuget-packages
           path: dist
       - name: Publish to NuGet
         run: |
           dotnet nuget push "dist/Consul.*.nupkg" --api-key ${{ secrets.FEEDZIO_API_KEY }} --source https://f.feedz.io/consuldotnet/preview/nuget/index.json
           dotnet nuget push "dist/Consul.AspNetCore.*.nupkg" --api-key ${{ secrets.FEEDZIO_API_KEY }} --source https://f.feedz.io/consuldotnet/preview/nuget/index.json
 
-  # Publish NuGet package when a tag is pushed.
+  # Publish NuGet packages when a tag is pushed.
   # Tests need to succeed for all components and on all platforms first,
   # including having a tag name that matches the version number.
   publish-release:
@@ -161,9 +163,10 @@ jobs:
     needs: package
     runs-on: ubuntu-18.04
     steps:
-      - name: Download NuGet package artifact
+      - name: Download NuGet package artifacts
         uses: actions/download-artifact@v2
         with:
+          name: nuget-packages
           path: dist
       - name: Publish to NuGet
         run: |


### PR DESCRIPTION
Our package publishing steps were broken because no artifact name was provided. This meant that packages got uploaded as `artifact` (the default name), but then all artifacts were downloaded and expanded in the `dist` directory, thus ending up in `dist/artifact/` instead of `dist/`.

This PR fixes that by uploading and downloading with an explicit name, ensuring that the NuGet packages end up in `dist/` in the publishing jobs.