### PR TITLE
CI: Fix warnings & deprecation messages in the workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,8 +1,0 @@
----
-version: 2
-
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -6,7 +6,6 @@ on:
     types: [completed]
     branches: [master]
 
-
 jobs:
   nudge:
     runs-on: ubuntu-latest

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -6,6 +6,7 @@ on:
     types: [completed]
     branches: [master]
 
+
 jobs:
   nudge:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-consul-versions.yml
+++ b/.github/workflows/update-consul-versions.yml
@@ -1,14 +1,15 @@
 name: "Update Consul versions"
 
 on:
-  schedule:
-    - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
+  pull_request:
+  # schedule:
+  #   - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
 
 jobs:
   update-consul-versions:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
-    if: github.repository == 'G-Research/consuldotnet'
+    # if: github.repository == 'G-Research/consuldotnet'
     environment: update-consul-versions
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +31,7 @@ jobs:
           installation_id=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $jwt" https://api.github.com/app/installations | jq '.[] | select(.account.login == "${{ github.repository_owner }}") | .id')
           token=$(curl -s -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer $jwt" https://api.github.com/app/installations/$installation_id/access_tokens | jq -r '.token')
           echo "::add-mask::$token"
-          echo "::set-output name=token::$token"
+          echo "token=$token" >> $GITHUB_OUTPUT
 
       - name: Install PowerShellForGitHub
         shell: pwsh

--- a/.github/workflows/update-consul-versions.yml
+++ b/.github/workflows/update-consul-versions.yml
@@ -1,15 +1,14 @@
 name: "Update Consul versions"
 
 on:
-  pull_request:
-  # schedule:
-  #   - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
+  schedule:
+    - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
 
 jobs:
   update-consul-versions:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
-    # if: github.repository == 'G-Research/consuldotnet'
+    if: github.repository == 'G-Research/consuldotnet'
     environment: update-consul-versions
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
#### What type of PR is this?

CI: Resolve deprecation & warning messages in workflows 
Enable DependaBot for GitHub actions

#### What this PR does / why we need it:

Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) 

- Remove `dependabot.yaml` as `dependabot.yml` is only one needed 
- Bump the steps where deprecation/warnings are shown in the job
- Fix `set-output` warnings in workflows 

__Optional__

- Resolve on upstream or find alternative for `technote-space/create-pr-action@v2` used in [Update consul versions](https://github.com/G-Research/consuldotnet/actions/runs/8197862332) workflow


#### Which issue(s) this PR fixes:

https://github.com/G-Research/gr-oss/issues/636

------------

# Testing results

**CI**
 - no change

**CodeQL**
 - no change

**Format**
 - no change

**Nudge**
 - https://github.com/gr-oss-devops/consuldotnet/actions/runs/9029288911

**Deploy website**
 - no change

**Update consul versions** 
 - https://github.com/gr-oss-devops/consuldotnet/actions/runs/9000614756
 - __NOTE__: `technote-space/create-pr-action@v2` action is still on Node16, this should be migrated or contributing on the upstream of the action
