### PR TITLE
Unblock the CI for enterprise version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
         run: |
           ./Consul.Test/consul agent -dev -config-file Consul.Test/test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &
           dotnet test Consul.Test --configuration=Release --logger "GitHubActions;report-warnings=false" --no-build -v=Normal --framework=${{ matrix.framework }}
+        env:
+            RUN_CONSUL_ENTERPRISE_TESTS: $RUN_CONSUL_ENTERPRISE_TESTS
       - name: Upload Consul logs
         if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           ./Consul.Test/consul agent -dev -config-file Consul.Test/test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &
           dotnet test Consul.Test --configuration=Release --logger "GitHubActions;report-warnings=false" --no-build -v=Normal --framework=${{ matrix.framework }}
         env:
-            RUN_CONSUL_ENTERPRISE_TESTS: $RUN_CONSUL_ENTERPRISE_TESTS
+            RUN_CONSUL_ENTERPRISE_TESTS: ${{ RUN_CONSUL_ENTERPRISE_TESTS }}
       - name: Upload Consul logs
         if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           ./Consul.Test/consul agent -dev -config-file Consul.Test/test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &
           dotnet test Consul.Test --configuration=Release --logger "GitHubActions;report-warnings=false" --no-build -v=Normal --framework=${{ matrix.framework }}
         env:
-            RUN_CONSUL_ENTERPRISE_TESTS: ${{ $RUN_CONSUL_ENTERPRISE_TESTS }}
+            RUN_CONSUL_ENTERPRISE_TESTS: ${{env.RUN_CONSUL_ENTERPRISE_TESTS }}
       - name: Upload Consul logs
         if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,10 @@ jobs:
         with:
           dotnet-version: 7.0.x
       - name: Setup Consul Enterprise URL
-        if: ${{ !github.event.repository.fork}}
+        # Consul enterprise until version 1.10.0 can be run even without a valid license,
+        # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
+        # This is necessary until a valid license is configured in the repository settings.
+        if: ${{ !github.event.repository.fork}} && !startsWith(github.ref, '1.1')
         run: |
           echo "ENTERPRISE=1" >> $GITHUB_ENV
       - name: Download Consul

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,19 +82,11 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7.0.x
-      - name: Condition1
-        if: ${{ !github.event.repository.fork}} && ${{ !startsWith(matrix.consul, '1.1') }}
-        run: |
-          echo "ENTERPRISE1=1"
-      - name: Condition2
-        if: ${{ !github.event.repository.fork && !startsWith(matrix.consul, '1.1') }}
-        run: |
-          echo "ENTERPRISE2=1"
       - name: Setup Consul Enterprise URL
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary until a valid license is configured in the repository settings.
-        if: ${{ !github.event.repository.fork}} && !startsWith(matrix.consul, '1.1')
+        if: ${{ !github.event.repository.fork && !startsWith(matrix.consul, '1.1') }}
         run: |
           echo "ENTERPRISE=1" >> $GITHUB_ENV
           echo "ENTERPRISE=1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           dotnet-version: 7.0.x
       - name: Setup Consul Enterprise URL
-        if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/master' }}
+        if: ${{ !github.event.repository.fork}}
         run: |
           echo "ENTERPRISE=1" >> $GITHUB_ENV
       - name: Download Consul

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,6 @@ jobs:
         if: ${{ !github.event.repository.fork && !startsWith(matrix.consul, '1.1') }}
         run: |
           echo "ENTERPRISE=1" >> $GITHUB_ENV
-          echo "ENTERPRISE=1"
       - name: Download Consul
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         shell: bash
         run: |
           ./Consul.Test/consul agent -dev -config-file Consul.Test/test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &
-          dotnet test Consul.Test --configuration=Release --logger "GitHubActions;report-warnings=false" --no-build -v=Normal --framework=${{ matrix.framework }} -e RUN_CONSUL_ENTERPRISE_TESTS=1
+          dotnet test Consul.Test --configuration=Release --logger "GitHubActions;report-warnings=false" --no-build -v=Normal --framework=${{ matrix.framework }}
       - name: Upload Consul logs
         if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,14 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7.0.x
+      - name: Condition1
+        if: ${{ !github.event.repository.fork}} && ${{ !startsWith(matrix.consul, '1.1') }}
+        run: |
+          echo "ENTERPRISE1=1"
+      - name: Condition2
+        if: ${{ !github.event.repository.fork && !startsWith(matrix.consul, '1.1') }}
+        run: |
+          echo "ENTERPRISE2=1"
       - name: Setup Consul Enterprise URL
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,13 +88,13 @@ jobs:
         # This is necessary until a valid license is configured in the repository settings.
         if: ${{ !github.event.repository.fork && !startsWith(matrix.consul, '1.1') }}
         run: |
-          echo "ENTERPRISE=1" >> $GITHUB_ENV
+          echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
       - name: Download Consul
         shell: bash
         run: |
           cd Consul.Test
           SYSTEM=$(uname | sed 's/MINGW.*/windows/' | tr A-Z a-z)
