### PR TITLE
[CI] Enable manual CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
   pull_request:
+  # Allow manual runs. It is necessary to run the workflow manually, when the "formatter" workflow applies any changes.
+  workflow_dispatch:
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true


### PR DESCRIPTION
We have a "formatter" workflow that applies automatic code changes. The downside of applying automatic code changes is that they do not trigger other workflows (e.g., the "CI" workflow). To work around this problem, we can enable manual workflow runs.