### PR TITLE
Update Consul agent versions used for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        consul: [1.6.10, 1.7.14, 1.8.16, 1.9.10, 1.10.3]
+        consul: [1.6.10, 1.7.14, 1.8.19, 1.9.14, 1.10.7]
         framework: [net461, netcoreapp2.1, netcoreapp3.1, net5.0]
         os: [ubuntu-18.04, windows-2019, macos-10.15]
       fail-fast: false


### PR DESCRIPTION
This PR updates (once again) the Consul agent versions to the latest ones available.

I will open another PR to add testing against Consul 1.11.x, as it requires some changes in our unit tests.