-          if [[ $ENTERPRISE == 1 ]]
+          if [[ $RUN_CONSUL_ENTERPRISE_TESTS == 1 ]]
           then
             curl -sSL https://releases.hashicorp.com/consul/${{ matrix.consul }}+ent/consul_${{ matrix.consul }}+ent_${SYSTEM}_amd64.zip -o consul.zip
           else 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary until a valid license is configured in the repository settings.
-        if: ${{ !github.event.repository.fork}} && !startsWith(github.ref, '1.1')
+        if: ${{ !github.event.repository.fork}} && !startsWith(${{ matrix.consul }}, '1.1')
         run: |
           echo "ENTERPRISE=1" >> $GITHUB_ENV
       - name: Download Consul

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           ./Consul.Test/consul agent -dev -config-file Consul.Test/test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &
           dotnet test Consul.Test --configuration=Release --logger "GitHubActions;report-warnings=false" --no-build -v=Normal --framework=${{ matrix.framework }}
         env:
-            RUN_CONSUL_ENTERPRISE_TESTS: ${{ RUN_CONSUL_ENTERPRISE_TESTS }}
+            RUN_CONSUL_ENTERPRISE_TESTS: ${{ $RUN_CONSUL_ENTERPRISE_TESTS }}
       - name: Upload Consul logs
         if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,10 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary until a valid license is configured in the repository settings.
-        if: ${{ !github.event.repository.fork}} && !startsWith(${{ matrix.consul }}, '1.1')
+        if: ${{ !github.event.repository.fork}} && !startsWith(matrix.consul, '1.1')
         run: |
           echo "ENTERPRISE=1" >> $GITHUB_ENV
+          echo "ENTERPRISE=1"
       - name: Download Consul
         shell: bash
         run: |

