### PR TITLE
Enterprise tests running on a PR from fork 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is still necessary although a valid license has been configured in the repository settings
         # because the license secret is unavailable when the pull request is created from a fork.
-        if: ${{ env.CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) }}
+        if: ${{ env.CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1') }}
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,9 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        consul: [1.6.10, 1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.8, 1.15.4, 1.16.0]
-        framework: [net461, net5.0, net6.0, net7.0]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        consul: [1.6.10, 1.16.0]
+        framework: [net7.0]
+        os: [ubuntu-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -86,7 +86,7 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
-        if: env.CONSUL_LICENSE != ''
+        if: ${{ !github.event.repository.fork && (env.CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) }}
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,8 @@ jobs:
       - name: Setup Consul Enterprise URL
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
-        # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
+        # This is still necessary although a valid license has been configured in the repository settings
+        # because the license secret is unavailable when the pull request is created from a fork.
         if: ${{ !github.event.repository.fork && (env.CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) }}
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
-        if: [[ !github.event.repository.fork && (${CONSUL_LICENSE} != '' || !startsWith(matrix.consul, '1.1')) ]]
+        if: [[ !github.event.repository.fork && ($CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) ]]
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,9 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        consul: [1.6.10, 1.16.0]
-        framework: [net7.0]
-        os: [ubuntu-latest]
+        consul: [1.6.10, 1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.8, 1.15.4, 1.16.0]
+        framework: [net461, net5.0, net6.0, net7.0]
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -107,7 +107,7 @@ jobs:
           rm consul.zip
       - name: Build
         run: dotnet build Consul.Test --configuration=Release --framework=${{ matrix.framework }}
-      - name: Run tests (Enterprise=${{env.RUN_CONSUL_ENTERPRISE_TESTS}})
+      - name: Run tests
         shell: bash
         run: |
           ./Consul.Test/consul agent -dev -config-file Consul.Test/test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &
@@ -192,4 +192,3 @@ jobs:
           path: dist
       - name: Publish to NuGet
         run: dotnet nuget push "dist/Consul.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
-        if: env.CONSUL_LICENSE == ''
+        if: env.CONSUL_LICENSE != ''
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,3 +187,4 @@ jobs:
           path: dist
       - name: Publish to NuGet
         run: dotnet nuget push "dist/Consul.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           rm consul.zip
       - name: Build
         run: dotnet build Consul.Test --configuration=Release --framework=${{ matrix.framework }}
-      - name: Run tests ${{ env.RUN_CONSUL_ENTERPRISE_TESTS }}
+      - name: Run tests ${{env.RUN_CONSUL_ENTERPRISE_TESTS}}
         shell: bash
         run: |
           ./Consul.Test/consul agent -dev -config-file Consul.Test/test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
-        if: ${{ !github.event.repository.fork && (${CONSUL_LICENSE} != '' || !startsWith(matrix.consul, '1.1')) }}
+        if: [[ !github.event.repository.fork && (${CONSUL_LICENSE} != '' || !startsWith(matrix.consul, '1.1')) ]]
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
-        if: [[ $CONSUL_LICENSE != '' ]]
+        if: [[ $CONSUL_LICENSE == '' ]]
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
-        if: ${{ !github.event.repository.fork && (secrets.CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) }}
+        if: ${{ !github.event.repository.fork && ($secrets.CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) }}
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
       - name: Download Consul

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
-        if: $CONSUL_LICENSE == ''
+        if: env.CONSUL_LICENSE == ''
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           rm consul.zip
       - name: Build
         run: dotnet build Consul.Test --configuration=Release --framework=${{ matrix.framework }}
-      - name: Run tests
+      - name: Run tests {{$RUN_CONSUL_ENTERPRISE_TESTS}}
         shell: bash
         run: |
           ./Consul.Test/consul agent -dev -config-file Consul.Test/test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,11 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
-        if: ${{ !github.event.repository.fork && ($secrets.CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) }}
+        if: ${{ !github.event.repository.fork && ($CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) }}
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
+        env:
+            CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
       - name: Download Consul
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is still necessary although a valid license has been configured in the repository settings
         # because the license secret is unavailable when the pull request is created from a fork.
-        if: ${{ !github.event.repository.fork && (env.CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) }}
+        if: ${{ env.CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) }}
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
-        if: ${{ !github.event.repository.fork && ($CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) }}
+        if: ${{ !github.event.repository.fork && (${CONSUL_LICENSE} != '' || !startsWith(matrix.consul, '1.1')) }}
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           rm consul.zip
       - name: Build
         run: dotnet build Consul.Test --configuration=Release --framework=${{ matrix.framework }}
-      - name: Run tests ${{env.RUN_CONSUL_ENTERPRISE_TESTS}}
+      - name: Run tests (Enterprise=${{env.RUN_CONSUL_ENTERPRISE_TESTS}})
         shell: bash
         run: |
           ./Consul.Test/consul agent -dev -config-file Consul.Test/test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           rm consul.zip
       - name: Build
         run: dotnet build Consul.Test --configuration=Release --framework=${{ matrix.framework }}
-      - name: Run tests (Enterprise= ${{ env.RUN_CONSUL_ENTERPRISE_TESTS }} )
+      - name: Run tests ${{ env.RUN_CONSUL_ENTERPRISE_TESTS }}
         shell: bash
         run: |
           ./Consul.Test/consul agent -dev -config-file Consul.Test/test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
-        if: [[ $CONSUL_LICENSE == '' ]]
+        if: $CONSUL_LICENSE == ''
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,10 @@ jobs:
         with:
           dotnet-version: 7.0.x
       - name: Setup Consul Enterprise URL
-        if: ${{ !github.event.repository.fork }}
+        # Consul enterprise until version 1.10.0 can be run even without a valid license,
+        # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
+        # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
+        if: ${{ !github.event.repository.fork && (secrets.CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) }}
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
       - name: Download Consul

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
         # This is necessary because valid license is configured in the repository settings but it is not available for pull requests from a fork.
-        if: [[ !github.event.repository.fork && ($CONSUL_LICENSE != '' || !startsWith(matrix.consul, '1.1')) ]]
+        if: [[ $CONSUL_LICENSE != '' ]]
         run: |
           echo "RUN_CONSUL_ENTERPRISE_TESTS=1" >> $GITHUB_ENV
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           rm consul.zip
       - name: Build
         run: dotnet build Consul.Test --configuration=Release --framework=${{ matrix.framework }}
-      - name: Run tests {{$RUN_CONSUL_ENTERPRISE_TESTS}}
+      - name: Run tests (Enterprise= ${{ env.RUN_CONSUL_ENTERPRISE_TESTS }} )
         shell: bash
         run: |
           ./Consul.Test/consul agent -dev -config-file Consul.Test/test_config.json -log-file consul.log >consul-stdout.log 2>consul-stderr.log &


### PR DESCRIPTION
Fixes problem with the missing consul license secret, when the PR is created from a fork.