### PR TITLE
Use security-and-quality suite for CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+name: "Security and Quality"
+
+# https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+queries:
+  - uses: security-and-quality

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,10 +46,7 @@ jobs:
       uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        config-file: ./.github/codeql/codeql-config.yml
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
CodeQL has two built-in [query suites](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs). By default it uses the `security-extended` one. By enabling `security-and-quality` we can benefit from additional code quality checks. 
From tests on my branch I can say that there are a few false positives (like "Call to obsolete method") but there are also real issues being detected e.g.:
> ### Equals should not apply "as"
> Implementations of 'Equals' should not use "as" to test the type of the argument, but rather call GetType(). This guards against the possibility that the argument type will be subclassed. Otherwise, it is likely that the Equals method will not be symmetric,  violating its contract.