### PR TITLE
Fix deadlock in .net framework.

### DIFF
--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -374,9 +374,9 @@ namespace Consul
         /// Services returns the locally registered services
         /// </summary>
         /// <returns>A map of the registered services and service data</returns>
-        public async Task<QueryResult<Dictionary<string, AgentService>>> Services(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<Dictionary<string, AgentService>>> Services(CancellationToken ct = default(CancellationToken))
         {
-            return await Services(null, ct);
+            return Services(null, ct);
         }
 
         /// <summary>
@@ -384,9 +384,9 @@ namespace Consul
         /// </summary>
         /// <param name="filter">Specifies the expression used to filter the queries results prior to returning the data</param>
         /// <returns>A map of the registered services and service data</returns>
-        public async Task<QueryResult<Dictionary<string, AgentService>>> Services(Filter filter, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<Dictionary<string, AgentService>>> Services(Filter filter, CancellationToken ct = default(CancellationToken))
         {
-            return await _client.Get<Dictionary<string, AgentService>>("/v1/agent/services", null, filter).Execute(ct);
+            return _client.Get<Dictionary<string, AgentService>>("/v1/agent/services", null, filter).Execute(ct);
         }
 
         /// <summary>


### PR DESCRIPTION
Deadlock occurs when calling ‘Services’ method synchronously in .Net Framework, which is a classic problem.

None of the other methods in this class use await, so I removed await.


