### PR TITLE
Removing unnecessary deregistration code from tests 

### DIFF
--- a/Consul.Test/CatalogTest.cs
+++ b/Consul.Test/CatalogTest.cs
@@ -168,25 +168,6 @@ namespace Consul.Test
 
             var services = await _client.Catalog.Service("redis");
 
-            var dereg = new CatalogDeregistration
-            {
-                Datacenter = "dc1",
-                Node = "foobar",
-                Address = "192.168.10.10",
-                CheckID = "service:" + svcID
-            };
-
-            await _client.Catalog.Deregister(dereg);
-
-            dereg = new CatalogDeregistration
-            {
-                Datacenter = "dc1",
-                Node = "foobar",
-                Address = "192.168.10.10"
-            };
-
-            await _client.Catalog.Deregister(dereg);
-
             Assert.True(services.Response.Length > 0);
             Assert.True(services.Response[0].ServiceTaggedAddresses.Count > 0);
             Assert.True(services.Response[0].ServiceTaggedAddresses.ContainsKey("wan"));


### PR DESCRIPTION
As mentioned on https://github.com/G-Research/consuldotnet/pull/111/files#r679150101, there is no need to explicitly deregister the test client. It will be deregistered automatically by the consul server.