### PR TITLE
Add CheckId to the AgentServiceCheck and mark the ID as obsolete

### DIFF
--- a/Consul.Test/AgentTest.cs
+++ b/Consul.Test/AgentTest.cs
@@ -602,5 +602,36 @@ namespace Consul.Test
 
             await _client.Agent.ServiceDeregister(svcID);
         }
+
+        [Fact]
+        public async Task Agent_Register_UseCustomCheckId()
+        {
+            var svcID = KVTest.GenerateTestKeyName();
+            var check1Id = svcID + "_checkId";
+            var check1Name = svcID + "_checkName";
+            var registration1 = new AgentServiceRegistration
+            {
+                Name = svcID,
+                Port = 8000,
+                Checks = new[]
+                {
+                    new AgentServiceCheck
+                    {
+                        Name = check1Name,
+                        CheckId = check1Id,
+                        TTL = TimeSpan.FromSeconds(15),
+                    },
+                }
+            };
+
+            await _client.Agent.ServiceRegister(registration1);
+
+            var checks = await _client.Agent.Checks();
+            Assert.Contains(check1Id, checks.Response.Keys);
+
+            var check = checks.Response[check1Id];
+            Assert.Equal(check.Name, check1Name);
+            Assert.Equal(check.CheckID, check1Id);
+        }
     }
 }

--- a/Consul.Test/AgentTest.cs
+++ b/Consul.Test/AgentTest.cs
@@ -618,7 +618,7 @@ namespace Consul.Test
                     new AgentServiceCheck
                     {
                         Name = check1Name,
-                        CheckId = check1Id,
+                        CheckID = check1Id,
                         TTL = TimeSpan.FromSeconds(15),
                     },
                 }

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -220,7 +220,7 @@ namespace Consul
         public string ID { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public string CheckId { get; set; }
+        public string CheckID { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Name { get; set; }

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -214,9 +214,13 @@ namespace Consul
     /// </summary>
     public class AgentServiceCheck
     {
-
+        // See https://github.com/G-Research/consuldotnet/issues/184
+        [Obsolete("Use CheckId instead")]
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string ID { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string CheckId { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Name { get; set; }


### PR DESCRIPTION
Fixes https://github.com/G-Research/consuldotnet/issues/184

Apparently, the [documentation about checks](https://developer.hashicorp.com/consul/api-docs/agent/check#json-request-body-schema) is incorrect. To specify the id of a check we need to use `CheckId` instead of `ID` parameter. I'm also adding a corresponding test so we have proof that it actually works.