### PR TITLE
Bump patch version for preview builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.6.10.5</VersionPrefix>
+    <VersionPrefix>1.6.10.6</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>


### PR DESCRIPTION
As per step 5 of our [release process](https://github.com/G-Research/consuldotnet/tree/v1.6.10.5#release-process), this PR bumps the patch version to the next unreleased one so that preview builds can be published properly.