### PR TITLE
Enforce `ConfigureAwait(false)` on the whole library

### DIFF
--- a/Consul.AspNetCore/Consul.AspNetCore.csproj
+++ b/Consul.AspNetCore/Consul.AspNetCore.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.10" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.10" />
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -353,7 +353,7 @@ namespace Consul
                 {
                     if (_nodeName == null)
                     {
-                        _nodeName = (await Self(ct)).Response["Config"]["NodeName"];
+                        _nodeName = (await Self(ct).ConfigureAwait(false)).Response["Config"]["NodeName"];
                     }
                 }
             }
@@ -376,7 +376,7 @@ namespace Consul
         /// <returns>A map of the registered services and service data</returns>
         public async Task<QueryResult<Dictionary<string, AgentService>>> Services(CancellationToken ct = default(CancellationToken))
         {
-            return await Services(null, ct);
+            return await Services(null, ct).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -386,7 +386,7 @@ namespace Consul
         /// <returns>A map of the registered services and service data</returns>
         public async Task<QueryResult<Dictionary<string, AgentService>>> Services(Filter filter, CancellationToken ct = default(CancellationToken))
         {
-            return await _client.Get<Dictionary<string, AgentService>>("/v1/agent/services", null, filter).Execute(ct);
+            return await _client.Get<Dictionary<string, AgentService>>("/v1/agent/services", null, filter).Execute(ct).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Consul/AuthMethod.cs
+++ b/Consul/AuthMethod.cs
@@ -241,7 +241,7 @@ namespace Consul
         /// <returns>A write result</returns>
         public async Task<WriteResult> Logout(WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
         {
-            return await _client.Post($"/v1/acl/logout", null, writeOptions).Execute(ct);
+            return await _client.Post($"/v1/acl/logout", null, writeOptions).Execute(ct).ConfigureAwait(false);
         }
     }
 

--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">

--- a/Consul/KV.cs
+++ b/Consul/KV.cs
@@ -600,7 +600,7 @@ namespace Consul
             }
 
             var req = _client.Put<List<TxnOp>, TxnResponse>("/v1/txn", txnOps, q);
-            var txnRes = await req.Execute(ct);
+            var txnRes = await req.Execute(ct).ConfigureAwait(false);
 
             var res = new WriteResult<KVTxnResponse>(txnRes, new KVTxnResponse(txnRes.Response));
 

--- a/Consul/PreparedQuery.cs
+++ b/Consul/PreparedQuery.cs
@@ -244,7 +244,7 @@ namespace Consul
 
         public async Task<WriteResult> Delete(string queryID, WriteOptions q, CancellationToken ct = default(CancellationToken))
         {
-            var res = await _client.DeleteReturning<string>(string.Format("/v1/query/{0}", queryID), q).Execute(ct);
+            var res = await _client.DeleteReturning<string>(string.Format("/v1/query/{0}", queryID), q).Execute(ct).ConfigureAwait(false);
             return new WriteResult(res);
         }
 


### PR DESCRIPTION
Follows up the user report from #146. By adding Roslyn analyser to the Consul project we prevent from similar issues happening ever again.

PS:
I've found a nice write up about the ConfigureAwait issue https://devblogs.microsoft.com/dotnet/configureawait-faq/ (TLDR: in the library code should use `ConfigureAwait(false)` to avoid some deadlock scenarios)