### PR TITLE
Add octo nudge workflow. Trigger on CI and CodeQL workflows

### DIFF
--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -1,0 +1,18 @@
+name: Nudge
+
+on:
+  workflow_run:
+    workflows: [CI,CodeQL]
+    types: [completed]
+    branches: [master]
+
+
+jobs:
+  nudge:
+    runs-on: ubuntu-latest
+    environment: nudge
+    steps:
+      - name: Send notification
+        uses: pavlovic-ivan/octo-nudge@v1
+        with:
+          webhooks: ${{ secrets.NUDGE_WEBHOOKS }}


### PR DESCRIPTION
@jgiannuzzi This PR introduces a workflow that will be triggered when CI and CodeQL workflows are completed. By default, you will receive a notification in Slack only if they had failed.

[Here](https://github.com/pavlovic-ivan/consuldotnet/actions/runs/3275997830) is the CI workflow that failed. And [here](https://github.com/pavlovic-ivan/consuldotnet/actions/runs/3276267169) is the workflow that got triggered, that had sent the notification to Slack.

In this PR, when the Github Action Octo Nudge is callled, it is using default values. In short:

- notify if workflow conclusion is failure
- notify if a workflow is triggered by a push or schedule to the master branch

You can check the rest [here](https://github.com/pavlovic-ivan/octo-nudge#action-input-arguments).

I've tested using my fork, my incoming webhook created withing Slack, and a channel i've created. Which means that you will need to create the incoming webhook and the channel, or connect the incoming webhook to an existing channel. Also, you will need a secret called `NUDGE_WEBHOOKS` in an environment, called `nudge`, with a protected branch rule set to master. If you need help, please let me know, i will be available for setting it up.

Lastly, this is how the notification looks like in Slack.
<img width="537" alt="Screenshot 2022-10-18 at 21 21 55" src="https://user-images.githubusercontent.com/23194814/196524507-a010533a-8b42-429b-aa8e-8ab48264e0e1.png">

For more configuration options, check the [Readme](https://github.com/pavlovic-ivan/octo-nudge#configuring-octo-nudge).