### PR TITLE
Fix the equality check

### DIFF
--- a/Consul/ACL.cs
+++ b/Consul/ACL.cs
@@ -65,8 +65,9 @@ namespace Consul
         public override bool Equals(object other)
 #pragma warning restore CS0809 // Obsolete member 'ACLType.Equals(object)' overrides non-obsolete member
         {
-            var a = other as ACLType;
-            return a != null && Equals(a);
+            return other != null &&
+                   GetType() == other.GetType() &&
+                   Equals((ACLType)other);
         }
 
 #pragma warning disable CS0809 // Obsolete member 'ACLType.Equals(object)' overrides non-obsolete member

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -68,7 +68,9 @@ namespace Consul
         public override bool Equals(object other)
         {
             // other could be a reference type, the is operator will return false if null
-            return other is TTLStatus && Equals(other as TTLStatus);
+            return other != null &&
+                   GetType() == other.GetType() &&
+                   Equals((TTLStatus)other);
         }
 
         public override int GetHashCode()

--- a/Consul/Health.cs
+++ b/Consul/Health.cs
@@ -74,7 +74,9 @@ namespace Consul
         public override bool Equals(object other)
         {
             // other could be a reference type, the is operator will return false if null
-            return other is HealthStatus && Equals(other as HealthStatus);
+            return other != null &&
+                   GetType() == other.GetType() &&
+                   Equals((HealthStatus)other);
         }
 
         public override int GetHashCode()

--- a/Consul/KV.cs
+++ b/Consul/KV.cs
@@ -103,7 +103,9 @@ namespace Consul
         public override bool Equals(object other)
         {
             // other could be a reference type, the is operator will return false if null
-            return other is KVTxnVerb && Equals(other as KVTxnVerb);
+            return other != null &&
+                   GetType() == other.GetType() &&
+                   Equals((KVTxnVerb)other);
         }
 
         public override int GetHashCode()

--- a/Consul/Session.cs
+++ b/Consul/Session.cs
@@ -51,8 +51,9 @@ namespace Consul
         public override bool Equals(object other)
         {
             // other could be a reference type, the is operator will return false if null
-            var a = other as SessionBehavior;
-            return a != null && Equals(a);
+            return other != null &&
+                   GetType() == other.GetType() &&
+                   Equals((SessionBehavior)other);
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
Fixes some warnings from the CodeQL "security-and-quality" checks:

> Equals should not apply "as"
> Implementations of 'Equals' should not use "as" to test the type of the argument, but rather call GetType(). This guards against the possibility that the argument type will be subclassed. Otherwise, it is likely that the Equals method will not be symmetric, violating its contract."