### PR TITLE
Auto-update Consul versions

### DIFF
--- a/.github/workflows/scripts/update-consul-versions.ps1
+++ b/.github/workflows/scripts/update-consul-versions.ps1
@@ -1,0 +1,32 @@
+$workflow = ".github/workflows/ci.yml"
+$owner = "hashicorp"
+$repo = "consul"
+
+# Suppress telemetry reminder
+Set-GitHubConfiguration -SuppressTelemetryReminder
+
+# Use GITHUB_TOKEN if provided
+if ($Env:GITHUB_TOKEN -ne $null)
+{
+  $token = ($Env:GITHUB_TOKEN | ConvertTo-SecureString -AsPlainText -Force)
+  $cred = New-Object System.Management.Automation.PSCredential "username is ignored", $token
+  Set-GitHubAuthentication -Credential $cred -SessionOnly
+}
+
+# Fetch all the latest stable Consul releases
+$releases = Get-GitHubRelease -OwnerName $owner -RepositoryName $repo | Where-Object { ! $_.PreRelease }
+
+# Find the latest version for each minor release
+$latest = @{}
+foreach ($release in $releases)
+{
+  $version = [version]($release.tag_name.Substring(1))
+  $minor = "$($version.Major).$($version.Minor)"
+  if (!$latest.ContainsKey($minor) -or $latest[$minor] -lt $version)
+  {
+    $latest[$minor] = $version
+  }
+}
+
+# Update the CI workflow with the latest versions
+(Get-Content $workflow) -Replace "consul: \[(\d+\.\d+\.\d+(, )?)+\]", "consul: [$($latest.Values | Sort-Object | ForEach-Object { [string]$_ } | Join-String -Separator ", ")]" | Set-Content $workflow

--- a/.github/workflows/update-consul-versions.yml
+++ b/.github/workflows/update-consul-versions.yml
@@ -1,0 +1,49 @@
+name: "Update Consul versions"
+
+on:
+  schedule:
+    - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
+
+jobs:
+  update-consul-versions:
+    # Only run on main repository
+    # Scheduled workflows do not have information about fork status, hence the hardcoded check
+    if: github.repository == 'G-Research/consuldotnet'
+    environment: update-consul-versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Step CLI
+        env:
+          VERSION: 0.19.0
+        run: |
+          curl -sLO https://github.com/smallstep/cli/releases/download/v${VERSION}/step-cli_${VERSION}_amd64.deb
+          sudo dpkg -i step-cli_${VERSION}_amd64.deb
+          rm step-cli_${VERSION}_amd64.deb
+
+      - name: Create access token
+        id: token
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          jwt=$(step crypto jwt sign --key /dev/fd/3 --issuer $APP_ID --expiration $(date -d +5min +%s) --subtle 3<<< $APP_PRIVATE_KEY)
+          installation_id=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $jwt" https://api.github.com/app/installations | jq '.[] | select(.account.login == "${{ github.repository_owner }}") | .id')
+          token=$(curl -s -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $jwt" https://api.github.com/app/installations/$installation_id/access_tokens | jq -r '.token')
+          echo "::add-mask::$token"
+          echo "::set-output name=token::$token"
+
+      - name: Install PowerShellForGitHub
+        shell: pwsh
+        run: Install-Module -Force PowerShellForGitHub
+
+      - name: Update consul versions
+        uses: technote-space/create-pr-action@v2
+        with:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+          EXECUTE_COMMANDS: pwsh .github/workflows/scripts/update-consul-versions.ps1
+          COMMIT_MESSAGE: 'Update Consul agent versions used for testing'
+          COMMIT_NAME: 'Consul.NET CI'
+          COMMIT_EMAIL: 'consuldotnet@gr-oss.io'
+          PR_BRANCH_PREFIX: 'schedule/'
+          PR_BRANCH_NAME: 'update-consul-versions'
+          PR_TITLE: 'Update Consul agent versions used for testing'


### PR DESCRIPTION
This PR introduces a new daily scheduled workflow that checks for the latest versions of Consul and updates our CI with them if needed. It will do so by creating a new branch with the changes and opening a PR, which is much better than me doing all of that manually every once in a while 😅

As the default token used by GitHub Actions does not have the special `workflows` permissions required to update our CI, a custom GitHub App had to be created instead with the required permissions. Its credentials have been set as secrets within the `update-consul-versions` environment that only `master` can access.

An example of a PR created by this workflow can be found here: https://github.com/jgiannuzzi/consuldotnet/pull/2