### PR TITLE
Adding properties: AliasService, AliasNode to AgentServiceCheck class

### DIFF
--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -280,6 +280,12 @@ namespace Consul
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public bool GRPCUseTLS { get; set; }
 
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string AliasService { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string AliasNode { get; set; }
+
         /// <summary>
         /// In Consul 0.7 and later, checks that are associated with a service
         /// may also contain this optional DeregisterCriticalServiceAfter field,


### PR DESCRIPTION
Adding properties: AliasService, AliasNode to AgentServiceCheck class for support:
https://developer.hashicorp.com/consul/api-docs/agent/check#aliasnode
https://developer.hashicorp.com/consul/api-docs/agent/check#aliasservice
Added tests, thanks to user @marcin-krystianc.