### PR TITLE
CI: Pin .NET SDK 6.0.102 for now to avoid dotnet format regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET SDK v6.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 6.0.102
       - name: Check format
         run: dotnet format --verify-no-changes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Setup .NET SDK v6.0.x
         uses: actions/setup-dotnet@v1
         with:
+          # Pin .NET SDK 6.0.102 for now to avoid dotnet format regression https://github.com/dotnet/format/issues/1519
           dotnet-version: 6.0.102
       - name: Check format
         run: dotnet format --verify-no-changes


### PR DESCRIPTION
Fixes https://github.com/G-Research/consuldotnet/runs/5330947266?check_suite_focus=true