### PR TITLE
Update CI, drop tests for old frameworks, add net7.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-format": {
+      "version": "5.1.250801",
+      "commands": [
+        "dotnet-format"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup .NET SDK v7.0.x100
+      - name: Setup .NET SDK v6.0.100
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.100
+          dotnet-version: 6.0.100
       - name: Check format
         run: dotnet format -v diag --verify-no-changes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
   # Enforces the consistency of code formatting using `.editorconfig` and the `dotnet-format` tool.
   check-format:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup .NET SDK v6.0.x
+      - name: Setup .NET SDK v7.0.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
       - name: Check format
         run: dotnet format --verify-no-changes
 
@@ -27,18 +27,13 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
-        framework: [netcoreapp3.1, net5.0, net6.0]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        framework: [netcoreapp3.1, net5.0, net6.0, net7.0]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup .NET Core SDK v3.1.x
-        if: matrix.framework == 'netcoreapp3.1'
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 3.1.x
       - name: Setup .NET SDK v5.0.x
         if: matrix.framework == 'net5.0'
         uses: actions/setup-dotnet@v3
@@ -48,6 +43,10 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
+      - name: Setup .NET SDK v7.0.x
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
       - name: Build
         run: dotnet build Consul.AspNetCore.Test --configuration=Release --framework=${{ matrix.framework }}
       - name: Run tests
@@ -58,23 +57,13 @@ jobs:
     strategy:
       matrix:
         consul: [1.6.10, 1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.7, 1.14.5, 1.15.1]
-        framework: [net461, netcoreapp2.1, netcoreapp3.1, net5.0, net6.0]
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        framework: [net461, net5.0, net6.0, net7.0]
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup .NET Core SDK v2.1.x
-        if: matrix.framework == 'netcoreapp2.1'
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 2.1.x
-      - name: Setup .NET Core SDK v3.1.x
-        if: matrix.framework == 'netcoreapp3.1'
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 3.1.x
       - name: Setup .NET SDK v5.0.x
         if: matrix.framework == 'net5.0'
         uses: actions/setup-dotnet@v3
@@ -84,6 +73,10 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
+      - name: Setup .NET SDK v7.0.x
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
       - name: Download Consul
         shell: bash
         run: |
@@ -151,7 +144,7 @@ jobs:
   publish-preview:
     if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/master' }}
     needs: package
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Download NuGet package artifacts
         uses: actions/download-artifact@v3
@@ -167,7 +160,7 @@ jobs:
   publish-release:
     if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}
     needs: package
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Download NuGet package artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup .NET SDK v5.0.x
+        if: matrix.framework == 'net5.0'
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 5.0.x
+      - name: Setup .NET SDK v6.0.x
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
       - name: Setup .NET SDK v7.0.x
         uses: actions/setup-dotnet@v3
         with:
@@ -58,6 +67,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup .NET SDK v5.0.x
+        if: matrix.framework == 'net5.0'
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 5.0.x
+      - name: Setup .NET SDK v6.0.x
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
       - name: Setup .NET SDK v7.0.x
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:
-  # Enforces the consistency of code formatting using `.editorconfig` and the `dotnet-format` tool.
+  # Enforces the consistency of code formatting using `.editorconfig` and the `dotnet format`.
   check-format:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ubuntu-latest
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7.0.x
-      // For the time being (https://github.com/dotnet/format/issues/1500, https://github.com/dotnet/format/issues/1560) we need to use `dotnet-format` instead of `dotnet format`
+      # For the time being (https://github.com/dotnet/format/issues/1500, https://github.com/dotnet/format/issues/1560) we need to use `dotnet-format` instead of `dotnet format`
       - name: Restore tool
         run: dotnet tool restore
       - name: Check format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,15 +37,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup .NET SDK v5.0.x
-        if: matrix.framework == 'net5.0'
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 5.0.x
-      - name: Setup .NET SDK v6.0.x
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 6.0.x
       - name: Setup .NET SDK v7.0.x
         uses: actions/setup-dotnet@v3
         with:
@@ -67,15 +58,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup .NET SDK v5.0.x
-        if: matrix.framework == 'net5.0'
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 5.0.x
-      - name: Setup .NET SDK v6.0.x
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 6.0.x
       - name: Setup .NET SDK v7.0.x
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup .NET SDK v6.0.x
+      - name: Setup .NET SDK v7.0.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
       - name: Create NuGet packages
         run: |
           if (-not ("${{ github.ref }}" -like "refs/tags/v*")) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           path: consul*.log
 
   package:
-    runs-on: windows-2019
+    runs-on: windows-latest
     needs: [Consul_AspNetCore, Consul]
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup .NET SDK v7.0.x
+      - name: Setup .NET SDK v7.0.x100
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 7.0.100
       - name: Check format
-        run: dotnet format --verify-no-changes
+        run: dotnet format -v diag --verify-no-changes
 
   Consul_AspNetCore:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7.0.x
+      // For the time being (https://github.com/dotnet/format/issues/1500, https://github.com/dotnet/format/issues/1560) we need to use `dotnet-format` instead of `dotnet format`
       - name: Restore tool
         run: dotnet tool restore
       - name: Check format
@@ -30,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        framework: [netcoreapp3.1, net5.0, net6.0, net7.0]
+        framework: [net5.0, net6.0, net7.0]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           dotnet-version: 5.0.x
       - name: Setup .NET SDK v6.0.x
+        if: matrix.framework == 'net6.0'
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
@@ -73,6 +74,7 @@ jobs:
         with:
           dotnet-version: 5.0.x
       - name: Setup .NET SDK v6.0.x
+        if: matrix.framework == 'net6.0'
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup .NET SDK v6.0.100
+      - name: Setup .NET SDK v7.0.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.100
+          dotnet-version: 7.0.x
+      - name: Restore tool
+        run: dotnet tool restore
       - name: Check format
-        run: dotnet format -v diag --verify-no-changes
+        run: dotnet tool run dotnet-format  -- --check
 
   Consul_AspNetCore:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id

--- a/Consul.AspNetCore.Test/Consul.AspNetCore.Test.csproj
+++ b/Consul.AspNetCore.Test/Consul.AspNetCore.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 

--- a/Consul.Test/Consul.Test.csproj
+++ b/Consul.Test/Consul.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net5.0;net6.0;net7.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <CopyLocalLockFileAssemblies Condition="'$(TargetFramework)' == 'netcoreapp2.1'" >true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "6.0.100",
+      "version": "7.0.100",
       "rollForward": "latestMinor"
     }
   }


### PR DESCRIPTION
- Ubuntu-18.04 is deprecated ( "The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023" - https://github.com/actions/runner-images/issues/6002). I think we should use "latest" images for all systems. Either "latest" or "fixed" images are being updated continuously, so I don't think there is a benefit of using a "fixed" version.
- netcoreapp2.1 and netcoreapp3.1 are now a [history](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle), I think it is enough to test the last three official releases.
- we need to use `dotnet-format` instead of `dotnet format` due to pending issues with the latter (https://github.com/dotnet/format/issues/1500, https://github.com/dotnet/format/issues/1560)