### PR TITLE
For the 4-number version we cannot use 0 as the last component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.7.14.0
+## 1.7.14.1
 * Add ServiceTags to the health check endpoint (#244)
 * Write correct value for KV.Release (#237)
 * Introduce Namespace (#229)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.7.14.0</VersionPrefix>
+    <VersionPrefix>1.7.14.1</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>


### PR DESCRIPTION
See the workflow failure(https://github.com/G-Research/consuldotnet/actions/runs/6580074725/job/17877720857), version `1.7.14.0` cannot be really created with NuGet as `1.7.14.0 ` and `1.7.14` are equivalent and NuGet chooses to create a 3-number version.