### PR TITLE
Change the suffix of preview versions for proper ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,11 +111,7 @@ jobs:
       - name: Create NuGet packages
         run: |
           if (-not ("${{ github.ref }}" -like "refs/tags/v*")) {
-            # WORKAROUND: Add letter prefix to ensure that MSBuild treats
-            # the suffix as a string. e.g. '0313071' will fail as an invalid
-            # version string, but 'G0313071' will succeeded. It looks like
-            # the parser does not like numbers with a leading zero.
-            $suffix = 'g' + $(git rev-parse --short HEAD)
+            $suffix = "preview-$(Get-Date -Format yyyyMMddHHmmss -AsUTC)-$(git rev-parse --short HEAD)"
             $params = "--version-suffix", $suffix
           }
 


### PR DESCRIPTION
This PR changes the suffix of preview versions to be `preview-yyyyMMddHHmmss-commitSHA` (e.g. `preview-20210705083815-562c1d5`) so that they are properly ordered on the feed.