### PR TITLE
CI: Revert .NET SDK pinning for dotnet format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Setup .NET SDK v6.0.x
         uses: actions/setup-dotnet@v1
         with:
-          # Pin .NET SDK 6.0.102 for now to avoid dotnet format regression https://github.com/dotnet/format/issues/1519
-          dotnet-version: 6.0.102
+          dotnet-version: 6.0.x
       - name: Check format
         run: dotnet format --verify-no-changes
 


### PR DESCRIPTION
Now that https://github.com/dotnet/format/issues/1519 has been solved (in .NET SDK 6.0.202), we can revert the pinning.