### PR TITLE
refactor: reuse already implemented methods in Namespaces

### DIFF
--- a/Consul/Namespace.cs
+++ b/Consul/Namespace.cs
@@ -49,8 +49,7 @@ namespace Consul
 
         public async Task<WriteResult<NamespaceResponse>> Create(Namespace ns, CancellationToken ct = default)
         {
-            var res = await _client.Put<Namespace, NamespaceResponse>("v1/namespace", ns, WriteOptions.Default).Execute(ct).ConfigureAwait(false);
-            return new WriteResult<NamespaceResponse>(res, res.Response);
+            return await Create(ns, WriteOptions.Default, ct).ConfigureAwait(false);
         }
 
         public async Task<WriteResult<NamespaceResponse>> Update(Namespace ns, WriteOptions q, CancellationToken ct = default)
@@ -59,10 +58,9 @@ namespace Consul
             return new WriteResult<NamespaceResponse>(res, res.Response);
         }
 
-        public async Task<WriteResult<NamespaceResponse>> Update(Namespace ns, CancellationToken ct = default)
+        public Task<WriteResult<NamespaceResponse>> Update(Namespace ns, CancellationToken ct = default)
         {
-            var res = await _client.Put<Namespace, NamespaceResponse>($"v1/namespace/{ns.Name}", ns, WriteOptions.Default).Execute(ct).ConfigureAwait(false);
-            return new WriteResult<NamespaceResponse>(res, res.Response);
+            return Update(ns, WriteOptions.Default, ct);
         }
 
         public Task<QueryResult<NamespaceResponse>> Read(string name, QueryOptions q, CancellationToken ct = default)
@@ -72,7 +70,7 @@ namespace Consul
 
         public Task<QueryResult<NamespaceResponse>> Read(string name, CancellationToken ct = default)
         {
-            return _client.Get<NamespaceResponse>($"v1/namespace/{name}", QueryOptions.Default).Execute(ct);
+            return Read(name, QueryOptions.Default, ct);
         }
 
         public Task<QueryResult<NamespaceResponse[]>> List(QueryOptions q, CancellationToken ct = default)
@@ -82,7 +80,7 @@ namespace Consul
 
         public Task<QueryResult<NamespaceResponse[]>> List(CancellationToken ct = default)
         {
-            return _client.Get<NamespaceResponse[]>($"v1/namespaces", QueryOptions.Default).Execute(ct);
+            return List(QueryOptions.Default, ct);
         }
 
         public Task<WriteResult> Delete(string name, WriteOptions q, CancellationToken ct = default)
@@ -92,7 +90,7 @@ namespace Consul
 
         public Task<WriteResult> Delete(string name, CancellationToken ct = default)
         {
-            return _client.Delete($"v1/namespace/{name}", WriteOptions.Default).Execute(ct);
+            return Delete(name, WriteOptions.Default, ct);
         }
     }
 

--- a/Consul/Namespace.cs
+++ b/Consul/Namespace.cs
@@ -58,39 +58,39 @@ namespace Consul
             return new WriteResult<NamespaceResponse>(res, res.Response);
         }
 
-        public Task<WriteResult<NamespaceResponse>> Update(Namespace ns, CancellationToken ct = default)
+        public async Task<WriteResult<NamespaceResponse>> Update(Namespace ns, CancellationToken ct = default)
         {
-            return Update(ns, WriteOptions.Default, ct);
+            return await Update(ns, WriteOptions.Default, ct).ConfigureAwait(false);
         }
 
-        public Task<QueryResult<NamespaceResponse>> Read(string name, QueryOptions q, CancellationToken ct = default)
+        public async Task<QueryResult<NamespaceResponse>> Read(string name, QueryOptions q, CancellationToken ct = default)
         {
-            return _client.Get<NamespaceResponse>($"v1/namespace/{name}", q).Execute(ct);
+            return await _client.Get<NamespaceResponse>($"v1/namespace/{name}", q).Execute(ct).ConfigureAwait(false);
         }
 
-        public Task<QueryResult<NamespaceResponse>> Read(string name, CancellationToken ct = default)
+        public async Task<QueryResult<NamespaceResponse>> Read(string name, CancellationToken ct = default)
         {
-            return Read(name, QueryOptions.Default, ct);
+            return await Read(name, QueryOptions.Default, ct).ConfigureAwait(false);
         }
 
-        public Task<QueryResult<NamespaceResponse[]>> List(QueryOptions q, CancellationToken ct = default)
+        public async Task<QueryResult<NamespaceResponse[]>> List(QueryOptions q, CancellationToken ct = default)
         {
-            return _client.Get<NamespaceResponse[]>($"v1/namespaces", q).Execute(ct);
+            return await _client.Get<NamespaceResponse[]>($"v1/namespaces", q).Execute(ct).ConfigureAwait(false);
         }
 
-        public Task<QueryResult<NamespaceResponse[]>> List(CancellationToken ct = default)
+        public async Task<QueryResult<NamespaceResponse[]>> List(CancellationToken ct = default)
         {
-            return List(QueryOptions.Default, ct);
+            return await List(QueryOptions.Default, ct).ConfigureAwait(false);
         }
 
-        public Task<WriteResult> Delete(string name, WriteOptions q, CancellationToken ct = default)
+        public async Task<WriteResult> Delete(string name, WriteOptions q, CancellationToken ct = default)
         {
-            return _client.Delete($"v1/namespace/{name}", q).Execute(ct);
+            return await _client.Delete($"v1/namespace/{name}", q).Execute(ct).ConfigureAwait(false);
         }
 
-        public Task<WriteResult> Delete(string name, CancellationToken ct = default)
+        public async Task<WriteResult> Delete(string name, CancellationToken ct = default)
         {
-            return Delete(name, WriteOptions.Default, ct);
+            return await Delete(name, WriteOptions.Default, ct).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
- Reuse implemented methods on overloads

No idea why I didn't write it like this originally.