### PR TITLE
Enable .NET source code analysis

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1,0 +1,6 @@
+# Top level entry required to mark this as a global AnalyzerConfig file
+is_global = true
+
+#### Diagnostic configuration ####
+dotnet_analyzer_diagnostic.category-reliability.severity = warning
+dotnet_analyzer_diagnostic.category-security.severity = warning

--- a/.globalconfig
+++ b/.globalconfig
@@ -2,5 +2,7 @@
 is_global = true
 
 #### Diagnostic configuration ####
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-options
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/categories
 dotnet_analyzer_diagnostic.category-reliability.severity = warning
 dotnet_analyzer_diagnostic.category-security.severity = warning

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -560,7 +560,9 @@ namespace Consul
             if (config.DisableServerCertificateValidation)
 #pragma warning restore CS0618 // Type or member is obsolete
             {
+#pragma warning disable CA5359 // The ServerCertificateValidationCallback is set to a function that accepts any server certificate...
                 handler.ServerCertificateValidationCallback += (certSender, cert, chain, sslPolicyErrors) => { return true; };
+#pragma warning restore CA5359
             }
             else
             {

--- a/Consul/Lock.cs
+++ b/Consul/Lock.cs
@@ -308,7 +308,7 @@ namespace Consul
 
                         // If the code executes this far, no other session has the lock, so try to lock it
                         var kvPair = LockEntry(LockSession);
-                        var locked = (await _client.KV.Acquire(kvPair).ConfigureAwait(false)).Response;
+                        var locked = (await _client.KV.Acquire(kvPair, ct).ConfigureAwait(false)).Response;
 
                         // KV acquisition succeeded, so the session now holds the lock
                         if (locked)
@@ -727,7 +727,7 @@ namespace Consul
             }
             finally
             {
-                await l.Release().ConfigureAwait(false);
+                await l.Release(ct).ConfigureAwait(false);
             }
 
         }

--- a/Consul/Semaphore.cs
+++ b/Consul/Semaphore.cs
@@ -348,7 +348,7 @@ namespace Consul
                         LockSession = Opts.Session;
                     }
 
-                    var contender = (await _client.KV.Acquire(ContenderEntry(LockSession)).ConfigureAwait(false)).Response;
+                    var contender = (await _client.KV.Acquire(ContenderEntry(LockSession), ct).ConfigureAwait(false)).Response;
                     if (!contender)
                     {
                         DisposeCancellationTokenSource();
@@ -381,7 +381,7 @@ namespace Consul
                         QueryResult<KVPair[]> pairs;
                         try
                         {
-                            pairs = await _client.KV.List(Opts.Prefix, qOpts).ConfigureAwait(false);
+                            pairs = await _client.KV.List(Opts.Prefix, qOpts, ct).ConfigureAwait(false);
                         }
                         catch (Exception ex)
                         {
@@ -424,7 +424,7 @@ namespace Consul
                         }
 
                         // Handle the case of not getting the lock
-                        if (!(await _client.KV.CAS(newLock).ConfigureAwait(false)).Response)
+                        if (!(await _client.KV.CAS(newLock, ct).ConfigureAwait(false)).Response)
                         {
                             continue;
                         }
@@ -442,7 +442,7 @@ namespace Consul
                 if (ct.IsCancellationRequested || (!IsHeld && !string.IsNullOrEmpty(Opts.Session)))
                 {
                     DisposeCancellationTokenSource();
-                    await _client.KV.Delete(ContenderEntry(LockSession).Key).ConfigureAwait(false);
+                    await _client.KV.Delete(ContenderEntry(LockSession).Key, ct).ConfigureAwait(false);
                     if (_sessionRenewTask != null)
                     {
                         try

--- a/Consul/Session.cs
+++ b/Consul/Session.cs
@@ -324,7 +324,7 @@ namespace Consul
         {
             if (se == null)
             {
-                return Create(null, q);
+                return Create(null, q, ct);
             }
             var noChecksEntry = new SessionEntry()
             {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <VersionPrefix>1.6.10.3</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <PackageTags>Consul;service discovery;distributed locking;health checking</PackageTags>
     <PackageReleaseNotes>https://github.com/G-Research/consuldotnet/blob/master/CHANGELOG.md</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/G-Research/consuldotnet</PackageProjectUrl>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
     "sdk": {
-      "version": "5.0.x"
+      "version": "5.0.100",
+      "rollForward": "minor"
     }
   }


### PR DESCRIPTION
We can enabling Roslyn analysers to catch code issues at compile time. In this PR we only enable `reliability` and `security` categories as enabling all would generate too much warnings.