--- a/Consul.Test/ACLTest.cs
+++ b/Consul.Test/ACLTest.cs
@@ -23,19 +23,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Versioning;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Consul.Test
 {
     public class ACLTest : BaseFixture
     {
-        private readonly ITestOutputHelper _output;
-
-        public ACLTest(ITestOutputHelper output)
-        {
-            this._output = output;
-        }
-
         async Task SkipIfAclNotSupportedAsync()
         {
             var cutOffVersion = SemanticVersion.Parse("1.11.0");

--- a/Consul.Test/ACLTest.cs
+++ b/Consul.Test/ACLTest.cs
@@ -18,7 +18,6 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Versioning;
@@ -28,10 +27,9 @@ namespace Consul.Test
 {
     public class ACLTest : BaseFixture
     {
-        async Task SkipIfAclNotSupportedAsync()
+        void SkipIfAclNotSupported()
         {
             var cutOffVersion = SemanticVersion.Parse("1.11.0");
-            QueryResult<Dictionary<string, Dictionary<string, dynamic>>> info = await _client.Agent.Self();
             Skip.If(AgentVersion >= cutOffVersion, $"Current version is {AgentVersion}, but the legacy ACL system was removed in Consul {cutOffVersion}");
         }
 
@@ -39,7 +37,7 @@ namespace Consul.Test
         public async Task ACL_CreateDestroyLegacyToken()
         {
             Skip.If(string.IsNullOrEmpty(TestHelper.MasterToken));
-            await SkipIfAclNotSupportedAsync();
+            SkipIfAclNotSupported();
 
 #pragma warning disable CS0618 // Type or member is obsolete
             var aclEntry = new ACLEntry
@@ -70,7 +68,7 @@ namespace Consul.Test
         public async Task ACL_CreateCloneUpdateDestroyLegacyToken()
         {
             Skip.If(string.IsNullOrEmpty(TestHelper.MasterToken));
-            await SkipIfAclNotSupportedAsync();
+            SkipIfAclNotSupported();
 
 #pragma warning disable CS0618 // Type or member is obsolete
             var newAclEntry = new ACLEntry
@@ -113,7 +111,7 @@ namespace Consul.Test
         public async Task ACL_GetLegacyTokenInfo()
         {
             Skip.If(string.IsNullOrEmpty(TestHelper.MasterToken));
-            await SkipIfAclNotSupportedAsync();
+            SkipIfAclNotSupported();
 
 #pragma warning disable CS0618 // Type or member is obsolete
             var aclEntry = await _client.ACL.Info(TestHelper.MasterToken);
@@ -129,7 +127,7 @@ namespace Consul.Test
         public async Task ACL_ListLegacyTokens()
         {
             Skip.If(string.IsNullOrEmpty(TestHelper.MasterToken));
-            await SkipIfAclNotSupportedAsync();
+            SkipIfAclNotSupported();
 
 #pragma warning disable CS0618 // Type or member is obsolete
             var aclList = await _client.ACL.List();
@@ -144,7 +142,7 @@ namespace Consul.Test
         public async Task ACL_TranslateRule()
         {
             Skip.If(string.IsNullOrEmpty(TestHelper.MasterToken));
-            await SkipIfAclNotSupportedAsync();
+            SkipIfAclNotSupported();
 
             var legacyRule = "agent \"\" {\n policy = \"read\"\n}";
             var newRule = "agent_prefix \"\" {\n  policy = \"read\"\n}";
@@ -160,7 +158,7 @@ namespace Consul.Test
         public async Task ACL_CreateTranslateLegacyTokenRuleDestroy()
         {
             Skip.If(string.IsNullOrEmpty(TestHelper.MasterToken));
-            await SkipIfAclNotSupportedAsync();
+            SkipIfAclNotSupported();
 
             var uniqueTokenName = "API Test " + DateTime.Now.ToLongTimeString();
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/Consul.Test/ACLTest.cs
+++ b/Consul.Test/ACLTest.cs
@@ -18,18 +18,29 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Consul.Test
 {
     public class ACLTest : BaseFixture
     {
+        private readonly ITestOutputHelper _output;
+
+        public ACLTest(ITestOutputHelper output)
+        {
+            this._output = output;
+        }
+
         async Task SkipIfAclNotSupportedAsync()
         {
-            var info = await _client.Agent.Self();
-            var version = new Version(info.Response["Config"]["Version"]);
+            QueryResult<Dictionary<string, Dictionary<string, dynamic>>> info = await _client.Agent.Self();
+            var versionString = info.Response["Config"]["Version"];
+            _output.WriteLine($"Version='{versionString}'");
+            var version = new Version(versionString);
             Skip.If(version >= new Version("1.11.0"), "Legacy ACL system was removed in Consul 1.11.");
         }
 

--- a/Consul.Test/ACLTest.cs
+++ b/Consul.Test/ACLTest.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NuGet.Versioning;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -37,11 +38,9 @@ namespace Consul.Test
 
         async Task SkipIfAclNotSupportedAsync()
         {
+            var cutOffVersion = SemanticVersion.Parse("1.11.0");
             QueryResult<Dictionary<string, Dictionary<string, dynamic>>> info = await _client.Agent.Self();
-            var versionString = info.Response["Config"]["Version"];
-            _output.WriteLine($"Version='{versionString}'");
-            var version = new Version(versionString);
-            Skip.If(version >= new Version("1.11.0"), "Legacy ACL system was removed in Consul 1.11.");
+            Skip.If(AgentVersion >= cutOffVersion, $"Current version is {AgentVersion}, but the legacy ACL system was removed in Consul {cutOffVersion}");
         }
 
         [SkippableFact]

--- a/Consul.Test/BaseFixture.cs
+++ b/Consul.Test/BaseFixture.cs
@@ -22,7 +22,7 @@ namespace Consul.Test
                 c.Address = TestHelper.HttpUri;
             });
 
-            var timeout = TimeSpan.FromSeconds(60);
+            var timeout = TimeSpan.FromSeconds(15);
             var cancelToken = new CancellationTokenSource(timeout).Token;
             Exception exception = null;
             var firstIteration = true;

--- a/Consul.Test/BaseFixture.cs
+++ b/Consul.Test/BaseFixture.cs
@@ -22,7 +22,7 @@ namespace Consul.Test
                 c.Address = TestHelper.HttpUri;
             });
 
-            var timeout = TimeSpan.FromSeconds(15);
+            var timeout = TimeSpan.FromSeconds(60);
             var cancelToken = new CancellationTokenSource(timeout).Token;
             Exception exception = null;
             var firstIteration = true;

--- a/Consul.Test/BaseFixture.cs
+++ b/Consul.Test/BaseFixture.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Versioning;
 using Xunit;
 
 namespace Consul.Test
@@ -11,6 +12,7 @@ namespace Consul.Test
     public class BaseFixture : IAsyncLifetime
     {
         protected ConsulClient _client;
+        protected static SemanticVersion AgentVersion;
 
         private static readonly Lazy<Task> Ready = new Lazy<Task>(async () =>
         {
@@ -58,6 +60,9 @@ namespace Consul.Test
                         continue;
 
                     await client.Session.Destroy(sessionRequest.Response);
+
+                    var info = await client.Agent.Self();
+                    AgentVersion = SemanticVersion.Parse(info.Response["Config"]["Version"]);
                     break;
                 }
                 catch (OperationCanceledException)

--- a/Consul.Test/Consul.Test.csproj
+++ b/Consul.Test/Consul.Test.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
+    <PackageReference Include="NuGet.Versioning" Version="6.6.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">

--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -86,7 +86,8 @@ namespace Consul.Test
         [EnterpriseOnlyFact]
         public async Task Operator_GetLicense()
         {
-            var license = await _client.Operator.GetConsulLicense();
+            var queryResult = await _client.Operator.GetConsulLicense();
+            Assert.NotNull(queryResult.Response);
         }
     }
 }


### PR DESCRIPTION
This PR:
1. Fixes version parsing by using a class that properly understands semantic versioning (e.g. version `1.6.10+ent`)
2. We run Enterprise tests on all branches. 
3. We don't have the license environment variable set yet, but it turns out that older versions of Consul can be run anyway.
