### PR TITLE
refactor/perf: apply lint suggestions

### DIFF
--- a/Consul/ACL.cs
+++ b/Consul/ACL.cs
@@ -204,7 +204,7 @@ namespace Consul
         /// <param name="acl">The ACL entry to create</param>
         /// <returns>A write result containing the newly created ACL token</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public Task<WriteResult<string>> Create(ACLEntry acl, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<string>> Create(ACLEntry acl, CancellationToken ct = default)
         {
             return Create(acl, WriteOptions.Default, ct);
         }
@@ -216,7 +216,7 @@ namespace Consul
         /// <param name="q">Customized write options</param>
         /// <returns>A write result containing the newly created ACL token</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public async Task<WriteResult<string>> Create(ACLEntry acl, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<string>> Create(ACLEntry acl, WriteOptions q, CancellationToken ct = default)
         {
             var res = await _client.Put<ACLEntry, ACLCreationResult>("/v1/acl/create", acl, q).Execute(ct).ConfigureAwait(false);
             return new WriteResult<string>(res, res.Response.ID);
@@ -228,7 +228,7 @@ namespace Consul
         /// <param name="acl">The ACL entry to update</param>
         /// <returns>An empty write result</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public Task<WriteResult> Update(ACLEntry acl, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> Update(ACLEntry acl, CancellationToken ct = default)
         {
             return Update(acl, WriteOptions.Default, ct);
         }
@@ -240,7 +240,7 @@ namespace Consul
         /// <param name="q">Customized write options</param>
         /// <returns>An empty write result</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public Task<WriteResult> Update(ACLEntry acl, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> Update(ACLEntry acl, WriteOptions q, CancellationToken ct = default)
         {
             return _client.Put("/v1/acl/update", acl, q).Execute(ct);
         }
@@ -251,7 +251,7 @@ namespace Consul
         /// <param name="id">The ACL ID to destroy</param>
         /// <returns>An empty write result</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public Task<WriteResult<bool>> Destroy(string id, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Destroy(string id, CancellationToken ct = default)
         {
             return Destroy(id, WriteOptions.Default, ct);
         }
@@ -263,7 +263,7 @@ namespace Consul
         /// <param name="q">Customized write options</param>
         /// <returns>An empty write result</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public Task<WriteResult<bool>> Destroy(string id, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Destroy(string id, WriteOptions q, CancellationToken ct = default)
         {
             return _client.PutReturning<bool>(string.Format("/v1/acl/destroy/{0}", id), q).Execute(ct);
         }
@@ -274,7 +274,7 @@ namespace Consul
         /// <param name="id">The ACL ID to clone</param>
         /// <returns>A write result containing the newly created ACL token</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public Task<WriteResult<string>> Clone(string id, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<string>> Clone(string id, CancellationToken ct = default)
         {
             return Clone(id, WriteOptions.Default, ct);
         }
@@ -286,7 +286,7 @@ namespace Consul
         /// <param name="q">Customized write options</param>
         /// <returns>A write result containing the newly created ACL token</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public async Task<WriteResult<string>> Clone(string id, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<string>> Clone(string id, WriteOptions q, CancellationToken ct = default)
         {
             var res = await _client.PutReturning<ACLCreationResult>(string.Format("/v1/acl/clone/{0}", id), q).Execute(ct).ConfigureAwait(false);
             return new WriteResult<string>(res, res.Response.ID);
@@ -298,7 +298,7 @@ namespace Consul
         /// <param name="id">The ACL ID to request information about</param>
         /// <returns>A query result containing the ACL entry matching the provided ID, or a query result with a null response if no token matched the provided ID</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public Task<QueryResult<ACLEntry>> Info(string id, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<ACLEntry>> Info(string id, CancellationToken ct = default)
         {
             return Info(id, QueryOptions.Default, ct);
         }
@@ -311,7 +311,7 @@ namespace Consul
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the ACL entry matching the provided ID, or a query result with a null response if no token matched the provided ID</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public async Task<QueryResult<ACLEntry>> Info(string id, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<QueryResult<ACLEntry>> Info(string id, QueryOptions q, CancellationToken ct = default)
         {
             var res = await _client.Get<ACLEntry[]>(string.Format("/v1/acl/info/{0}", id), q).Execute(ct).ConfigureAwait(false);
             return new QueryResult<ACLEntry>(res, res.Response != null && res.Response.Length > 0 ? res.Response[0] : null);
@@ -322,7 +322,7 @@ namespace Consul
         /// </summary>
         /// <returns>A write result containing the list of all ACLs</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public Task<QueryResult<ACLEntry[]>> List(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<ACLEntry[]>> List(CancellationToken ct = default)
         {
             return List(QueryOptions.Default, ct);
         }
@@ -334,7 +334,7 @@ namespace Consul
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the list of all ACLs</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public Task<QueryResult<ACLEntry[]>> List(QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<ACLEntry[]>> List(QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<ACLEntry[]>("/v1/acl/list", q).Execute(ct);
         }
@@ -346,7 +346,7 @@ namespace Consul
         /// <param name="ct">>Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A string containing the translated rule(s)</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public Task<WriteResult<string>> TranslateRules(string rules, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<string>> TranslateRules(string rules, CancellationToken ct = default)
         {
             return TranslateRules(rules, WriteOptions.Default, ct);
         }
@@ -359,7 +359,7 @@ namespace Consul
         /// <param name="ct">>Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A string containing the translated rule(s)</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public async Task<WriteResult<string>> TranslateRules(string rules, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<string>> TranslateRules(string rules, WriteOptions q, CancellationToken ct = default)
         {
 
             var res = await _client.Post($"/v1/acl/rules/translate", rules, q).Execute(ct).ConfigureAwait(false);
@@ -373,7 +373,7 @@ namespace Consul
         /// <param name="ct">>Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A string containing the translated rule(s)</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public Task<QueryResult<string>> TranslateLegacyTokenRules(string id, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<string>> TranslateLegacyTokenRules(string id, CancellationToken ct = default)
         {
             return TranslateLegacyTokenRules(id, QueryOptions.Default, ct);
         }
@@ -386,7 +386,7 @@ namespace Consul
         /// <param name="ct">>Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A string containing the translated rule(s)</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        public async Task<QueryResult<string>> TranslateLegacyTokenRules(string id, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<QueryResult<string>> TranslateLegacyTokenRules(string id, QueryOptions q, CancellationToken ct = default)
         {
             var res = await _client.Get($"/v1/acl/rules/translate/{id}", q).Execute(ct).ConfigureAwait(false);
             return new QueryResult<string>(res, res.Response);

--- a/Consul/ACLReplication.cs
+++ b/Consul/ACLReplication.cs
@@ -91,7 +91,7 @@ namespace Consul
         /// </summary>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result with details of the ACL Replication system in Consul</returns>
-        public Task<QueryResult<ACLReplicationEntry>> Status(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<ACLReplicationEntry>> Status(CancellationToken ct = default)
         {
             return Status(QueryOptions.Default, ct);
         }
@@ -102,7 +102,7 @@ namespace Consul
         /// <param name="queryOptions">Any query options for the request</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result with details of the ACL Replication system in Consul</returns>
-        public async Task<QueryResult<ACLReplicationEntry>> Status(QueryOptions queryOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<QueryResult<ACLReplicationEntry>> Status(QueryOptions queryOptions, CancellationToken ct = default)
         {
             var res = await _client.Get<ACLReplicationEntry>("/v1/acl/replication", queryOptions).Execute(ct).ConfigureAwait(false);
             return new QueryResult<ACLReplicationEntry>(res, res.Response);

--- a/Consul/AuthMethod.cs
+++ b/Consul/AuthMethod.cs
@@ -91,7 +91,7 @@ namespace Consul
         /// <param name="authMethod">The new ACL AuthMethod</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL AuthMethod</returns>
-        public Task<WriteResult<AuthMethodEntry>> Create(AuthMethodEntry authMethod, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<AuthMethodEntry>> Create(AuthMethodEntry authMethod, CancellationToken ct = default)
         {
             return Create(authMethod, WriteOptions.Default, ct);
         }
@@ -103,7 +103,7 @@ namespace Consul
         /// <param name="writeOptions">Customized write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL AuthMethod</returns>
-        public async Task<WriteResult<AuthMethodEntry>> Create(AuthMethodEntry authMethod, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<AuthMethodEntry>> Create(AuthMethodEntry authMethod, WriteOptions writeOptions, CancellationToken ct = default)
         {
             var res = await _client.Put<AuthMethodEntry, AuthMethodActionResult>("/v1/acl/auth-method", authMethod, writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<AuthMethodEntry>(res, res.Response);
@@ -115,7 +115,7 @@ namespace Consul
         /// <param name="authMethod">The modified ACL AuthMethod</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the updated ACL AuthMethod</returns>
-        public Task<WriteResult<AuthMethodEntry>> Update(AuthMethodEntry authMethod, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<AuthMethodEntry>> Update(AuthMethodEntry authMethod, CancellationToken ct = default)
         {
             return Update(authMethod, WriteOptions.Default, ct);
         }
@@ -127,7 +127,7 @@ namespace Consul
         /// <param name="writeOptions">Customized write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the updated ACL AuthMethod</returns>
-        public async Task<WriteResult<AuthMethodEntry>> Update(AuthMethodEntry authMethod, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<AuthMethodEntry>> Update(AuthMethodEntry authMethod, WriteOptions writeOptions, CancellationToken ct = default)
         {
             var res = await _client.Put<AuthMethodEntry, AuthMethodActionResult>($"/v1/acl/auth-method/{authMethod.Name}", authMethod, writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<AuthMethodEntry>(res, res.Response);
@@ -139,7 +139,7 @@ namespace Consul
         /// <param name="name">The name of the ACL AuthMethod to delete</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>Success (true) or failure (false)</returns>
-        public Task<WriteResult<bool>> Delete(string name, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Delete(string name, CancellationToken ct = default)
         {
             return Delete(name, WriteOptions.Default, ct);
         }
@@ -151,7 +151,7 @@ namespace Consul
         /// <param name="writeOptions">Customized write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>Success (true) or failure (false)</returns>
-        public Task<WriteResult<bool>> Delete(string name, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Delete(string name, WriteOptions writeOptions, CancellationToken ct = default)
         {
             return _client.DeleteReturning<bool>($"/v1/acl/auth-method/{name}", writeOptions).Execute(ct);
         }
@@ -162,7 +162,7 @@ namespace Consul
         /// <param name="name">The Name of the ACL AuthMethod to get</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the requested ACL AuthMethod</returns>
-        public Task<QueryResult<AuthMethodEntry>> Read(string name, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<AuthMethodEntry>> Read(string name, CancellationToken ct = default)
         {
             return Read(name, QueryOptions.Default, ct);
         }
@@ -174,7 +174,7 @@ namespace Consul
         /// <param name="queryOptions">Customized query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the requested ACL AuthMethod</returns>
-        public async Task<QueryResult<AuthMethodEntry>> Read(string name, QueryOptions queryOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<QueryResult<AuthMethodEntry>> Read(string name, QueryOptions queryOptions, CancellationToken ct = default)
         {
             var res = await _client.Get<AuthMethodActionResult>($"/v1/acl/auth-method/{name}", queryOptions).Execute(ct).ConfigureAwait(false);
             return new QueryResult<AuthMethodEntry>(res, res.Response);
@@ -185,7 +185,7 @@ namespace Consul
         /// </summary>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing an array of ACL AuthMethods</returns>
-        public Task<QueryResult<AuthMethodEntry[]>> List(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<AuthMethodEntry[]>> List(CancellationToken ct = default)
         {
             return List(QueryOptions.Default, ct);
         }
@@ -196,7 +196,7 @@ namespace Consul
         /// <param name="queryOptions">Customized query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing an array of ACL AuthMethods</returns>
-        public Task<QueryResult<AuthMethodEntry[]>> List(QueryOptions queryOptions, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<AuthMethodEntry[]>> List(QueryOptions queryOptions, CancellationToken ct = default)
         {
             return _client.Get<AuthMethodEntry[]>("/v1/acl/auth-methods", queryOptions).Execute(ct);
         }
@@ -206,7 +206,7 @@ namespace Consul
         /// </summary>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing an ACL Token for the login</returns>
-        public Task<WriteResult<TokenEntry>> Login(CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<TokenEntry>> Login(CancellationToken ct = default)
         {
             return Login(WriteOptions.Default, ct);
         }
@@ -217,7 +217,7 @@ namespace Consul
         /// <param name="writeOptions"></param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>>A write result containing an ACL Token for the login</returns>
-        public async Task<WriteResult<TokenEntry>> Login(WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<TokenEntry>> Login(WriteOptions writeOptions, CancellationToken ct = default)
         {
             var res = await _client.PutReturning<TokenEntry>("/v1/acl/login", writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<TokenEntry>(res, res.Response);
@@ -228,7 +228,7 @@ namespace Consul
         /// </summary>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result</returns>
-        public Task<WriteResult> Logout(CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> Logout(CancellationToken ct = default)
         {
             return Logout(WriteOptions.Default, ct);
         }
@@ -239,7 +239,7 @@ namespace Consul
         /// <param name="writeOptions"></param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result</returns>
-        public async Task<WriteResult> Logout(WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult> Logout(WriteOptions writeOptions, CancellationToken ct = default)
         {
             return await _client.Post($"/v1/acl/logout", null, writeOptions).Execute(ct).ConfigureAwait(false);
         }

--- a/Consul/Client_PostRequests.cs
+++ b/Consul/Client_PostRequests.cs
@@ -252,7 +252,7 @@ namespace Consul
 
             if (typeof(TIn) == typeof(byte[]))
             {
-                var bodyBytes = (_body as byte[]);
+                var bodyBytes = _body as byte[];
                 if (bodyBytes != null)
                 {
                     content = new ByteArrayContent(bodyBytes);

--- a/Consul/Client_Request.cs
+++ b/Consul/Client_Request.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Text;
 using Newtonsoft.Json;
 
 namespace Consul
@@ -118,9 +119,6 @@ namespace Consul
             }
         }
 
-        protected static byte[] Serialize(object value)
-        {
-            return System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(value));
-        }
+        protected static byte[] Serialize(object value) => Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(value));
     }
 }

--- a/Consul/Coordinate.cs
+++ b/Consul/Coordinate.cs
@@ -65,7 +65,7 @@ namespace Consul
         /// Datacenters is used to return the coordinates of all the servers in the WAN pool.
         /// </summary>
         /// <returns>A query result containing a map of datacenters, each with a list of coordinates of all the servers in the WAN pool</returns>
-        public Task<QueryResult<CoordinateDatacenterMap[]>> Datacenters(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<CoordinateDatacenterMap[]>> Datacenters(CancellationToken ct = default)
         {
             return _client.Get<CoordinateDatacenterMap[]>(string.Format("/v1/coordinate/datacenters")).Execute(ct);
         }
@@ -74,7 +74,7 @@ namespace Consul
         /// Nodes is used to return the coordinates of all the nodes in the LAN pool.
         /// </summary>
         /// <returns>A query result containing coordinates of all the nodes in the LAN pool</returns>
-        public Task<QueryResult<CoordinateEntry[]>> Nodes(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<CoordinateEntry[]>> Nodes(CancellationToken ct = default)
         {
             return Nodes(QueryOptions.Default, ct);
         }
@@ -84,7 +84,7 @@ namespace Consul
         /// </summary>
         /// <param name="q">Customized query options</param>
         /// <returns>A query result containing coordinates of all the nodes in the LAN pool</returns>
-        public Task<QueryResult<CoordinateEntry[]>> Nodes(QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<CoordinateEntry[]>> Nodes(QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<CoordinateEntry[]>(string.Format("/v1/coordinate/nodes"), q).Execute(ct);
         }

--- a/Consul/Event.cs
+++ b/Consul/Event.cs
@@ -55,7 +55,7 @@ namespace Consul
             _client = c;
         }
 
-        public Task<WriteResult<string>> Fire(UserEvent ue, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<string>> Fire(UserEvent ue, CancellationToken ct = default)
         {
             return Fire(ue, WriteOptions.Default, ct);
         }
@@ -66,7 +66,7 @@ namespace Consul
         /// <param name="ue">A User Event definition</param>
         /// <param name="q">Customized write options</param>
         /// <returns></returns>
-        public async Task<WriteResult<string>> Fire(UserEvent ue, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<string>> Fire(UserEvent ue, WriteOptions q, CancellationToken ct = default)
         {
             var req = _client.Put<byte[], EventCreationResult>(string.Format("/v1/event/fire/{0}", ue.Name), ue.Payload, q);
             if (!string.IsNullOrEmpty(ue.NodeFilter))
@@ -89,7 +89,7 @@ namespace Consul
         /// List is used to get the most recent events an agent has received. This list can be optionally filtered by the name. This endpoint supports quasi-blocking queries. The index is not monotonic, nor does it provide provide LastContact or KnownLeader.
         /// </summary>
         /// <returns>An array of events</returns>
-        public Task<QueryResult<UserEvent[]>> List(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<UserEvent[]>> List(CancellationToken ct = default)
         {
             return List(string.Empty, QueryOptions.Default, ct);
         }
@@ -99,7 +99,7 @@ namespace Consul
         /// </summary>
         /// <param name="name">The name of the event to filter for</param>
         /// <returns>An array of events</returns>
-        public Task<QueryResult<UserEvent[]>> List(string name, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<UserEvent[]>> List(string name, CancellationToken ct = default)
         {
             return List(name, QueryOptions.Default, ct);
         }

--- a/Consul/Health.cs
+++ b/Consul/Health.cs
@@ -189,7 +189,7 @@ namespace Consul
         /// </summary>
         /// <param name="service">The service ID</param>
         /// <returns>A query result containing the health checks matching the provided service ID, or a query result with a null response if no service matched the provided ID</returns>
-        public Task<QueryResult<HealthCheck[]>> Checks(string service, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<HealthCheck[]>> Checks(string service, CancellationToken ct = default)
         {
             return Checks(service, QueryOptions.Default, ct);
         }
@@ -201,7 +201,7 @@ namespace Consul
         /// <param name="q">Customized query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the health checks matching the provided service ID, or a query result with a null response if no service matched the provided ID</returns>
-        public Task<QueryResult<HealthCheck[]>> Checks(string service, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<HealthCheck[]>> Checks(string service, QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<HealthCheck[]>(string.Format("/v1/health/checks/{0}", service), q).Execute(ct);
         }
@@ -211,7 +211,7 @@ namespace Consul
         /// </summary>
         /// <param name="node">The node name</param>
         /// <returns>A query result containing the health checks matching the provided node ID, or a query result with a null response if no node matched the provided ID</returns>
-        public Task<QueryResult<HealthCheck[]>> Node(string node, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<HealthCheck[]>> Node(string node, CancellationToken ct = default)
         {
             return Node(node, QueryOptions.Default, ct);
         }
@@ -223,7 +223,7 @@ namespace Consul
         /// <param name="q">Customized query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the health checks matching the provided node ID, or a query result with a null response if no node matched the provided ID</returns>
-        public Task<QueryResult<HealthCheck[]>> Node(string node, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<HealthCheck[]>> Node(string node, QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<HealthCheck[]>(string.Format("/v1/health/node/{0}", node), q).Execute(ct);
         }
@@ -233,7 +233,7 @@ namespace Consul
         /// </summary>
         /// <param name="service">The service ID</param>
         /// <returns>A query result containing the service members matching the provided service ID, or a query result with a null response if no service members matched the filters provided</returns>
-        public Task<QueryResult<ServiceEntry[]>> Service(string service, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<ServiceEntry[]>> Service(string service, CancellationToken ct = default)
         {
             return Service(service, string.Empty, false, QueryOptions.Default, ct);
         }
@@ -244,7 +244,7 @@ namespace Consul
         /// <param name="service">The service ID</param>
         /// <param name="tag">The service member tag</param>
         /// <returns>A query result containing the service members matching the provided service ID and tag, or a query result with a null response if no service members matched the filters provided</returns>
-        public Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, CancellationToken ct = default)
         {
             return Service(service, tag, false, QueryOptions.Default, ct);
         }
@@ -256,7 +256,7 @@ namespace Consul
         /// <param name="tag">The service member tag</param>
         /// <param name="passingOnly">Only return if the health check is in the Passing state</param>
         /// <returns>A query result containing the service members matching the provided service ID, tag, and health status, or a query result with a null response if no service members matched the filters provided</returns>
-        public Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, CancellationToken ct = default)
         {
             return Service(service, tag, passingOnly, QueryOptions.Default, ct);
         }
@@ -270,7 +270,7 @@ namespace Consul
         /// <param name="q">Customized query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the service members matching the provided service ID, tag, and health status, or a query result with a null response if no service members matched the filters provided</returns>
-        public Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, CancellationToken ct = default)
         {
             return Service(service, tag, passingOnly, q, null, ct);
         }
@@ -285,7 +285,7 @@ namespace Consul
         /// <param name="filter">Specifies the expression used to filter the queries results prior to returning the data</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the service members matching the provided service ID, tag, and health status, or a query result with a null response if no service members matched the filters provided</returns>
-        public Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, Filter filter, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, Filter filter, CancellationToken ct = default)
         {
             var req = _client.Get<ServiceEntry[]>(string.Format("/v1/health/service/{0}", service), q, filter);
             if (!string.IsNullOrEmpty(tag))
@@ -304,7 +304,7 @@ namespace Consul
         /// </summary>
         /// <param name="status">The health status to filter for</param>
         /// <returns>A query result containing a list of health checks in the specified state, or a query result with a null response if no health checks matched the provided state</returns>
-        public Task<QueryResult<HealthCheck[]>> State(HealthStatus status, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<HealthCheck[]>> State(HealthStatus status, CancellationToken ct = default)
         {
             return State(status, QueryOptions.Default, ct);
         }
@@ -316,7 +316,7 @@ namespace Consul
         /// <param name="q">Customized query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing a list of health checks in the specified state, or a query result with a null response if no health checks matched the provided state</returns>
-        public Task<QueryResult<HealthCheck[]>> State(HealthStatus status, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<HealthCheck[]>> State(HealthStatus status, QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<HealthCheck[]>(string.Format("/v1/health/state/{0}", status.Status), q).Execute(ct);
         }

--- a/Consul/Interfaces/IACLEndpoint.cs
+++ b/Consul/Interfaces/IACLEndpoint.cs
@@ -30,36 +30,36 @@ namespace Consul
     public interface IACLEndpoint
     {
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<WriteResult<string>> Clone(string id, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<string>> Clone(string id, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<WriteResult<string>> Clone(string id, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<string>> Clone(string id, WriteOptions q, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<WriteResult<string>> Create(ACLEntry acl, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<string>> Create(ACLEntry acl, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<WriteResult<string>> Create(ACLEntry acl, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<string>> Create(ACLEntry acl, WriteOptions q, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<WriteResult<bool>> Destroy(string id, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<bool>> Destroy(string id, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<WriteResult<bool>> Destroy(string id, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<bool>> Destroy(string id, WriteOptions q, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<QueryResult<ACLEntry>> Info(string id, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<ACLEntry>> Info(string id, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<QueryResult<ACLEntry>> Info(string id, QueryOptions q, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<ACLEntry>> Info(string id, QueryOptions q, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<QueryResult<ACLEntry[]>> List(CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<ACLEntry[]>> List(CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<QueryResult<ACLEntry[]>> List(QueryOptions q, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<ACLEntry[]>> List(QueryOptions q, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<WriteResult> Update(ACLEntry acl, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult> Update(ACLEntry acl, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<WriteResult> Update(ACLEntry acl, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult> Update(ACLEntry acl, WriteOptions q, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<WriteResult<string>> TranslateRules(string rules, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<string>> TranslateRules(string rules, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<WriteResult<string>> TranslateRules(string rules, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<string>> TranslateRules(string rules, WriteOptions q, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<QueryResult<string>> TranslateLegacyTokenRules(string id, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<string>> TranslateLegacyTokenRules(string id, CancellationToken ct = default);
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
-        Task<QueryResult<string>> TranslateLegacyTokenRules(string id, QueryOptions q, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<string>> TranslateLegacyTokenRules(string id, QueryOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IACLReplicationEndpoint.cs
+++ b/Consul/Interfaces/IACLReplicationEndpoint.cs
@@ -26,7 +26,7 @@ namespace Consul
     /// </summary>
     public interface IACLReplicationEndpoint
     {
-        Task<QueryResult<ACLReplicationEntry>> Status(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<ACLReplicationEntry>> Status(QueryOptions q, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<ACLReplicationEntry>> Status(CancellationToken ct = default);
+        Task<QueryResult<ACLReplicationEntry>> Status(QueryOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IAuthMethodEndpoint.cs
+++ b/Consul/Interfaces/IAuthMethodEndpoint.cs
@@ -26,19 +26,19 @@ namespace Consul
     /// </summary>
     public interface IAuthMethodEndpoint
     {
-        Task<WriteResult<AuthMethodEntry>> Create(AuthMethodEntry authMethod, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<AuthMethodEntry>> Create(AuthMethodEntry authMethod, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Delete(string id, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<AuthMethodEntry>> Read(string id, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<AuthMethodEntry>> Read(string id, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<AuthMethodEntry[]>> List(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<AuthMethodEntry[]>> List(QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<TokenEntry>> Login(CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<TokenEntry>> Login(WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> Logout(CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> Logout(WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<AuthMethodEntry>> Update(AuthMethodEntry authMethod, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<AuthMethodEntry>> Update(AuthMethodEntry authMethod, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<AuthMethodEntry>> Create(AuthMethodEntry authMethod, CancellationToken ct = default);
+        Task<WriteResult<AuthMethodEntry>> Create(AuthMethodEntry authMethod, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default);
+        Task<WriteResult<bool>> Delete(string id, WriteOptions q, CancellationToken ct = default);
+        Task<QueryResult<AuthMethodEntry>> Read(string id, CancellationToken ct = default);
+        Task<QueryResult<AuthMethodEntry>> Read(string id, QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<AuthMethodEntry[]>> List(CancellationToken ct = default);
+        Task<QueryResult<AuthMethodEntry[]>> List(QueryOptions q, CancellationToken ct = default);
+        Task<WriteResult<TokenEntry>> Login(CancellationToken ct = default);
+        Task<WriteResult<TokenEntry>> Login(WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult> Logout(CancellationToken ct = default);
+        Task<WriteResult> Logout(WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<AuthMethodEntry>> Update(AuthMethodEntry authMethod, CancellationToken ct = default);
+        Task<WriteResult<AuthMethodEntry>> Update(AuthMethodEntry authMethod, WriteOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IConsulClient.cs
+++ b/Consul/Interfaces/IConsulClient.cs
@@ -34,21 +34,21 @@ namespace Consul
         IPolicyEndpoint Policy { get; }
         IRoleEndpoint Role { get; }
         ITokenEndpoint Token { get; }
-        Task<IDistributedLock> AcquireLock(LockOptions opts, CancellationToken ct = default(CancellationToken));
-        Task<IDistributedLock> AcquireLock(string key, CancellationToken ct = default(CancellationToken));
-        Task<IDistributedSemaphore> AcquireSemaphore(SemaphoreOptions opts, CancellationToken ct = default(CancellationToken));
-        Task<IDistributedSemaphore> AcquireSemaphore(string prefix, int limit, CancellationToken ct = default(CancellationToken));
+        Task<IDistributedLock> AcquireLock(LockOptions opts, CancellationToken ct = default);
+        Task<IDistributedLock> AcquireLock(string key, CancellationToken ct = default);
+        Task<IDistributedSemaphore> AcquireSemaphore(SemaphoreOptions opts, CancellationToken ct = default);
+        Task<IDistributedSemaphore> AcquireSemaphore(string prefix, int limit, CancellationToken ct = default);
         IAgentEndpoint Agent { get; }
         ICatalogEndpoint Catalog { get; }
         IDistributedLock CreateLock(LockOptions opts);
         IDistributedLock CreateLock(string key);
         IEventEndpoint Event { get; }
-        Task ExecuteInSemaphore(SemaphoreOptions opts, Action a, CancellationToken ct = default(CancellationToken));
-        Task ExecuteInSemaphore(string prefix, int limit, Action a, CancellationToken ct = default(CancellationToken));
-        Task ExecuteLocked(LockOptions opts, Action action, CancellationToken ct = default(CancellationToken));
+        Task ExecuteInSemaphore(SemaphoreOptions opts, Action a, CancellationToken ct = default);
+        Task ExecuteInSemaphore(string prefix, int limit, Action a, CancellationToken ct = default);
+        Task ExecuteLocked(LockOptions opts, Action action, CancellationToken ct = default);
         [Obsolete("This method will be removed in a future release. Replace calls with the method signature ExecuteLocked(LockOptions, Action, CancellationToken)")]
         Task ExecuteLocked(LockOptions opts, CancellationToken ct, Action action);
-        Task ExecuteLocked(string key, Action action, CancellationToken ct = default(CancellationToken));
+        Task ExecuteLocked(string key, Action action, CancellationToken ct = default);
         [Obsolete("This method will be removed in a future release. Replace calls with the method signature ExecuteLocked(string, Action, CancellationToken)")]
         Task ExecuteLocked(string key, CancellationToken ct, Action action);
         IHealthEndpoint Health { get; }

--- a/Consul/Interfaces/ICoordinateEndpoint.cs
+++ b/Consul/Interfaces/ICoordinateEndpoint.cs
@@ -27,8 +27,8 @@ namespace Consul
     /// </summary>
     public interface ICoordinateEndpoint
     {
-        Task<QueryResult<CoordinateDatacenterMap[]>> Datacenters(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<CoordinateEntry[]>> Nodes(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<CoordinateEntry[]>> Nodes(QueryOptions q, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<CoordinateDatacenterMap[]>> Datacenters(CancellationToken ct = default);
+        Task<QueryResult<CoordinateEntry[]>> Nodes(CancellationToken ct = default);
+        Task<QueryResult<CoordinateEntry[]>> Nodes(QueryOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IDistributedLock.cs
+++ b/Consul/Interfaces/IDistributedLock.cs
@@ -30,8 +30,8 @@ namespace Consul
     {
         bool IsHeld { get; }
 
-        Task<CancellationToken> Acquire(CancellationToken ct = default(CancellationToken));
-        Task Destroy(CancellationToken ct = default(CancellationToken));
-        Task Release(CancellationToken ct = default(CancellationToken));
+        Task<CancellationToken> Acquire(CancellationToken ct = default);
+        Task Destroy(CancellationToken ct = default);
+        Task Release(CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IDistributedSemaphore.cs
+++ b/Consul/Interfaces/IDistributedSemaphore.cs
@@ -30,8 +30,8 @@ namespace Consul
     {
         bool IsHeld { get; }
 
-        Task<CancellationToken> Acquire(CancellationToken ct = default(CancellationToken));
-        Task Destroy(CancellationToken ct = default(CancellationToken));
-        Task Release(CancellationToken ct = default(CancellationToken));
+        Task<CancellationToken> Acquire(CancellationToken ct = default);
+        Task Destroy(CancellationToken ct = default);
+        Task Release(CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IEventEndpoint.cs
+++ b/Consul/Interfaces/IEventEndpoint.cs
@@ -27,11 +27,11 @@ namespace Consul
     /// </summary>
     public interface IEventEndpoint
     {
-        Task<WriteResult<string>> Fire(UserEvent ue, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<string>> Fire(UserEvent ue, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<string>> Fire(UserEvent ue, CancellationToken ct = default);
+        Task<WriteResult<string>> Fire(UserEvent ue, WriteOptions q, CancellationToken ct = default);
         ulong IDToIndex(string uuid);
-        Task<QueryResult<UserEvent[]>> List(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<UserEvent[]>> List(string name, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<UserEvent[]>> List(string name, QueryOptions q, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<UserEvent[]>> List(CancellationToken ct = default);
+        Task<QueryResult<UserEvent[]>> List(string name, CancellationToken ct = default);
+        Task<QueryResult<UserEvent[]>> List(string name, QueryOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IHealthEndpoint.cs
+++ b/Consul/Interfaces/IHealthEndpoint.cs
@@ -28,16 +28,16 @@ namespace Consul
     /// </summary>
     public interface IHealthEndpoint
     {
-        Task<QueryResult<HealthCheck[]>> Checks(string service, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<HealthCheck[]>> Checks(string service, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<HealthCheck[]>> Node(string node, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<HealthCheck[]>> Node(string node, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<ServiceEntry[]>> Service(string service, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, Filter filter, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<HealthCheck[]>> State(HealthStatus status, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<HealthCheck[]>> State(HealthStatus status, QueryOptions q, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<HealthCheck[]>> Checks(string service, CancellationToken ct = default);
+        Task<QueryResult<HealthCheck[]>> Checks(string service, QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<HealthCheck[]>> Node(string node, CancellationToken ct = default);
+        Task<QueryResult<HealthCheck[]>> Node(string node, QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<ServiceEntry[]>> Service(string service, CancellationToken ct = default);
+        Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, CancellationToken ct = default);
+        Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, CancellationToken ct = default);
+        Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, QueryOptions q, Filter filter, CancellationToken ct = default);
+        Task<QueryResult<HealthCheck[]>> State(HealthStatus status, CancellationToken ct = default);
+        Task<QueryResult<HealthCheck[]>> State(HealthStatus status, QueryOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IKVEndpoint.cs
+++ b/Consul/Interfaces/IKVEndpoint.cs
@@ -28,28 +28,28 @@ namespace Consul
     /// </summary>
     public interface IKVEndpoint
     {
-        Task<WriteResult<bool>> Acquire(KVPair p, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Acquire(KVPair p, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> CAS(KVPair p, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> CAS(KVPair p, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Delete(string key, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Delete(string key, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> DeleteCAS(KVPair p, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> DeleteCAS(KVPair p, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> DeleteTree(string prefix, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> DeleteTree(string prefix, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<KVPair>> Get(string key, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<KVPair>> Get(string key, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<string[]>> Keys(string prefix, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<string[]>> Keys(string prefix, string separator, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<string[]>> Keys(string prefix, string separator, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<KVPair[]>> List(string prefix, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<KVPair[]>> List(string prefix, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Put(KVPair p, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Put(KVPair p, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Release(KVPair p, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Release(KVPair p, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<KVTxnResponse>> Txn(List<KVTxnOp> txn, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<KVTxnResponse>> Txn(List<KVTxnOp> txn, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<bool>> Acquire(KVPair p, CancellationToken ct = default);
+        Task<WriteResult<bool>> Acquire(KVPair p, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<bool>> CAS(KVPair p, CancellationToken ct = default);
+        Task<WriteResult<bool>> CAS(KVPair p, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<bool>> Delete(string key, CancellationToken ct = default);
+        Task<WriteResult<bool>> Delete(string key, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<bool>> DeleteCAS(KVPair p, CancellationToken ct = default);
+        Task<WriteResult<bool>> DeleteCAS(KVPair p, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<bool>> DeleteTree(string prefix, CancellationToken ct = default);
+        Task<WriteResult<bool>> DeleteTree(string prefix, WriteOptions q, CancellationToken ct = default);
+        Task<QueryResult<KVPair>> Get(string key, CancellationToken ct = default);
+        Task<QueryResult<KVPair>> Get(string key, QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<string[]>> Keys(string prefix, CancellationToken ct = default);
+        Task<QueryResult<string[]>> Keys(string prefix, string separator, CancellationToken ct = default);
+        Task<QueryResult<string[]>> Keys(string prefix, string separator, QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<KVPair[]>> List(string prefix, CancellationToken ct = default);
+        Task<QueryResult<KVPair[]>> List(string prefix, QueryOptions q, CancellationToken ct = default);
+        Task<WriteResult<bool>> Put(KVPair p, CancellationToken ct = default);
+        Task<WriteResult<bool>> Put(KVPair p, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<bool>> Release(KVPair p, CancellationToken ct = default);
+        Task<WriteResult<bool>> Release(KVPair p, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<KVTxnResponse>> Txn(List<KVTxnOp> txn, CancellationToken ct = default);
+        Task<WriteResult<KVTxnResponse>> Txn(List<KVTxnOp> txn, WriteOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IOperatorEndpoint.cs
+++ b/Consul/Interfaces/IOperatorEndpoint.cs
@@ -30,18 +30,18 @@ namespace Consul
     /// </summary>
     public interface IOperatorEndpoint
     {
-        Task<QueryResult<RaftConfiguration>> RaftGetConfiguration(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<RaftConfiguration>> RaftGetConfiguration(QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> RaftRemovePeerByAddress(string address, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> RaftRemovePeerByAddress(string address, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> KeyringInstall(string key, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> KeyringInstall(string key, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<KeyringResponse[]>> KeyringList(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<KeyringResponse[]>> KeyringList(QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> KeyringRemove(string key, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> KeyringRemove(string key, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> KeyringUse(string key, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> KeyringUse(string key, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<RaftConfiguration>> RaftGetConfiguration(CancellationToken ct = default);
+        Task<QueryResult<RaftConfiguration>> RaftGetConfiguration(QueryOptions q, CancellationToken ct = default);
+        Task<WriteResult> RaftRemovePeerByAddress(string address, CancellationToken ct = default);
+        Task<WriteResult> RaftRemovePeerByAddress(string address, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult> KeyringInstall(string key, CancellationToken ct = default);
+        Task<WriteResult> KeyringInstall(string key, WriteOptions q, CancellationToken ct = default);
+        Task<QueryResult<KeyringResponse[]>> KeyringList(CancellationToken ct = default);
+        Task<QueryResult<KeyringResponse[]>> KeyringList(QueryOptions q, CancellationToken ct = default);
+        Task<WriteResult> KeyringRemove(string key, CancellationToken ct = default);
+        Task<WriteResult> KeyringRemove(string key, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult> KeyringUse(string key, CancellationToken ct = default);
+        Task<WriteResult> KeyringUse(string key, WriteOptions q, CancellationToken ct = default);
         Task<QueryResult<ConsulLicense>> GetConsulLicense(string datacenter = "", CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IPolicyEndpoint.cs
+++ b/Consul/Interfaces/IPolicyEndpoint.cs
@@ -27,15 +27,15 @@ namespace Consul
     /// </summary>
     public interface IPolicyEndpoint
     {
-        Task<WriteResult<PolicyEntry>> Create(PolicyEntry policy, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<PolicyEntry>> Create(PolicyEntry policy, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Delete(string id, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<PolicyEntry[]>> List(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<PolicyEntry[]>> List(QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<PolicyEntry>> Read(string id, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<PolicyEntry>> Read(string id, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<PolicyEntry>> Update(PolicyEntry policy, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<PolicyEntry>> Update(PolicyEntry policy, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<PolicyEntry>> Create(PolicyEntry policy, CancellationToken ct = default);
+        Task<WriteResult<PolicyEntry>> Create(PolicyEntry policy, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default);
+        Task<WriteResult<bool>> Delete(string id, WriteOptions q, CancellationToken ct = default);
+        Task<QueryResult<PolicyEntry[]>> List(CancellationToken ct = default);
+        Task<QueryResult<PolicyEntry[]>> List(QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<PolicyEntry>> Read(string id, CancellationToken ct = default);
+        Task<QueryResult<PolicyEntry>> Read(string id, QueryOptions q, CancellationToken ct = default);
+        Task<WriteResult<PolicyEntry>> Update(PolicyEntry policy, CancellationToken ct = default);
+        Task<WriteResult<PolicyEntry>> Update(PolicyEntry policy, WriteOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IPreparedQueryEndpoint.cs
+++ b/Consul/Interfaces/IPreparedQueryEndpoint.cs
@@ -28,17 +28,17 @@ namespace Consul
     /// </summary>
     public interface IPreparedQueryEndpoint
     {
-        Task<WriteResult<string>> Create(PreparedQueryDefinition query, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<string>> Create(PreparedQueryDefinition query, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> Update(PreparedQueryDefinition query, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> Update(PreparedQueryDefinition query, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<PreparedQueryDefinition[]>> List(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<PreparedQueryDefinition[]>> List(QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<PreparedQueryDefinition[]>> Get(string queryID, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<PreparedQueryDefinition[]>> Get(string queryID, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> Delete(string queryID, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> Delete(string queryID, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<PreparedQueryExecuteResponse>> Execute(string queryIDOrName, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<PreparedQueryExecuteResponse>> Execute(string queryIDOrName, QueryOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<string>> Create(PreparedQueryDefinition query, CancellationToken ct = default);
+        Task<WriteResult<string>> Create(PreparedQueryDefinition query, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult> Update(PreparedQueryDefinition query, CancellationToken ct = default);
+        Task<WriteResult> Update(PreparedQueryDefinition query, WriteOptions q, CancellationToken ct = default);
+        Task<QueryResult<PreparedQueryDefinition[]>> List(CancellationToken ct = default);
+        Task<QueryResult<PreparedQueryDefinition[]>> List(QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<PreparedQueryDefinition[]>> Get(string queryID, CancellationToken ct = default);
+        Task<QueryResult<PreparedQueryDefinition[]>> Get(string queryID, QueryOptions q, CancellationToken ct = default);
+        Task<WriteResult> Delete(string queryID, CancellationToken ct = default);
+        Task<WriteResult> Delete(string queryID, WriteOptions q, CancellationToken ct = default);
+        Task<QueryResult<PreparedQueryExecuteResponse>> Execute(string queryIDOrName, CancellationToken ct = default);
+        Task<QueryResult<PreparedQueryExecuteResponse>> Execute(string queryIDOrName, QueryOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IRawEndpoint.cs
+++ b/Consul/Interfaces/IRawEndpoint.cs
@@ -27,7 +27,7 @@ namespace Consul
     /// </summary>
     public interface IRawEndpoint
     {
-        Task<QueryResult<dynamic>> Query(string endpoint, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<dynamic>> Write(string endpoint, object obj, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<dynamic>> Query(string endpoint, QueryOptions q, CancellationToken ct = default);
+        Task<WriteResult<dynamic>> Write(string endpoint, object obj, WriteOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IRoleEndpoint.cs
+++ b/Consul/Interfaces/IRoleEndpoint.cs
@@ -27,17 +27,17 @@ namespace Consul
     /// </summary>
     public interface IRoleEndpoint
     {
-        Task<WriteResult<RoleEntry>> Create(RoleEntry role, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<RoleEntry>> Create(RoleEntry role, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Delete(string id, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<RoleEntry[]>> List(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<RoleEntry[]>> List(QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<RoleEntry>> Read(string id, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<RoleEntry>> Read(string id, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<RoleEntry>> ReadByName(string name, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<RoleEntry>> ReadByName(string name, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<RoleEntry>> Update(RoleEntry role, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<RoleEntry>> Update(RoleEntry role, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<RoleEntry>> Create(RoleEntry role, CancellationToken ct = default);
+        Task<WriteResult<RoleEntry>> Create(RoleEntry role, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default);
+        Task<WriteResult<bool>> Delete(string id, WriteOptions q, CancellationToken ct = default);
+        Task<QueryResult<RoleEntry[]>> List(CancellationToken ct = default);
+        Task<QueryResult<RoleEntry[]>> List(QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<RoleEntry>> Read(string id, CancellationToken ct = default);
+        Task<QueryResult<RoleEntry>> Read(string id, QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<RoleEntry>> ReadByName(string name, CancellationToken ct = default);
+        Task<QueryResult<RoleEntry>> ReadByName(string name, QueryOptions q, CancellationToken ct = default);
+        Task<WriteResult<RoleEntry>> Update(RoleEntry role, CancellationToken ct = default);
+        Task<WriteResult<RoleEntry>> Update(RoleEntry role, WriteOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/ISessionEndpoint.cs
+++ b/Consul/Interfaces/ISessionEndpoint.cs
@@ -28,22 +28,22 @@ namespace Consul
     /// </summary>
     public interface ISessionEndpoint
     {
-        Task<WriteResult<string>> Create(CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<string>> Create(SessionEntry se, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<string>> Create(SessionEntry se, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<string>> CreateNoChecks(CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<string>> CreateNoChecks(SessionEntry se, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<string>> CreateNoChecks(SessionEntry se, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Destroy(string id, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Destroy(string id, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<SessionEntry>> Info(string id, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<SessionEntry>> Info(string id, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<SessionEntry[]>> List(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<SessionEntry[]>> List(QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<SessionEntry[]>> Node(string node, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<SessionEntry[]>> Node(string node, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<SessionEntry>> Renew(string id, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<SessionEntry>> Renew(string id, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<string>> Create(CancellationToken ct = default);
+        Task<WriteResult<string>> Create(SessionEntry se, CancellationToken ct = default);
+        Task<WriteResult<string>> Create(SessionEntry se, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<string>> CreateNoChecks(CancellationToken ct = default);
+        Task<WriteResult<string>> CreateNoChecks(SessionEntry se, CancellationToken ct = default);
+        Task<WriteResult<string>> CreateNoChecks(SessionEntry se, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<bool>> Destroy(string id, CancellationToken ct = default);
+        Task<WriteResult<bool>> Destroy(string id, WriteOptions q, CancellationToken ct = default);
+        Task<QueryResult<SessionEntry>> Info(string id, CancellationToken ct = default);
+        Task<QueryResult<SessionEntry>> Info(string id, QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<SessionEntry[]>> List(CancellationToken ct = default);
+        Task<QueryResult<SessionEntry[]>> List(QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<SessionEntry[]>> Node(string node, CancellationToken ct = default);
+        Task<QueryResult<SessionEntry[]>> Node(string node, QueryOptions q, CancellationToken ct = default);
+        Task<WriteResult<SessionEntry>> Renew(string id, CancellationToken ct = default);
+        Task<WriteResult<SessionEntry>> Renew(string id, WriteOptions q, CancellationToken ct = default);
         Task RenewPeriodic(TimeSpan initialTTL, string id, CancellationToken ct);
         Task RenewPeriodic(TimeSpan initialTTL, string id, WriteOptions q, CancellationToken ct);
     }

--- a/Consul/Interfaces/ISnapshotEndpoint.cs
+++ b/Consul/Interfaces/ISnapshotEndpoint.cs
@@ -29,9 +29,9 @@ namespace Consul
     /// </summary>
     public interface ISnapshotEndpoint
     {
-        Task<QueryResult<Stream>> Save(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<Stream>> Save(QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> Restore(Stream s, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult> Restore(Stream s, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<QueryResult<Stream>> Save(CancellationToken ct = default);
+        Task<QueryResult<Stream>> Save(QueryOptions q, CancellationToken ct = default);
+        Task<WriteResult> Restore(Stream s, CancellationToken ct = default);
+        Task<WriteResult> Restore(Stream s, WriteOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/IStatusEndpoint.cs
+++ b/Consul/Interfaces/IStatusEndpoint.cs
@@ -27,7 +27,7 @@ namespace Consul
     /// </summary>
     public interface IStatusEndpoint
     {
-        Task<string> Leader(CancellationToken ct = default(CancellationToken));
-        Task<string[]> Peers(CancellationToken ct = default(CancellationToken));
+        Task<string> Leader(CancellationToken ct = default);
+        Task<string[]> Peers(CancellationToken ct = default);
     }
 }

--- a/Consul/Interfaces/ITokenEndpoint.cs
+++ b/Consul/Interfaces/ITokenEndpoint.cs
@@ -27,19 +27,19 @@ namespace Consul
     /// </summary>
     public interface ITokenEndpoint
     {
-        Task<WriteResult<TokenEntry>> Bootstrap(CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<TokenEntry>> Bootstrap(WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<TokenEntry>> Clone(string id, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<TokenEntry>> Clone(string id, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<TokenEntry>> Create(TokenEntry token, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<TokenEntry>> Create(TokenEntry token, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<bool>> Delete(string id, WriteOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<TokenEntry>> Read(string id, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<TokenEntry>> Read(string id, QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<TokenEntry[]>> List(CancellationToken ct = default(CancellationToken));
-        Task<QueryResult<TokenEntry[]>> List(QueryOptions q, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<TokenEntry>> Update(TokenEntry token, CancellationToken ct = default(CancellationToken));
-        Task<WriteResult<TokenEntry>> Update(TokenEntry token, WriteOptions q, CancellationToken ct = default(CancellationToken));
+        Task<WriteResult<TokenEntry>> Bootstrap(CancellationToken ct = default);
+        Task<WriteResult<TokenEntry>> Bootstrap(WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<TokenEntry>> Clone(string id, CancellationToken ct = default);
+        Task<WriteResult<TokenEntry>> Clone(string id, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<TokenEntry>> Create(TokenEntry token, CancellationToken ct = default);
+        Task<WriteResult<TokenEntry>> Create(TokenEntry token, WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default);
+        Task<WriteResult<bool>> Delete(string id, WriteOptions q, CancellationToken ct = default);
+        Task<QueryResult<TokenEntry>> Read(string id, CancellationToken ct = default);
+        Task<QueryResult<TokenEntry>> Read(string id, QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<TokenEntry[]>> List(CancellationToken ct = default);
+        Task<QueryResult<TokenEntry[]>> List(QueryOptions q, CancellationToken ct = default);
+        Task<WriteResult<TokenEntry>> Update(TokenEntry token, CancellationToken ct = default);
+        Task<WriteResult<TokenEntry>> Update(TokenEntry token, WriteOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/KV.cs
+++ b/Consul/KV.cs
@@ -254,7 +254,7 @@ namespace Consul
         /// </summary>p.Validate();
         /// <param name="p">The key/value pair to store in Consul</param>
         /// <returns>A write result indicating if the acquisition attempt succeeded</returns>
-        public Task<WriteResult<bool>> Acquire(KVPair p, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Acquire(KVPair p, CancellationToken ct = default)
         {
             return Acquire(p, WriteOptions.Default, ct);
         }
@@ -265,7 +265,7 @@ namespace Consul
         /// <param name="p">The key/value pair to store in Consul</param>
         /// <param name="q">Customized write options</param>
         /// <returns>A write result indicating if the acquisition attempt succeeded</returns>
-        public Task<WriteResult<bool>> Acquire(KVPair p, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Acquire(KVPair p, WriteOptions q, CancellationToken ct = default)
         {
             p.Validate();
             var req = _client.Put<byte[], bool>(string.Format("/v1/kv/{0}", p.Key.TrimStart('/')), p.Value, q);
@@ -282,7 +282,7 @@ namespace Consul
         /// </summary>
         /// <param name="p">The key/value pair to store in Consul</param>
         /// <returns>A write result indicating if the write attempt succeeded</returns>
-        public Task<WriteResult<bool>> CAS(KVPair p, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> CAS(KVPair p, CancellationToken ct = default)
         {
             return CAS(p, WriteOptions.Default, ct);
         }
@@ -293,7 +293,7 @@ namespace Consul
         /// <param name="p">The key/value pair to store in Consul</param>
         /// <param name="q">Customized write options</param>
         /// <returns>A write result indicating if the write attempt succeeded</returns>
-        public Task<WriteResult<bool>> CAS(KVPair p, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> CAS(KVPair p, WriteOptions q, CancellationToken ct = default)
         {
             p.Validate();
             var req = _client.Put<byte[], bool>(string.Format("/v1/kv/{0}", p.Key.TrimStart('/')), p.Value, q);
@@ -310,7 +310,7 @@ namespace Consul
         /// </summary>
         /// <param name="key">The key name to delete</param>
         /// <returns>A write result indicating if the delete attempt succeeded</returns>
-        public Task<WriteResult<bool>> Delete(string key, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Delete(string key, CancellationToken ct = default)
         {
             return Delete(key, WriteOptions.Default, ct);
         }
@@ -321,7 +321,7 @@ namespace Consul
         /// <param name="key">The key name to delete</param>
         /// <param name="q">Customized write options</param>
         /// <returns>A write result indicating if the delete attempt succeeded</returns>
-        public Task<WriteResult<bool>> Delete(string key, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Delete(string key, WriteOptions q, CancellationToken ct = default)
         {
             KVPair.ValidatePath(key);
             return _client.DeleteReturning<bool>(string.Format("/v1/kv/{0}", key.TrimStart('/')), q).Execute(ct);
@@ -332,7 +332,7 @@ namespace Consul
         /// </summary>
         /// <param name="p">The key/value pair to delete</param>
         /// <returns>A write result indicating if the delete attempt succeeded</returns>
-        public Task<WriteResult<bool>> DeleteCAS(KVPair p, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> DeleteCAS(KVPair p, CancellationToken ct = default)
         {
             return DeleteCAS(p, WriteOptions.Default, ct);
         }
@@ -343,7 +343,7 @@ namespace Consul
         /// <param name="p">The key/value pair to delete</param>
         /// <param name="q">Customized write options</param>
         /// <returns>A write result indicating if the delete attempt succeeded</returns>
-        public Task<WriteResult<bool>> DeleteCAS(KVPair p, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> DeleteCAS(KVPair p, WriteOptions q, CancellationToken ct = default)
         {
             p.Validate();
             var req = _client.DeleteReturning<bool>(string.Format("/v1/kv/{0}", p.Key.TrimStart('/')), q);
@@ -356,7 +356,7 @@ namespace Consul
         /// </summary>
         /// <param name="prefix">The key prefix to delete from</param>
         /// <returns>A write result indicating if the recursive delete attempt succeeded</returns>
-        public Task<WriteResult<bool>> DeleteTree(string prefix, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> DeleteTree(string prefix, CancellationToken ct = default)
         {
             return DeleteTree(prefix, WriteOptions.Default, ct);
         }
@@ -367,7 +367,7 @@ namespace Consul
         /// <param name="prefix">The key prefix to delete from</param>
         /// <param name="q">Customized write options</param>
         /// <returns>A write result indicating if the recursiv edelete attempt succeeded</returns>
-        public Task<WriteResult<bool>> DeleteTree(string prefix, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> DeleteTree(string prefix, WriteOptions q, CancellationToken ct = default)
         {
             KVPair.ValidatePath(prefix);
             var req = _client.DeleteReturning<bool>(string.Format("/v1/kv/{0}", prefix.TrimStart('/')), q);
@@ -380,7 +380,7 @@ namespace Consul
         /// </summary>
         /// <param name="key">The key name</param>
         /// <returns>A query result containing the requested key/value pair, or a query result with a null response if the key does not exist</returns>
-        public Task<QueryResult<KVPair>> Get(string key, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<KVPair>> Get(string key, CancellationToken ct = default)
         {
             return Get(key, QueryOptions.Default, ct);
         }
@@ -392,7 +392,7 @@ namespace Consul
         /// <param name="q">Customized query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the requested key/value pair, or a query result with a null response if the key does not exist</returns>
-        public async Task<QueryResult<KVPair>> Get(string key, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<QueryResult<KVPair>> Get(string key, QueryOptions q, CancellationToken ct = default)
         {
             var req = _client.Get<KVPair[]>(string.Format("/v1/kv/{0}", key.TrimStart('/')), q);
             var res = await req.Execute(ct).ConfigureAwait(false);
@@ -404,7 +404,7 @@ namespace Consul
         /// </summary>
         /// <param name="prefix">The key prefix to filter on</param>
         /// <returns>A query result containing a list of key names</returns>
-        public Task<QueryResult<string[]>> Keys(string prefix, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<string[]>> Keys(string prefix, CancellationToken ct = default)
         {
             return Keys(prefix, string.Empty, QueryOptions.Default, ct);
         }
@@ -415,7 +415,7 @@ namespace Consul
         /// <param name="prefix">The key prefix to filter on</param>
         /// <param name="separator">The terminating suffix of the filter - e.g. a separator of "/" and a prefix of "/web/" will match "/web/foo" and "/web/foo/" but not "/web/foo/baz"</param>
         /// <returns>A query result containing a list of key names</returns>
-        public Task<QueryResult<string[]>> Keys(string prefix, string separator, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<string[]>> Keys(string prefix, string separator, CancellationToken ct = default)
         {
             return Keys(prefix, separator, QueryOptions.Default, ct);
         }
@@ -428,7 +428,7 @@ namespace Consul
         /// <param name="q">Customized query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing a list of key names</returns>
-        public Task<QueryResult<string[]>> Keys(string prefix, string separator, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<string[]>> Keys(string prefix, string separator, QueryOptions q, CancellationToken ct = default)
         {
             var req = _client.Get<string[]>(string.Format("/v1/kv/{0}", prefix.TrimStart('/')), q);
             req.Params["keys"] = string.Empty;
@@ -444,7 +444,7 @@ namespace Consul
         /// </summary>
         /// <param name="prefix">The prefix to search under. Does not have to be a full path - e.g. a prefix of "ab" will find keys "abcd" and "ab11" but not "acdc"</param>
         /// <returns>A query result containing the keys matching the prefix</returns>
-        public Task<QueryResult<KVPair[]>> List(string prefix, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<KVPair[]>> List(string prefix, CancellationToken ct = default)
         {
             return List(prefix, QueryOptions.Default, ct);
         }
@@ -456,7 +456,7 @@ namespace Consul
         /// <param name="q">Customized query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns></returns>
-        public Task<QueryResult<KVPair[]>> List(string prefix, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<KVPair[]>> List(string prefix, QueryOptions q, CancellationToken ct = default)
         {
             var req = _client.Get<KVPair[]>(string.Format("/v1/kv/{0}", prefix.TrimStart('/')), q);
             req.Params["recurse"] = string.Empty;
@@ -468,7 +468,7 @@ namespace Consul
         /// </summary>
         /// <param name="p">The key/value pair to store in Consul</param>
         /// <returns>A write result indicating if the write attempt succeeded</returns>
-        public Task<WriteResult<bool>> Put(KVPair p, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Put(KVPair p, CancellationToken ct = default)
         {
             return Put(p, WriteOptions.Default, ct);
         }
@@ -479,7 +479,7 @@ namespace Consul
         /// <param name="p">The key/value pair to store in Consul</param>
         /// <param name="q">Customized write options</param>
         /// <returns>A write result indicating if the write attempt succeeded</returns>
-        public Task<WriteResult<bool>> Put(KVPair p, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Put(KVPair p, WriteOptions q, CancellationToken ct = default)
         {
             p.Validate();
             var req = _client.Put<byte[], bool>(string.Format("/v1/kv/{0}", p.Key.TrimStart('/')), p.Value, q);
@@ -495,7 +495,7 @@ namespace Consul
         /// </summary>
         /// <param name="p">The key/value pair to store in Consul</param>
         /// <returns>A write result indicating if the release attempt succeeded</returns>
-        public Task<WriteResult<bool>> Release(KVPair p, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Release(KVPair p, CancellationToken ct = default)
         {
             return Release(p, WriteOptions.Default, ct);
         }
@@ -506,7 +506,7 @@ namespace Consul
         /// <param name="p">The key/value pair to store in Consul</param>
         /// <param name="q">Customized write options</param>
         /// <returns>A write result indicating if the release attempt succeeded</returns>
-        public Task<WriteResult<bool>> Release(KVPair p, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Release(KVPair p, WriteOptions q, CancellationToken ct = default)
         {
             p.Validate();
             var req = _client.Put<object, bool>(string.Format("/v1/kv/{0}", p.Key.TrimStart('/')), null, q);
@@ -551,7 +551,7 @@ namespace Consul
         /// <param name="txn">The constructed transaction</param>
         /// <param name="ct">A CancellationToken to prematurely end the request</param>
         /// <returns>The transaction response</returns>
-        public Task<WriteResult<KVTxnResponse>> Txn(List<KVTxnOp> txn, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<KVTxnResponse>> Txn(List<KVTxnOp> txn, CancellationToken ct = default)
         {
             return Txn(txn, WriteOptions.Default, ct);
         }
@@ -590,7 +590,7 @@ namespace Consul
         /// <param name="q">Customized write options</param>
         /// <param name="ct">A CancellationToken to prematurely end the request</param>
         /// <returns>The transaction response</returns>
-        public async Task<WriteResult<KVTxnResponse>> Txn(List<KVTxnOp> txn, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<KVTxnResponse>> Txn(List<KVTxnOp> txn, WriteOptions q, CancellationToken ct = default)
         {
             var txnOps = new List<TxnOp>(txn.Count);
 

--- a/Consul/Lock.cs
+++ b/Consul/Lock.cs
@@ -382,7 +382,7 @@ namespace Consul
         /// <summary>
         /// Unlock released the lock. It is an error to call this if the lock is not currently held.
         /// </summary>
-        public async Task Release(CancellationToken ct = default(CancellationToken))
+        public async Task Release(CancellationToken ct = default)
         {
             try
             {
@@ -420,7 +420,7 @@ namespace Consul
         /// <summary>
         /// Destroy is used to cleanup the lock entry. It is not necessary to invoke. It will fail if the lock is in use.
         /// </summary>
-        public async Task Destroy(CancellationToken ct = default(CancellationToken))
+        public async Task Destroy(CancellationToken ct = default)
         {
             using (await _mutex.LockAsync().ConfigureAwait(false))
             {
@@ -668,7 +668,7 @@ namespace Consul
         /// <param name="key"></param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        public Task<IDistributedLock> AcquireLock(string key, CancellationToken ct = default(CancellationToken))
+        public Task<IDistributedLock> AcquireLock(string key, CancellationToken ct = default)
         {
             if (string.IsNullOrEmpty(key))
             {
@@ -683,7 +683,7 @@ namespace Consul
         /// <param name="opts"></param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        public async Task<IDistributedLock> AcquireLock(LockOptions opts, CancellationToken ct = default(CancellationToken))
+        public async Task<IDistributedLock> AcquireLock(LockOptions opts, CancellationToken ct = default)
         {
             if (opts == null)
             {
@@ -701,7 +701,7 @@ namespace Consul
         /// <param name="key"></param>
         /// <param name="action"></param>
         /// <returns></returns>
-        public Task ExecuteLocked(string key, Action action, CancellationToken ct = default(CancellationToken))
+        public Task ExecuteLocked(string key, Action action, CancellationToken ct = default)
         {
             if (string.IsNullOrEmpty(key))
             {
@@ -716,7 +716,7 @@ namespace Consul
         /// <param name="opts"></param>
         /// <param name="action"></param>
         /// <returns></returns>
-        public async Task ExecuteLocked(LockOptions opts, Action action, CancellationToken ct = default(CancellationToken))
+        public async Task ExecuteLocked(LockOptions opts, Action action, CancellationToken ct = default)
         {
             if (opts == null)
             {

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -18,7 +18,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -126,7 +125,7 @@ namespace Consul
         /// <summary>
         /// RaftGetConfiguration is used to query the current Raft peer set.
         /// </summary>
-        public Task<QueryResult<RaftConfiguration>> RaftGetConfiguration(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<RaftConfiguration>> RaftGetConfiguration(CancellationToken ct = default)
         {
             return RaftGetConfiguration(QueryOptions.Default, ct);
         }
@@ -134,7 +133,7 @@ namespace Consul
         /// <summary>
         /// RaftGetConfiguration is used to query the current Raft peer set.
         /// </summary>
-        public Task<QueryResult<RaftConfiguration>> RaftGetConfiguration(QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<RaftConfiguration>> RaftGetConfiguration(QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<RaftConfiguration>("/v1/operator/raft/configuration", q).Execute(ct);
         }
@@ -144,7 +143,7 @@ namespace Consul
         /// quorum but no longer known to Serf or the catalog) by address in the form of
         /// "IP:port".
         /// </summary>
-        public Task<WriteResult> RaftRemovePeerByAddress(string address, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> RaftRemovePeerByAddress(string address, CancellationToken ct = default)
         {
             return RaftRemovePeerByAddress(address, WriteOptions.Default, ct);
         }
@@ -154,7 +153,7 @@ namespace Consul
         /// quorum but no longer known to Serf or the catalog) by address in the form of
         /// "IP:port".
         /// </summary>
-        public Task<WriteResult> RaftRemovePeerByAddress(string address, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> RaftRemovePeerByAddress(string address, WriteOptions q, CancellationToken ct = default)
         {
             var req = _client.Delete("/v1/operator/raft/peer", q);
 
@@ -169,7 +168,7 @@ namespace Consul
         /// <summary>
         /// KeyringInstall is used to install a new gossip encryption key into the cluster
         /// </summary>
-        public Task<WriteResult> KeyringInstall(string key, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> KeyringInstall(string key, CancellationToken ct = default)
         {
             return KeyringInstall(key, WriteOptions.Default, ct);
         }
@@ -177,7 +176,7 @@ namespace Consul
         /// <summary>
         /// KeyringInstall is used to install a new gossip encryption key into the cluster
         /// </summary>
-        public Task<WriteResult> KeyringInstall(string key, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> KeyringInstall(string key, WriteOptions q, CancellationToken ct = default)
         {
             return _client.Post("/v1/operator/keyring", new KeyringRequest() { Key = key }, q).Execute(ct);
         }
@@ -185,7 +184,7 @@ namespace Consul
         /// <summary>
         /// KeyringList is used to list the gossip keys installed in the cluster
         /// </summary>
-        public Task<QueryResult<KeyringResponse[]>> KeyringList(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<KeyringResponse[]>> KeyringList(CancellationToken ct = default)
         {
             return KeyringList(QueryOptions.Default, ct);
         }
@@ -193,7 +192,7 @@ namespace Consul
         /// <summary>
         /// KeyringList is used to list the gossip keys installed in the cluster
         /// </summary>
-        public Task<QueryResult<KeyringResponse[]>> KeyringList(QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<KeyringResponse[]>> KeyringList(QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<KeyringResponse[]>("/v1/operator/keyring", q).Execute(ct);
         }
@@ -201,7 +200,7 @@ namespace Consul
         /// <summary>
         /// KeyringRemove is used to remove a gossip encryption key from the cluster
         /// </summary>
-        public Task<WriteResult> KeyringRemove(string key, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> KeyringRemove(string key, CancellationToken ct = default)
         {
             return KeyringRemove(key, WriteOptions.Default, ct);
         }
@@ -209,7 +208,7 @@ namespace Consul
         /// <summary>
         /// KeyringRemove is used to remove a gossip encryption key from the cluster
         /// </summary>
-        public Task<WriteResult> KeyringRemove(string key, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> KeyringRemove(string key, WriteOptions q, CancellationToken ct = default)
         {
             return _client.DeleteAccepting("/v1/operator/keyring", new KeyringRequest() { Key = key }, q).Execute(ct);
         }
@@ -217,7 +216,7 @@ namespace Consul
         /// <summary>
         /// KeyringUse is used to change the active gossip encryption key
         /// </summary>
-        public Task<WriteResult> KeyringUse(string key, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> KeyringUse(string key, CancellationToken ct = default)
         {
             return KeyringUse(key, WriteOptions.Default, ct);
         }
@@ -225,7 +224,7 @@ namespace Consul
         /// <summary>
         /// KeyringUse is used to change the active gossip encryption key
         /// </summary>
-        public Task<WriteResult> KeyringUse(string key, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> KeyringUse(string key, WriteOptions q, CancellationToken ct = default)
         {
             return _client.Put("/v1/operator/keyring", new KeyringRequest() { Key = key }, q).Execute(ct);
         }
@@ -276,9 +275,6 @@ namespace Consul
         /// <summary>
         /// Operator returns a handle to the operator endpoints.
         /// </summary>
-        public IOperatorEndpoint Operator
-        {
-            get { return _operator.Value; }
-        }
+        public IOperatorEndpoint Operator => _operator.Value;
     }
 }

--- a/Consul/Policy.cs
+++ b/Consul/Policy.cs
@@ -57,12 +57,12 @@ namespace Consul
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string[] Datacenters { get; set; }
 
-        public bool ShouldSerializeCreateIndex()
+        public static bool ShouldSerializeCreateIndex()
         {
             return false;
         }
 
-        public bool ShouldSerializeModifyIndex()
+        public static bool ShouldSerializeModifyIndex()
         {
             return false;
         }
@@ -118,7 +118,7 @@ namespace Consul
         /// <param name="policy">The new ACL PolicyEntry</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL Policy</returns>
-        public Task<WriteResult<PolicyEntry>> Create(PolicyEntry policy, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<PolicyEntry>> Create(PolicyEntry policy, CancellationToken ct = default)
         {
             return Create(policy, WriteOptions.Default, ct);
         }
@@ -130,7 +130,7 @@ namespace Consul
         /// <param name="writeOptions">Customised write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL Policy</returns>
-        public async Task<WriteResult<PolicyEntry>> Create(PolicyEntry policy, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<PolicyEntry>> Create(PolicyEntry policy, WriteOptions writeOptions, CancellationToken ct = default)
         {
             var res = await _client.Put<PolicyEntry, PolicyActionResult>("/v1/acl/policy", policy, writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<PolicyEntry>(res, res.Response);
@@ -142,7 +142,7 @@ namespace Consul
         /// <param name="id">The ID of the ACL Policy to delete</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>Success (true) or failure (false)</returns>
-        public Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default)
         {
             return Delete(id, WriteOptions.Default, ct);
         }
@@ -154,7 +154,7 @@ namespace Consul
         /// <param name="writeOptions">Customised write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>Success (true) or failure (false)</returns>
-        public async Task<WriteResult<bool>> Delete(string id, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<bool>> Delete(string id, WriteOptions writeOptions, CancellationToken ct = default)
         {
             var res = await _client.DeleteReturning<bool>($"/v1/acl/policy/{id}", writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<bool>(res, res.Response);
@@ -165,7 +165,7 @@ namespace Consul
         /// </summary>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing an array of ACL Policies</returns>
-        public Task<QueryResult<PolicyEntry[]>> List(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<PolicyEntry[]>> List(CancellationToken ct = default)
         {
             return List(QueryOptions.Default, ct);
         }
@@ -176,7 +176,7 @@ namespace Consul
         /// <param name="queryOptions">Customised query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing an array of ACL Policies</returns>
-        public async Task<QueryResult<PolicyEntry[]>> List(QueryOptions queryOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<QueryResult<PolicyEntry[]>> List(QueryOptions queryOptions, CancellationToken ct = default)
         {
             var res = await _client.Get<PolicyEntry[]>("/v1/acl/policies", queryOptions).Execute(ct).ConfigureAwait(false);
             return new QueryResult<PolicyEntry[]>(res, res.Response);
@@ -188,7 +188,7 @@ namespace Consul
         /// <param name="id">The ID of the ACL Policy to get</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the requested ACL Policy</returns>
-        public Task<QueryResult<PolicyEntry>> Read(string id, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<PolicyEntry>> Read(string id, CancellationToken ct = default)
         {
             return Read(id, QueryOptions.Default, ct);
         }
@@ -200,7 +200,7 @@ namespace Consul
         /// <param name="queryOptions">Customised query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the requested ACL Policy</returns>
-        public async Task<QueryResult<PolicyEntry>> Read(string id, QueryOptions queryOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<QueryResult<PolicyEntry>> Read(string id, QueryOptions queryOptions, CancellationToken ct = default)
         {
             var res = await _client.Get<PolicyEntry>($"/v1/acl/policy/{id}", queryOptions).Execute(ct).ConfigureAwait(false);
             return new QueryResult<PolicyEntry>(res, res.Response);
@@ -212,7 +212,7 @@ namespace Consul
         /// <param name="policy">The modified ACL Policy</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the updated ACL Policy</returns>
-        public Task<WriteResult<PolicyEntry>> Update(PolicyEntry policy, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<PolicyEntry>> Update(PolicyEntry policy, CancellationToken ct = default)
         {
             return Update(policy, WriteOptions.Default, ct);
         }
@@ -224,7 +224,7 @@ namespace Consul
         /// <param name="writeOptions">Customised write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the updated ACL policy</returns>
-        public async Task<WriteResult<PolicyEntry>> Update(PolicyEntry policy, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<PolicyEntry>> Update(PolicyEntry policy, WriteOptions writeOptions, CancellationToken ct = default)
         {
             var res = await _client.Put<PolicyEntry, PolicyActionResult>($"/v1/acl/policy/{policy.ID}", policy, writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<PolicyEntry>(res, res.Response);
@@ -238,9 +238,6 @@ namespace Consul
         /// <summary>
         /// Policy returns a handle to the ACL Policy endpoints
         /// </summary>
-        public IPolicyEndpoint Policy
-        {
-            get { return _policy.Value; }
-        }
+        public IPolicyEndpoint Policy => _policy.Value;
     }
 }

--- a/Consul/PreparedQuery.cs
+++ b/Consul/PreparedQuery.cs
@@ -18,8 +18,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -227,64 +225,64 @@ namespace Consul
             _client = c;
         }
 
-        public Task<WriteResult<string>> Create(PreparedQueryDefinition query, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<string>> Create(PreparedQueryDefinition query, CancellationToken ct = default)
         {
             return Create(query, WriteOptions.Default, ct);
         }
 
-        public async Task<WriteResult<string>> Create(PreparedQueryDefinition query, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<string>> Create(PreparedQueryDefinition query, WriteOptions q, CancellationToken ct = default)
         {
             var res = await _client.Post<PreparedQueryDefinition, PreparedQueryCreationResult>("/v1/query", query, q).Execute(ct).ConfigureAwait(false);
             return new WriteResult<string>(res, res.Response.ID);
         }
 
-        public Task<WriteResult> Delete(string queryID, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> Delete(string queryID, CancellationToken ct = default)
         {
             return Delete(queryID, WriteOptions.Default, ct);
         }
 
-        public async Task<WriteResult> Delete(string queryID, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult> Delete(string queryID, WriteOptions q, CancellationToken ct = default)
         {
             var res = await _client.DeleteReturning<string>(string.Format("/v1/query/{0}", queryID), q).Execute(ct).ConfigureAwait(false);
             return new WriteResult(res);
         }
 
-        public Task<QueryResult<PreparedQueryExecuteResponse>> Execute(string queryIDOrName, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<PreparedQueryExecuteResponse>> Execute(string queryIDOrName, CancellationToken ct = default)
         {
             return Execute(queryIDOrName, QueryOptions.Default, ct);
         }
 
-        public Task<QueryResult<PreparedQueryExecuteResponse>> Execute(string queryIDOrName, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<PreparedQueryExecuteResponse>> Execute(string queryIDOrName, QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<PreparedQueryExecuteResponse>(string.Format("/v1/query/{0}/execute", queryIDOrName), q).Execute(ct);
         }
 
-        public Task<QueryResult<PreparedQueryDefinition[]>> Get(string queryID, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<PreparedQueryDefinition[]>> Get(string queryID, CancellationToken ct = default)
         {
             return Get(queryID, QueryOptions.Default, ct);
         }
 
-        public Task<QueryResult<PreparedQueryDefinition[]>> Get(string queryID, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<PreparedQueryDefinition[]>> Get(string queryID, QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<PreparedQueryDefinition[]>(string.Format("/v1/query/{0}", queryID), q).Execute(ct);
         }
 
-        public Task<QueryResult<PreparedQueryDefinition[]>> List(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<PreparedQueryDefinition[]>> List(CancellationToken ct = default)
         {
             return List(QueryOptions.Default, ct);
         }
 
-        public Task<QueryResult<PreparedQueryDefinition[]>> List(QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<PreparedQueryDefinition[]>> List(QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<PreparedQueryDefinition[]>("/v1/query", q).Execute(ct);
         }
 
-        public Task<WriteResult> Update(PreparedQueryDefinition query, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> Update(PreparedQueryDefinition query, CancellationToken ct = default)
         {
             return Update(query, WriteOptions.Default, ct);
         }
 
-        public Task<WriteResult> Update(PreparedQueryDefinition query, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> Update(PreparedQueryDefinition query, WriteOptions q, CancellationToken ct = default)
         {
             return _client.Put(string.Format("/v1/query/{0}", query.ID), query, q).Execute(ct);
         }
@@ -297,9 +295,6 @@ namespace Consul
         /// <summary>
         /// Catalog returns a handle to the catalog endpoints
         /// </summary>
-        public IPreparedQueryEndpoint PreparedQuery
-        {
-            get { return _preparedquery.Value; }
-        }
+        public IPreparedQueryEndpoint PreparedQuery => _preparedquery.Value;
     }
 }

--- a/Consul/Raw.cs
+++ b/Consul/Raw.cs
@@ -41,7 +41,7 @@ namespace Consul
         /// <param name="q">Custom query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>The data returned by the custom endpoint</returns>
-        public Task<QueryResult<dynamic>> Query(string endpoint, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<dynamic>> Query(string endpoint, QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<dynamic>(endpoint, q).Execute(ct);
         }
@@ -53,7 +53,7 @@ namespace Consul
         /// <param name="obj">The object to serialize and send to the endpoint. Must be able to be JSON serialized, or be an object of type byte[], which is sent without serialzation.</param>
         /// <param name="q">Custom write options</param>
         /// <returns>The data returned by the custom endpoint in response to the write request</returns>
-        public Task<WriteResult<dynamic>> Write(string endpoint, object obj, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<dynamic>> Write(string endpoint, object obj, WriteOptions q, CancellationToken ct = default)
         {
             return _client.Put<object, dynamic>(endpoint, obj, q).Execute(ct);
         }
@@ -66,9 +66,6 @@ namespace Consul
         /// <summary>
         /// Raw returns a handle to query endpoints
         /// </summary>
-        public IRawEndpoint Raw
-        {
-            get { return _raw.Value; }
-        }
+        public IRawEndpoint Raw => _raw.Value;
     }
 }

--- a/Consul/Role.cs
+++ b/Consul/Role.cs
@@ -58,43 +58,43 @@ namespace Consul
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public ServiceIdentity[] ServiceIdentities { get; set; }
 
-        public bool ShouldSerializeCreateIndex()
+        public static bool ShouldSerializeCreateIndex()
         {
             return false;
         }
 
-        public bool ShouldSerializeModifyIndex()
+        public static bool ShouldSerializeModifyIndex()
         {
             return false;
         }
 
         public RoleEntry()
-            : this(string.Empty, string.Empty, string.Empty, new PolicyLink[] { }, new ServiceIdentity[] { })
+            : this(string.Empty, string.Empty, string.Empty, Array.Empty<PolicyLink>(), Array.Empty<ServiceIdentity>())
         {
         }
 
         public RoleEntry(string name)
-            : this(string.Empty, name, string.Empty, new PolicyLink[] { }, new ServiceIdentity[] { })
+            : this(string.Empty, name, string.Empty, Array.Empty<PolicyLink>(), Array.Empty<ServiceIdentity>())
         {
         }
 
         public RoleEntry(string name, string description)
-            : this(string.Empty, name, description, new PolicyLink[] { }, new ServiceIdentity[] { })
+            : this(string.Empty, name, description, Array.Empty<PolicyLink>(), Array.Empty<ServiceIdentity>())
         {
         }
 
         public RoleEntry(string id, string name, string description)
-            : this(id, name, description, new PolicyLink[] { }, new ServiceIdentity[] { })
+            : this(id, name, description, Array.Empty<PolicyLink>(), Array.Empty<ServiceIdentity>())
         {
         }
 
         public RoleEntry(string id, string name, string description, PolicyLink[] policies)
-            : this(id, name, description, policies, new ServiceIdentity[] { })
+            : this(id, name, description, policies, Array.Empty<ServiceIdentity>())
         {
         }
 
         public RoleEntry(string id, string name, string description, ServiceIdentity[] serviceIdentities)
-            : this(id, name, description, new PolicyLink[] { }, serviceIdentities)
+            : this(id, name, description, Array.Empty<PolicyLink>(), serviceIdentities)
         {
         }
 
@@ -134,7 +134,7 @@ namespace Consul
         /// <param name="policy">The new ACL Role</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL Role</returns>
-        public Task<WriteResult<RoleEntry>> Create(RoleEntry policy, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<RoleEntry>> Create(RoleEntry policy, CancellationToken ct = default)
         {
             return Create(policy, WriteOptions.Default, ct);
         }
@@ -146,7 +146,7 @@ namespace Consul
         /// <param name="writeOptions">Customised write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL Role</returns>
-        public async Task<WriteResult<RoleEntry>> Create(RoleEntry policy, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<RoleEntry>> Create(RoleEntry policy, WriteOptions writeOptions, CancellationToken ct = default)
         {
             var res = await _client.Put<RoleEntry, RoleActionResult>("/v1/acl/role", policy, writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<RoleEntry>(res, res.Response);
@@ -158,7 +158,7 @@ namespace Consul
         /// <param name="id">The ID of the ACL Role to delete</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>Success (true) or failure (false)</returns>
-        public Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default)
         {
             return Delete(id, WriteOptions.Default, ct);
         }
@@ -170,7 +170,7 @@ namespace Consul
         /// <param name="writeOptions">Customised write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>Success (true) or failure (false)</returns>
-        public async Task<WriteResult<bool>> Delete(string id, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<bool>> Delete(string id, WriteOptions writeOptions, CancellationToken ct = default)
         {
             var res = await _client.DeleteReturning<bool>($"/v1/acl/role/{id}", writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<bool>(res, res.Response);
@@ -181,7 +181,7 @@ namespace Consul
         /// </summary>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing an array of ACL Roles</returns>
-        public Task<QueryResult<RoleEntry[]>> List(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<RoleEntry[]>> List(CancellationToken ct = default)
         {
             return List(QueryOptions.Default, ct);
         }
@@ -192,7 +192,7 @@ namespace Consul
         /// <param name="queryOptions">Customised query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing an array of ACL Roles</returns>
-        public async Task<QueryResult<RoleEntry[]>> List(QueryOptions queryOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<QueryResult<RoleEntry[]>> List(QueryOptions queryOptions, CancellationToken ct = default)
         {
             var res = await _client.Get<RoleEntry[]>("/v1/acl/roles", queryOptions).Execute(ct).ConfigureAwait(false);
             return new QueryResult<RoleEntry[]>(res, res.Response);
@@ -204,7 +204,7 @@ namespace Consul
         /// <param name="id">The ID of the ACL Role to get</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the requested ACL Role</returns>
-        public Task<QueryResult<RoleEntry>> Read(string id, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<RoleEntry>> Read(string id, CancellationToken ct = default)
         {
             return Read(id, QueryOptions.Default, ct);
         }
@@ -216,7 +216,7 @@ namespace Consul
         /// <param name="queryOptions">Customised query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the requested ACL Role</returns>
-        public async Task<QueryResult<RoleEntry>> Read(string id, QueryOptions queryOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<QueryResult<RoleEntry>> Read(string id, QueryOptions queryOptions, CancellationToken ct = default)
         {
             var res = await _client.Get<RoleEntry>($"/v1/acl/role/{id}", queryOptions).Execute(ct).ConfigureAwait(false);
             return new QueryResult<RoleEntry>(res, res.Response);
@@ -228,7 +228,7 @@ namespace Consul
         /// <param name="name">The Name of the ACL Role to get</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the requested ACL Role</returns>
-        public Task<QueryResult<RoleEntry>> ReadByName(string name, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<RoleEntry>> ReadByName(string name, CancellationToken ct = default)
         {
             return ReadByName(name, QueryOptions.Default, ct);
         }
@@ -240,7 +240,7 @@ namespace Consul
         /// <param name="queryOptions">Customised query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the requested ACL Role</returns>
-        public async Task<QueryResult<RoleEntry>> ReadByName(string name, QueryOptions queryOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<QueryResult<RoleEntry>> ReadByName(string name, QueryOptions queryOptions, CancellationToken ct = default)
         {
             var res = await _client.Get<RoleEntry>($"/v1/acl/role/name/{name}", queryOptions).Execute(ct).ConfigureAwait(false);
             return new QueryResult<RoleEntry>(res, res.Response);
@@ -252,7 +252,7 @@ namespace Consul
         /// <param name="role">The modified ACL Role</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the updated ACL Role</returns>
-        public Task<WriteResult<RoleEntry>> Update(RoleEntry role, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<RoleEntry>> Update(RoleEntry role, CancellationToken ct = default)
         {
             return Update(role, WriteOptions.Default, ct);
         }
@@ -264,7 +264,7 @@ namespace Consul
         /// <param name="writeOptions">Customised write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the updated ACL Role</returns>
-        public async Task<WriteResult<RoleEntry>> Update(RoleEntry role, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<RoleEntry>> Update(RoleEntry role, WriteOptions writeOptions, CancellationToken ct = default)
         {
             var res = await _client.Put<RoleEntry, RoleActionResult>($"/v1/acl/role/{role.ID}", role, writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<RoleEntry>(res, res.Response);
@@ -278,9 +278,6 @@ namespace Consul
         /// <summary>
         /// Role returns a handle to the ACL Role endpoints
         /// </summary>
-        public IRoleEndpoint Role
-        {
-            get { return _role.Value; }
-        }
+        public IRoleEndpoint Role => _role.Value;
     }
 }

--- a/Consul/Semaphore.cs
+++ b/Consul/Semaphore.cs
@@ -462,7 +462,7 @@ namespace Consul
         /// <summary>
         /// Release is used to voluntarily give up our semaphore slot. It is an error to call this if the semaphore has not been acquired.
         /// </summary>
-        public async Task Release(CancellationToken ct = default(CancellationToken))
+        public async Task Release(CancellationToken ct = default)
         {
             try
             {
@@ -531,7 +531,7 @@ namespace Consul
         /// <summary>
         /// Destroy is used to cleanup the semaphore entry. It is not necessary to invoke. It will fail if the semaphore is in use.
         /// </summary>
-        public async Task Destroy(CancellationToken ct = default(CancellationToken))
+        public async Task Destroy(CancellationToken ct = default)
         {
             using (await _mutex.LockAsync().ConfigureAwait(false))
             {
@@ -793,7 +793,7 @@ namespace Consul
 
         public string Prefix
         {
-            get { return _prefix; }
+            get => _prefix;
             set
             {
                 if (!string.IsNullOrEmpty(value))
@@ -811,7 +811,7 @@ namespace Consul
 
         public int Limit
         {
-            get { return _limit; }
+            get => _limit;
             set
             {
                 if (value > 0)
@@ -878,7 +878,7 @@ namespace Consul
             }
             return new Semaphore(this) { Opts = opts };
         }
-        public Task<IDistributedSemaphore> AcquireSemaphore(string prefix, int limit, CancellationToken ct = default(CancellationToken))
+        public Task<IDistributedSemaphore> AcquireSemaphore(string prefix, int limit, CancellationToken ct = default)
         {
             if (string.IsNullOrEmpty(prefix))
             {
@@ -890,7 +890,7 @@ namespace Consul
             }
             return AcquireSemaphore(new SemaphoreOptions(prefix, limit), ct);
         }
-        public async Task<IDistributedSemaphore> AcquireSemaphore(SemaphoreOptions opts, CancellationToken ct = default(CancellationToken))
+        public async Task<IDistributedSemaphore> AcquireSemaphore(SemaphoreOptions opts, CancellationToken ct = default)
         {
             if (opts == null)
             {
@@ -902,7 +902,7 @@ namespace Consul
             return semaphore;
         }
 
-        public Task ExecuteInSemaphore(string prefix, int limit, Action a, CancellationToken ct = default(CancellationToken))
+        public Task ExecuteInSemaphore(string prefix, int limit, Action a, CancellationToken ct = default)
         {
             if (string.IsNullOrEmpty(prefix))
             {
@@ -915,7 +915,7 @@ namespace Consul
             return ExecuteInSemaphore(new SemaphoreOptions(prefix, limit), a, ct);
         }
 
-        public async Task ExecuteInSemaphore(SemaphoreOptions opts, Action a, CancellationToken ct = default(CancellationToken))
+        public async Task ExecuteInSemaphore(SemaphoreOptions opts, Action a, CancellationToken ct = default)
         {
             if (opts == null)
             {

--- a/Consul/ServiceIdentity.cs
+++ b/Consul/ServiceIdentity.cs
@@ -15,6 +15,7 @@
 //    limitations under the License.
 //  </copyright>
 // -----------------------------------------------------------------------
+using System;
 
 namespace Consul
 {
@@ -24,7 +25,7 @@ namespace Consul
     public class ServiceIdentity
     {
         public ServiceIdentity()
-            : this(string.Empty, new string[] { })
+            : this(string.Empty, Array.Empty<string>())
         {
         }
 

--- a/Consul/Session.cs
+++ b/Consul/Session.cs
@@ -24,6 +24,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
+#if !(NETSTANDARD || NETCOREAPP)
+    using System.Runtime.Serialization;
+#endif
+
 namespace Consul
 {
     public class SessionBehavior : IEquatable<SessionBehavior>

--- a/Consul/Session.cs
+++ b/Consul/Session.cs
@@ -20,7 +20,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
-using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -144,12 +143,12 @@ namespace Consul
             Checks = new List<string>();
         }
 
-        public bool ShouldSerializeID()
+        public static bool ShouldSerializeID()
         {
             return false;
         }
 
-        public bool ShouldSerializeCreateIndex()
+        public static bool ShouldSerializeCreateIndex()
         {
             return false;
         }
@@ -261,7 +260,7 @@ namespace Consul
         /// <param name="se">The SessionEntry options to use</param>
         /// <returns>A write result containing the new session ID</returns>
 
-        public Task<WriteResult<string>> Create(CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<string>> Create(CancellationToken ct = default)
         {
             return Create(null, WriteOptions.Default, ct);
         }
@@ -270,7 +269,7 @@ namespace Consul
         /// Create makes a new session with default options.
         /// </summary>
         /// <returns>A write result containing the new session ID</returns>
-        public Task<WriteResult<string>> Create(SessionEntry se, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<string>> Create(SessionEntry se, CancellationToken ct = default)
         {
             return Create(se, WriteOptions.Default, ct);
         }
@@ -281,7 +280,7 @@ namespace Consul
         /// <param name="se">The SessionEntry options to use</param>
         /// <param name="q">Customized write options</param>
         /// <returns>A write result containing the new session ID</returns>
-        public async Task<WriteResult<string>> Create(SessionEntry se, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<string>> Create(SessionEntry se, WriteOptions q, CancellationToken ct = default)
         {
             var res = await _client.Put<SessionEntry, SessionCreationResult>("/v1/session/create", se, q).Execute(ct).ConfigureAwait(false);
             return new WriteResult<string>(res, res.Response.ID);
@@ -289,7 +288,7 @@ namespace Consul
         /// <summary>
         /// CreateNoChecks is like Create but is used specifically to create a session with no associated health checks.
         /// </summary>
-        public Task<WriteResult<string>> CreateNoChecks(CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<string>> CreateNoChecks(CancellationToken ct = default)
         {
             return CreateNoChecks(null, WriteOptions.Default, ct);
         }
@@ -299,7 +298,7 @@ namespace Consul
         /// </summary>
         /// <param name="se">The SessionEntry options to use</param>
         /// <returns>A write result containing the new session ID</returns>
-        public Task<WriteResult<string>> CreateNoChecks(SessionEntry se, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<string>> CreateNoChecks(SessionEntry se, CancellationToken ct = default)
         {
             return CreateNoChecks(se, WriteOptions.Default, ct);
         }
@@ -310,7 +309,7 @@ namespace Consul
         /// <param name="se">The SessionEntry options to use</param>
         /// <param name="q">Customized write options</param>
         /// <returns>A write result containing the new session ID</returns>
-        public Task<WriteResult<string>> CreateNoChecks(SessionEntry se, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<string>> CreateNoChecks(SessionEntry se, WriteOptions q, CancellationToken ct = default)
         {
             if (se == null)
             {
@@ -333,7 +332,7 @@ namespace Consul
         /// </summary>
         /// <param name="id">The session ID to destroy</param>
         /// <returns>A write result containing the result of the session destruction</returns>
-        public Task<WriteResult<bool>> Destroy(string id, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Destroy(string id, CancellationToken ct = default)
         {
             return Destroy(id, WriteOptions.Default, ct);
         }
@@ -344,7 +343,7 @@ namespace Consul
         /// <param name="id">The session ID to destroy</param>
         /// <param name="q">Customized write options</param>
         /// <returns>A write result containing the result of the session destruction</returns>
-        public Task<WriteResult<bool>> Destroy(string id, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Destroy(string id, WriteOptions q, CancellationToken ct = default)
         {
             return _client.Put<object, bool>(string.Format("/v1/session/destroy/{0}", id), null, q).Execute(ct);
         }
@@ -354,7 +353,7 @@ namespace Consul
         /// </summary>
         /// <param name="id">The session ID to look up</param>
         /// <returns>A query result containing the session information, or an empty query result if the session entry does not exist</returns>
-        public Task<QueryResult<SessionEntry>> Info(string id, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<SessionEntry>> Info(string id, CancellationToken ct = default)
         {
             return Info(id, QueryOptions.Default, ct);
         }
@@ -365,7 +364,7 @@ namespace Consul
         /// <param name="id">The session ID to look up</param>
         /// <param name="q">Customized query options</param>
         /// <returns>A query result containing the session information, or an empty query result if the session entry does not exist</returns>
-        public async Task<QueryResult<SessionEntry>> Info(string id, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<QueryResult<SessionEntry>> Info(string id, QueryOptions q, CancellationToken ct = default)
         {
             var res = await _client.Get<SessionEntry[]>(string.Format("/v1/session/info/{0}", id), q).Execute(ct).ConfigureAwait(false);
             return new QueryResult<SessionEntry>(res, res.Response != null && res.Response.Length > 0 ? res.Response[0] : null);
@@ -375,7 +374,7 @@ namespace Consul
         /// List gets all active sessions
         /// </summary>
         /// <returns>A query result containing list of all sessions, or an empty query result if no sessions exist</returns>
-        public Task<QueryResult<SessionEntry[]>> List(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<SessionEntry[]>> List(CancellationToken ct = default)
         {
             return List(QueryOptions.Default, ct);
         }
@@ -385,7 +384,7 @@ namespace Consul
         /// </summary>
         /// <param name="q">Customized query options</param>
         /// <returns>A query result containing the list of sessions, or an empty query result if no sessions exist</returns>
-        public Task<QueryResult<SessionEntry[]>> List(QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<SessionEntry[]>> List(QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<SessionEntry[]>("/v1/session/list", q).Execute(ct);
         }
@@ -395,7 +394,7 @@ namespace Consul
         /// </summary>
         /// <param name="node">The node ID</param>
         /// <returns>A query result containing the list of sessions, or an empty query result if no sessions exist</returns>
-        public Task<QueryResult<SessionEntry[]>> Node(string node, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<SessionEntry[]>> Node(string node, CancellationToken ct = default)
         {
             return Node(node, QueryOptions.Default, ct);
         }
@@ -406,7 +405,7 @@ namespace Consul
         /// <param name="node">The node ID</param>
         /// <param name="q">Customized query options</param>
         /// <returns>A query result containing the list of sessions, or an empty query result if no sessions exist</returns>
-        public Task<QueryResult<SessionEntry[]>> Node(string node, QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<SessionEntry[]>> Node(string node, QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<SessionEntry[]>(string.Format("/v1/session/node/{0}", node), q).Execute(ct);
         }
@@ -416,7 +415,7 @@ namespace Consul
         /// </summary>
         /// <param name="id">The session ID to renew</param>
         /// <returns>An updated session entry</returns>
-        public Task<WriteResult<SessionEntry>> Renew(string id, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<SessionEntry>> Renew(string id, CancellationToken ct = default)
         {
             return Renew(id, WriteOptions.Default, ct);
         }
@@ -427,7 +426,7 @@ namespace Consul
         /// <param name="id">The session ID to renew</param>
         /// <param name="q">Customized write options</param>
         /// <returns>An updated session entry</returns>
-        public async Task<WriteResult<SessionEntry>> Renew(string id, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<SessionEntry>> Renew(string id, WriteOptions q, CancellationToken ct = default)
         {
             var res = await _client.Put<object, SessionEntry[]>(string.Format("/v1/session/renew/{0}", id), null, q).Execute(ct).ConfigureAwait(false);
             if (res.StatusCode == HttpStatusCode.NotFound)

--- a/Consul/Snapshot.cs
+++ b/Consul/Snapshot.cs
@@ -17,9 +17,7 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -39,22 +37,22 @@ namespace Consul
             _client = c;
         }
 
-        public Task<WriteResult> Restore(Stream s, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> Restore(Stream s, CancellationToken ct = default)
         {
             return Restore(s, WriteOptions.Default, ct);
         }
 
-        public Task<WriteResult> Restore(Stream s, WriteOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult> Restore(Stream s, WriteOptions q, CancellationToken ct = default)
         {
             return _client.Put("/v1/snapshot", s, q).Execute(ct);
         }
 
-        public Task<QueryResult<Stream>> Save(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<Stream>> Save(CancellationToken ct = default)
         {
             return Save(QueryOptions.Default, ct);
         }
 
-        public Task<QueryResult<Stream>> Save(QueryOptions q, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<Stream>> Save(QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<Stream>("/v1/snapshot", q).ExecuteStreaming(ct);
         }
@@ -67,9 +65,6 @@ namespace Consul
         /// <summary>
         /// Catalog returns a handle to the snapshot endpoints
         /// </summary>
-        public ISnapshotEndpoint Snapshot
-        {
-            get { return _snapshot.Value; }
-        }
+        public ISnapshotEndpoint Snapshot => _snapshot.Value;
     }
 }

--- a/Consul/Status.cs
+++ b/Consul/Status.cs
@@ -34,7 +34,7 @@ namespace Consul
         /// Leader is used to query for a known leader
         /// </summary>
         /// <returns>A write result containing the leader node name</returns>
-        public async Task<string> Leader(CancellationToken ct = default(CancellationToken))
+        public async Task<string> Leader(CancellationToken ct = default)
         {
             var res = await _client.Get<string>("/v1/status/leader").Execute(ct).ConfigureAwait(false);
             return res.Response;
@@ -44,7 +44,7 @@ namespace Consul
         /// Peers is used to query for a known raft peers
         /// </summary>
         /// <returns>A write result containing the list of Raft peers</returns>
-        public async Task<string[]> Peers(CancellationToken ct = default(CancellationToken))
+        public async Task<string[]> Peers(CancellationToken ct = default)
         {
             var res = await _client.Get<string[]>("/v1/status/peers").Execute(ct).ConfigureAwait(false);
             return res.Response;
@@ -58,9 +58,6 @@ namespace Consul
         /// <summary>
         /// Status returns a handle to the status endpoint
         /// </summary>
-        public IStatusEndpoint Status
-        {
-            get { return _status.Value; }
-        }
+        public IStatusEndpoint Status => _status.Value;
     }
 }

--- a/Consul/Token.cs
+++ b/Consul/Token.cs
@@ -45,38 +45,38 @@ namespace Consul
         public string AuthMethod { get; set; }
 
 
-        public bool ShouldSerializeCreateIndex()
+        public static bool ShouldSerializeCreateIndex()
         {
             return false;
         }
 
-        public bool ShouldSerializeModifyIndex()
+        public static bool ShouldSerializeModifyIndex()
         {
             return false;
         }
 
         public TokenEntry()
-            : this(string.Empty, string.Empty, new PolicyLink[] { }, new RoleLink[] { }, new ServiceIdentity[] { })
+            : this(string.Empty, string.Empty, Array.Empty<PolicyLink>(), Array.Empty<RoleLink>(), Array.Empty<ServiceIdentity>())
         {
         }
 
         public TokenEntry(string description, PolicyLink[] policies)
-            : this(string.Empty, description, policies, new RoleLink[] { }, new ServiceIdentity[] { })
+            : this(string.Empty, description, policies, Array.Empty<RoleLink>(), Array.Empty<ServiceIdentity>())
         {
         }
 
         public TokenEntry(string description, RoleLink[] roles)
-            : this(string.Empty, description, new PolicyLink[] { }, roles, new ServiceIdentity[] { })
+            : this(string.Empty, description, Array.Empty<PolicyLink>(), roles, Array.Empty<ServiceIdentity>())
         {
         }
 
         public TokenEntry(string description, ServiceIdentity[] serviceIdentities)
-            : this(string.Empty, description, new PolicyLink[] { }, new RoleLink[] { }, serviceIdentities)
+            : this(string.Empty, description, Array.Empty<PolicyLink>(), Array.Empty<RoleLink>(), serviceIdentities)
         {
         }
 
         public TokenEntry(string accessorId, string description)
-            : this(accessorId, description, new PolicyLink[] { }, new RoleLink[] { }, new ServiceIdentity[] { })
+            : this(accessorId, description, Array.Empty<PolicyLink>(), Array.Empty<RoleLink>(), Array.Empty<ServiceIdentity>())
         {
         }
 
@@ -119,7 +119,7 @@ namespace Consul
         /// </summary>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL Token</returns>
-        public Task<WriteResult<TokenEntry>> Bootstrap(CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<TokenEntry>> Bootstrap(CancellationToken ct = default)
         {
             return Bootstrap(WriteOptions.Default, ct);
         }
@@ -130,7 +130,7 @@ namespace Consul
         /// <param name="writeOptions">Customized write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL Token</returns>
-        public async Task<WriteResult<TokenEntry>> Bootstrap(WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<TokenEntry>> Bootstrap(WriteOptions writeOptions, CancellationToken ct = default)
         {
             var res = await _client.PutReturning<TokenActionResult>("/v1/acl/bootstrap", writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<TokenEntry>(res, res.Response);
@@ -142,7 +142,7 @@ namespace Consul
         /// <param name="token">The new ACL Token</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL Token</returns>
-        public Task<WriteResult<TokenEntry>> Create(TokenEntry token, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<TokenEntry>> Create(TokenEntry token, CancellationToken ct = default)
         {
             return Create(token, WriteOptions.Default, ct);
         }
@@ -154,7 +154,7 @@ namespace Consul
         /// <param name="writeOptions">Customized write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL Token</returns>
-        public async Task<WriteResult<TokenEntry>> Create(TokenEntry token, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<TokenEntry>> Create(TokenEntry token, WriteOptions writeOptions, CancellationToken ct = default)
         {
             var res = await _client.Put<TokenEntry, TokenActionResult>("/v1/acl/token", token, writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<TokenEntry>(res, res.Response);
@@ -166,7 +166,7 @@ namespace Consul
         /// <param name="token">The modified ACL Token</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the updated ACL Token</returns>
-        public Task<WriteResult<TokenEntry>> Update(TokenEntry token, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<TokenEntry>> Update(TokenEntry token, CancellationToken ct = default)
         {
             return Update(token, WriteOptions.Default, ct);
         }
@@ -178,7 +178,7 @@ namespace Consul
         /// <param name="writeOptions">Customized write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the updated ACL Token</returns>
-        public async Task<WriteResult<TokenEntry>> Update(TokenEntry token, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<TokenEntry>> Update(TokenEntry token, WriteOptions writeOptions, CancellationToken ct = default)
         {
             var res = await _client.Put<TokenEntry, TokenActionResult>($"/v1/acl/token/{token.AccessorID}", token, writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<TokenEntry>(res, res.Response);
@@ -190,7 +190,7 @@ namespace Consul
         /// <param name="id">The Accessor ID of the ACL Token to delete</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>Success (true) or failure (false)</returns>
-        public Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Delete(string id, CancellationToken ct = default)
         {
             return Delete(id, WriteOptions.Default, ct);
         }
@@ -202,7 +202,7 @@ namespace Consul
         /// <param name="writeOptions">Customized write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>Success (true) or failure (false)</returns>
-        public Task<WriteResult<bool>> Delete(string id, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<bool>> Delete(string id, WriteOptions writeOptions, CancellationToken ct = default)
         {
             return _client.DeleteReturning<bool>($"/v1/acl/token/{id}", writeOptions).Execute(ct);
         }
@@ -213,7 +213,7 @@ namespace Consul
         /// <param name="id">The Accessor ID of the ACL Token to clone</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL token</returns>
-        public Task<WriteResult<TokenEntry>> Clone(string id, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<TokenEntry>> Clone(string id, CancellationToken ct = default)
         {
             return Clone(id, WriteOptions.Default, ct);
         }
@@ -225,7 +225,7 @@ namespace Consul
         /// <param name="writeOptions">Customized write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL token</returns>
-        public Task<WriteResult<TokenEntry>> Clone(string id, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public Task<WriteResult<TokenEntry>> Clone(string id, WriteOptions writeOptions, CancellationToken ct = default)
         {
             return Clone(id, string.Empty, writeOptions, ct);
         }
@@ -238,12 +238,13 @@ namespace Consul
         /// <param name="writeOptions">Customized write options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A write result containing the created ACL token</returns>
-        public async Task<WriteResult<TokenEntry>> Clone(string id, string description, WriteOptions writeOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<WriteResult<TokenEntry>> Clone(string id, string description, WriteOptions writeOptions, CancellationToken ct = default)
         {
             var body = new Dictionary<string, string>
-                {
-                    {"Description", description}
-                };
+            {
+                {"Description", description}
+            };
+
             var res = await _client.Put<object, TokenActionResult>($"/v1/acl/token/{id}/clone", body, writeOptions).Execute(ct).ConfigureAwait(false);
             return new WriteResult<TokenEntry>(res, res.Response);
         }
@@ -254,7 +255,7 @@ namespace Consul
         /// <param name="id">The Accessor ID of the ACL Token to get</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the requested ACL Token</returns>
-        public Task<QueryResult<TokenEntry>> Read(string id, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<TokenEntry>> Read(string id, CancellationToken ct = default)
         {
             return Read(id, QueryOptions.Default, ct);
         }
@@ -266,7 +267,7 @@ namespace Consul
         /// <param name="queryOptions">Customized query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing the requested ACL Token</returns>
-        public async Task<QueryResult<TokenEntry>> Read(string id, QueryOptions queryOptions, CancellationToken ct = default(CancellationToken))
+        public async Task<QueryResult<TokenEntry>> Read(string id, QueryOptions queryOptions, CancellationToken ct = default)
         {
             var res = await _client.Get<TokenActionResult>($"/v1/acl/token/{id}", queryOptions).Execute(ct).ConfigureAwait(false);
             return new QueryResult<TokenEntry>(res, res.Response);
@@ -277,7 +278,7 @@ namespace Consul
         /// </summary>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing an array of ACL Tokens</returns>
-        public Task<QueryResult<TokenEntry[]>> List(CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<TokenEntry[]>> List(CancellationToken ct = default)
         {
             return List(QueryOptions.Default, ct);
         }
@@ -288,7 +289,7 @@ namespace Consul
         /// <param name="queryOptions">Customized query options</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>A query result containing an array of ACL Tokens</returns>
-        public Task<QueryResult<TokenEntry[]>> List(QueryOptions queryOptions, CancellationToken ct = default(CancellationToken))
+        public Task<QueryResult<TokenEntry[]>> List(QueryOptions queryOptions, CancellationToken ct = default)
         {
             return _client.Get<TokenEntry[]>("/v1/acl/tokens", queryOptions).Execute(ct);
         }
@@ -301,9 +302,6 @@ namespace Consul
         /// <summary>
         /// Token returns a handle to the ACL Token endpoints
         /// </summary>
-        public ITokenEndpoint Token
-        {
-            get { return _token.Value; }
-        }
+        public ITokenEndpoint Token => _token.Value;
     }
 }

--- a/Consul/Transaction.cs
+++ b/Consul/Transaction.cs
@@ -16,10 +16,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Consul


### PR DESCRIPTION
- Fixed a bug where a using directive was not appropriately guarded with a preprocessor
- Small performance win by using `Array.Empty` to avoid zero-length array allocations