### PR TITLE
Add support for replace-existing-checks parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Add support for `replace-existing-checks` parameter of service registration endpoint that allows to replace existing checks when re-registering a service
 
 ## 1.6.10.6
 * Enforce ConfigureAwait(false) on the whole library (#148)

--- a/Consul.Test/AgentTest.cs
+++ b/Consul.Test/AgentTest.cs
@@ -544,5 +544,99 @@ namespace Consul.Test
             Assert.Equal(svcID1, (await _client.Agent.Services(metaSelector[uniqueMeta] == "bar1")).Response.Keys.Single());
             Assert.Equal(svcID2, (await _client.Agent.Services(metaSelector[uniqueMeta] == "bar2")).Response.Keys.Single());
         }
+
+        [Fact]
+        public async Task Agent_ReRegister()
+        {
+            var svcID = KVTest.GenerateTestKeyName();
+            var check1Name = svcID + "1";
+            var check2Name = svcID + "2";
+            var check3Name = svcID + "3";
+            var registration1 = new AgentServiceRegistration
+            {
+                Name = svcID,
+                Port = 8000,
+                Checks = new[]
+                {
+                    new AgentServiceCheck
+                    {
+                        Name = check1Name,
+                        TTL = TimeSpan.FromSeconds(15)
+                    },
+                    new AgentServiceCheck
+                    {
+                        Name = check2Name,
+                        TTL = TimeSpan.FromSeconds(15)
+                    }
+                }
+            };
+            var registration2 = new AgentServiceRegistration
+            {
+                Name = svcID,
+                Port = 8000,
+                Check = new AgentServiceCheck
+                {
+                    Name = check3Name,
+                    TTL = TimeSpan.FromSeconds(15)
+                }
+            };
+
+            await _client.Agent.ServiceRegister(registration1);
+            await _client.Agent.ServiceRegister(registration2);
+
+            var checks = await _client.Agent.Checks();
+            Assert.Contains(check1Name, checks.Response.Values.Select(c => c.Name));
+            Assert.Contains(check2Name, checks.Response.Values.Select(c => c.Name));
+            Assert.Contains(check3Name, checks.Response.Values.Select(c => c.Name));
+
+            await _client.Agent.ServiceDeregister(svcID);
+        }
+
+        [Fact]
+        public async Task Agent_ReRegister_ReplaceExistingChecks()
+        {
+            var svcID = KVTest.GenerateTestKeyName();
+            var check1Name = svcID + "1";
+            var check2Name = svcID + "2";
+            var check3Name = svcID + "3";
+            var registration1 = new AgentServiceRegistration
+            {
+                Name = svcID,
+                Port = 8000,
+                Checks = new[]
+                {
+                    new AgentServiceCheck
+                    {
+                        Name = check1Name,
+                        TTL = TimeSpan.FromSeconds(15)
+                    },
+                    new AgentServiceCheck
+                    {
+                        Name = check2Name,
+                        TTL = TimeSpan.FromSeconds(15)
+                    }
+                }
+            };
+            var registration2 = new AgentServiceRegistration
+            {
+                Name = svcID,
+                Port = 8000,
+                Check = new AgentServiceCheck
+                {
+                    Name = check3Name,
+                    TTL = TimeSpan.FromSeconds(15)
+                }
+            };
+
+            await _client.Agent.ServiceRegister(registration1);
+            await _client.Agent.ServiceRegister(registration2, replaceExistingChecks: true);
+
+            var checks = await _client.Agent.Checks();
+            Assert.DoesNotContain(check1Name, checks.Response.Values.Select(c => c.Name));
+            Assert.DoesNotContain(check2Name, checks.Response.Values.Select(c => c.Name));
+            Assert.Contains(check3Name, checks.Response.Values.Select(c => c.Name));
+
+            await _client.Agent.ServiceDeregister(svcID);
+        }
     }
 }

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -410,7 +410,23 @@ namespace Consul
         /// <returns>An empty write result</returns>
         public Task<WriteResult> ServiceRegister(AgentServiceRegistration service, CancellationToken ct = default(CancellationToken))
         {
-            return _client.Put("/v1/agent/service/register", service, null).Execute(ct);
+            return ServiceRegister(service, replaceExistingChecks: false, ct);
+        }
+
+        /// <summary>
+        /// ServiceRegister is used to register a new service with the local agent
+        /// </summary>
+        /// <param name="service">A service registration object</param>
+        /// <param name="replaceExistingChecks">Missing health checks from the request will be deleted from the agent.</param>
+        /// <returns>An empty write result</returns>
+        public Task<WriteResult> ServiceRegister(AgentServiceRegistration service, bool replaceExistingChecks, CancellationToken ct = default(CancellationToken))
+        {
+            var req = _client.Put("/v1/agent/service/register", service, null);
+            if (replaceExistingChecks)
+            {
+                req.Params["replace-existing-checks"] = "true";
+            }
+            return req.Execute(ct);
         }
 
         /// <summary>

--- a/Consul/Interfaces/IAgentEndpoint.cs
+++ b/Consul/Interfaces/IAgentEndpoint.cs
@@ -48,6 +48,7 @@ namespace Consul
         Task<QueryResult<Dictionary<string, Dictionary<string, dynamic>>>> Self(CancellationToken ct = default(CancellationToken));
         Task<WriteResult> ServiceDeregister(string serviceID, CancellationToken ct = default(CancellationToken));
         Task<WriteResult> ServiceRegister(AgentServiceRegistration service, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult> ServiceRegister(AgentServiceRegistration service, bool replaceExistingChecks, CancellationToken ct = default(CancellationToken));
         Task<QueryResult<Dictionary<string, AgentService>>> Services(CancellationToken ct = default(CancellationToken));
         Task<QueryResult<Dictionary<string, AgentService>>> Services(Filter filter, CancellationToken ct = default(CancellationToken));
         Task<WriteResult> UpdateTTL(string checkID, string output, TTLStatus status, CancellationToken ct = default(CancellationToken));


### PR DESCRIPTION
Consul docs about parameter: https://www.consul.io/api-docs/agent/service#replace-existing-checks
It was added in Consul v1.6.1, but not presented in this library