### PR TITLE
Fix macOS net5.0 failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         framework: [net6.0, net7.0, net8.0]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -62,7 +62,7 @@ jobs:
       matrix:
         consul: [1.6.10, 1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.0]
         framework: [net461, net6.0, net7.0, net8.0]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
         framework: [net6.0, net7.0, net8.0]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -62,7 +62,7 @@ jobs:
       matrix:
         consul: [1.6.10, 1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.0]
         framework: [net461, net6.0, net7.0, net8.0]
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,11 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
-      - name: Setup .NET SDK v7.0.30x
+      - name: Setup .NET SDK v7.0.3xx
         if: matrix.framework == 'net461'
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.30x
+          dotnet-version: 7.0.3xx
       - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
-      - name: Setup .NET SDK v7.0.3xx
-        if: matrix.framework == 'net461'
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 7.0.3xx
       - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:
@@ -115,14 +110,6 @@ jobs:
 
           unzip consul.zip
           rm consul.zip
-
-      # TODO: Workaround for the https://github.com/microsoft/vstest/issues/4549
-      # use dotnet-version: 7.0.x when the 7.0.401+ is avaialble
-      - name: Workaround for the https://github.com/microsoft/vstest/issues/4549 (net461&7.0.400)
-        if: matrix.framework == 'net461'
-        shell: bash
-        run: |
-          dotnet new globaljson --sdk-version 7.0.300 --roll-forward=latestPatch --force
 
       - name: Build
         run: dotnet build Consul.Test --configuration=Release --framework=${{ matrix.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,26 +31,26 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        framework: [net5.0, net6.0, net7.0]
+        framework: [net6.0, net7.0, net8.0]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup .NET SDK v5.0.x
-        if: matrix.framework == 'net5.0'
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 5.0.x
       - name: Setup .NET SDK v6.0.x
         if: matrix.framework == 'net6.0'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
       - name: Setup .NET SDK v7.0.x
+        if: matrix.framework == 'net7.0'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
+      - name: Setup .NET SDK v8.0.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
       - name: Build
         run: dotnet build Consul.AspNetCore.Test --configuration=Release --framework=${{ matrix.framework }}
       - name: Run tests
@@ -61,29 +61,27 @@ jobs:
     strategy:
       matrix:
         consul: [1.6.10, 1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.0]
-        framework: [net461, net5.0, net6.0, net7.0]
+        framework: [net461, net6.0, net7.0, net8.0]
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup .NET SDK v5.0.x
-        if: matrix.framework == 'net5.0'
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 5.0.x
       - name: Setup .NET SDK v6.0.x
         if: matrix.framework == 'net6.0'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
       - name: Setup .NET SDK v7.0.x
+        if: matrix.framework == 'net7.0'
         uses: actions/setup-dotnet@v4
         with:
-          # TODO: Workaround for the https://github.com/microsoft/vstest/issues/4549
-          # use dotnet-version: 7.0.x when the 7.0.401+ is avaialble
-          dotnet-version: 7.0.307
+          dotnet-version: 7.0.x
+      - name: Setup .NET SDK v8.0.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
       - name: Setup Consul Enterprise URL
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.
@@ -145,10 +143,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup .NET SDK v7.0.x
+      - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - name: Create NuGet packages
         run: |
           if (-not ("${{ github.ref }}" -like "refs/tags/v*")) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,11 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
-      - name: Setup .NET SDK v7.0.300
+      - name: Setup .NET SDK v7.0.30x
         if: matrix.framework == 'net461'
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.300
+          dotnet-version: 7.0.30x
       - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,11 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
+      - name: Setup .NET SDK v7.0.300
+        if: matrix.framework == 'net461'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 7.0.300
       - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog 
+# Changelog
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changelog 
 
 ## Unreleased
 

--- a/Consul.AspNetCore.Test/Consul.AspNetCore.Test.csproj
+++ b/Consul.AspNetCore.Test/Consul.AspNetCore.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 

--- a/Consul.Test/Consul.Test.csproj
+++ b/Consul.Test/Consul.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;net7.0;net8.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <CopyLocalLockFileAssemblies Condition="'$(TargetFramework)' == 'netcoreapp2.1'">true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "7.0.100",
+      "version": "8.0.100",
       "rollForward": "latestMinor"
     }
   }


### PR DESCRIPTION
Since `net5.0` is long out of support and the `macos-latest` now points to arm64 macos runners, which only support .NET 6 and above, we fix it by:
- removing tests for `net5.0` and adding `net8.0` instead
- removing workaround for `net461` (workaround is not needed anymore)