### PR TITLE
Fixing flaky Health_Connect test

### DIFF
--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -85,10 +85,10 @@ namespace Consul.Test
                 Name = svcID,
                 Port = 8000,
                 TaggedAddresses = new Dictionary<string, ServiceTaggedAddress>
-                {
-                    { "lan", new ServiceTaggedAddress { Address = "127.0.0.1", Port = 80 } },
-                    { "wan", new ServiceTaggedAddress { Address = "192.168.10.10", Port = 8000 } }
-                }
+                    {
+                        {"lan", new ServiceTaggedAddress {Address = "127.0.0.1", Port = 80}},
+                        {"wan", new ServiceTaggedAddress {Address = "192.168.10.10", Port = 8000}}
+                    }
             };
 
             await _client.Agent.ServiceRegister(registration);
@@ -117,27 +117,7 @@ namespace Consul.Test
             public string Name;
             public List<HealthCheck> Checks;
             public HealthStatus Expected;
-        }
 
-        public class RepeatAttribute : DataAttribute
-        {
-            private readonly int _count;
-
-            public RepeatAttribute(int count)
-            {
-                if (count < 1)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(count),
-                        "Repeat count must be greater than 0.");
-                }
-
-                _count = count;
-            }
-
-            public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-            {
-                return Enumerable.Range(0, _count).Select(x => new object[] { x });
-            }
         }
 
         [Fact]
@@ -183,7 +163,7 @@ namespace Consul.Test
         {
             var cases = new List<AggregatedStatusResult>()
             {
-                new AggregatedStatusResult() { Name = "empty", Expected = HealthStatus.Passing, Checks = null },
+                new AggregatedStatusResult() {Name="empty", Expected=HealthStatus.Passing, Checks = null},
                 new AggregatedStatusResult() {Name="passing", Expected=HealthStatus.Passing, Checks = new List<HealthCheck>()
                 {
                     new HealthCheck() {Status = HealthStatus.Passing }

--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -205,30 +205,30 @@ namespace Consul.Test
                     new HealthCheck() { CheckID=HealthStatus.ServiceMaintenancePrefix + "service"}
                 }},
                 new AggregatedStatusResult() {Name="unknown", Expected=HealthStatus.Passing, Checks = new List<HealthCheck>()
-                        {
+                {
                     new HealthCheck() { Status = HealthStatus.Any}
                 }},
                 new AggregatedStatusResult() {Name="maintenance_over_critical", Expected=HealthStatus.Maintenance, Checks = new List<HealthCheck>()
-                        {
-                            new HealthCheck() { CheckID = HealthStatus.NodeMaintenance },
-                            new HealthCheck() { Status = HealthStatus.Critical }
+                {
+                    new HealthCheck() { CheckID=HealthStatus.NodeMaintenance },
+                    new HealthCheck() {Status = HealthStatus.Critical }
                 }},
                 new AggregatedStatusResult() {Name="critical_over_warning", Expected=HealthStatus.Critical, Checks = new List<HealthCheck>()
-                        {
-                            new HealthCheck() { Status = HealthStatus.Critical },
-                            new HealthCheck() { Status = HealthStatus.Warning }
+                {
+                    new HealthCheck() {Status = HealthStatus.Critical },
+                    new HealthCheck() {Status = HealthStatus.Warning }
                 }},
                 new AggregatedStatusResult() {Name="warning_over_passing", Expected=HealthStatus.Warning, Checks = new List<HealthCheck>()
-                        {
-                            new HealthCheck() { Status = HealthStatus.Warning },
-                            new HealthCheck() { Status = HealthStatus.Passing }
+                {
+                    new HealthCheck() {Status = HealthStatus.Warning },
+                    new HealthCheck() {Status = HealthStatus.Passing }
                 }},
                 new AggregatedStatusResult() {Name="lots", Expected=HealthStatus.Warning, Checks = new List<HealthCheck>()
-                    {
-                        new HealthCheck() { Status = HealthStatus.Passing },
-                        new HealthCheck() { Status = HealthStatus.Passing },
-                        new HealthCheck() { Status = HealthStatus.Warning },
-                        new HealthCheck() { Status = HealthStatus.Passing }
+                {
+                    new HealthCheck() {Status = HealthStatus.Passing },
+                    new HealthCheck() {Status = HealthStatus.Passing },
+                    new HealthCheck() {Status = HealthStatus.Warning },
+                    new HealthCheck() {Status = HealthStatus.Passing }
                 }}
             };
             foreach (var test_case in cases)

--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -180,7 +180,7 @@ namespace Consul.Test
                         null); // Passing null for the filter parameter
                     Assert.Equal(HttpStatusCode.OK, checks.StatusCode);
                     lastIndex = checks.LastIndex;
-                } while (checks.Response.Any());
+                } while (!checks.Response.Any());
 
                 Assert.NotEmpty(checks.Response);
             }

--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -140,7 +140,7 @@ namespace Consul.Test
                 ulong lastIndex = 0;
                 do
                 {
-                    var q = new QueryOptions { WaitIndex = lastIndex};
+                    var q = new QueryOptions { WaitIndex = lastIndex };
                     // Use the Health.Connect method to query health information for Connect-enabled services
                     checks = await _client.Health.Connect(destinationServiceID, "", false, q, null,
                         new CancellationTokenSource(TimeSpan.FromMinutes(1)).Token);

--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -21,10 +21,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Consul.Test
 {

--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -140,7 +140,7 @@ namespace Consul.Test
                 ulong lastIndex = 0;
                 do
                 {
-                    var q = new QueryOptions { WaitIndex = lastIndex };
+                    var q = new QueryOptions { WaitIndex = lastIndex, };
                     // Use the Health.Connect method to query health information for Connect-enabled services
                     checks = await _client.Health.Connect(destinationServiceID, "", false, q, null,
                         new CancellationTokenSource(TimeSpan.FromMinutes(1)).Token);

--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -23,7 +23,6 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
-using Consul.Filtering;
 using Xunit;
 using Xunit.Sdk;
 
@@ -86,10 +85,10 @@ namespace Consul.Test
                 Name = svcID,
                 Port = 8000,
                 TaggedAddresses = new Dictionary<string, ServiceTaggedAddress>
-                    {
-                        {"lan", new ServiceTaggedAddress {Address = "127.0.0.1", Port = 80}},
-                        {"wan", new ServiceTaggedAddress {Address = "192.168.10.10", Port = 8000}}
-                    }
+                {
+                    { "lan", new ServiceTaggedAddress { Address = "127.0.0.1", Port = 80 } },
+                    { "wan", new ServiceTaggedAddress { Address = "192.168.10.10", Port = 8000 } }
+                }
             };
 
             await _client.Agent.ServiceRegister(registration);
@@ -118,7 +117,6 @@ namespace Consul.Test
             public string Name;
             public List<HealthCheck> Checks;
             public HealthStatus Expected;
-
         }
 
         public class RepeatAttribute : DataAttribute
@@ -132,6 +130,7 @@ namespace Consul.Test
                     throw new ArgumentOutOfRangeException(nameof(count),
                         "Repeat count must be greater than 0.");
                 }
+
                 _count = count;
             }
 
@@ -142,8 +141,6 @@ namespace Consul.Test
         }
 
         [Fact]
-        [Repeat(100)]
-        #pragma warning disable xUnit1005
         public async Task Health_Connect()
         {
             var destinationServiceID = KVTest.GenerateTestKeyName();
@@ -153,17 +150,8 @@ namespace Consul.Test
                 ID = destinationServiceID,
                 Name = destinationServiceID,
                 Port = 8000,
-                Check = new AgentServiceCheck
-                {
-                    TTL = TimeSpan.FromSeconds(15)
-                },
-                Connect = new AgentServiceConnect
-                {
-                    SidecarService = new AgentServiceRegistration
-                    {
-                        Port = 8001
-                    }
-                }
+                Check = new AgentServiceCheck { TTL = TimeSpan.FromSeconds(15) },
+                Connect = new AgentServiceConnect { SidecarService = new AgentServiceRegistration { Port = 8001 } }
             };
 
             try
@@ -195,7 +183,7 @@ namespace Consul.Test
         {
             var cases = new List<AggregatedStatusResult>()
             {
-                new AggregatedStatusResult() {Name="empty", Expected=HealthStatus.Passing, Checks = null},
+                new AggregatedStatusResult() { Name = "empty", Expected = HealthStatus.Passing, Checks = null },
                 new AggregatedStatusResult() {Name="passing", Expected=HealthStatus.Passing, Checks = new List<HealthCheck>()
                 {
                     new HealthCheck() {Status = HealthStatus.Passing }
@@ -217,30 +205,30 @@ namespace Consul.Test
                     new HealthCheck() { CheckID=HealthStatus.ServiceMaintenancePrefix + "service"}
                 }},
                 new AggregatedStatusResult() {Name="unknown", Expected=HealthStatus.Passing, Checks = new List<HealthCheck>()
-                {
+                        {
                     new HealthCheck() { Status = HealthStatus.Any}
                 }},
                 new AggregatedStatusResult() {Name="maintenance_over_critical", Expected=HealthStatus.Maintenance, Checks = new List<HealthCheck>()
-                {
-                    new HealthCheck() { CheckID=HealthStatus.NodeMaintenance },
-                    new HealthCheck() {Status = HealthStatus.Critical }
+                        {
+                            new HealthCheck() { CheckID = HealthStatus.NodeMaintenance },
+                            new HealthCheck() { Status = HealthStatus.Critical }
                 }},
                 new AggregatedStatusResult() {Name="critical_over_warning", Expected=HealthStatus.Critical, Checks = new List<HealthCheck>()
-                {
-                    new HealthCheck() {Status = HealthStatus.Critical },
-                    new HealthCheck() {Status = HealthStatus.Warning }
+                        {
+                            new HealthCheck() { Status = HealthStatus.Critical },
+                            new HealthCheck() { Status = HealthStatus.Warning }
                 }},
                 new AggregatedStatusResult() {Name="warning_over_passing", Expected=HealthStatus.Warning, Checks = new List<HealthCheck>()
-                {
-                    new HealthCheck() {Status = HealthStatus.Warning },
-                    new HealthCheck() {Status = HealthStatus.Passing }
+                        {
+                            new HealthCheck() { Status = HealthStatus.Warning },
+                            new HealthCheck() { Status = HealthStatus.Passing }
                 }},
                 new AggregatedStatusResult() {Name="lots", Expected=HealthStatus.Warning, Checks = new List<HealthCheck>()
-                {
-                    new HealthCheck() {Status = HealthStatus.Passing },
-                    new HealthCheck() {Status = HealthStatus.Passing },
-                    new HealthCheck() {Status = HealthStatus.Warning },
-                    new HealthCheck() {Status = HealthStatus.Passing }
+                    {
+                        new HealthCheck() { Status = HealthStatus.Passing },
+                        new HealthCheck() { Status = HealthStatus.Passing },
+                        new HealthCheck() { Status = HealthStatus.Warning },
+                        new HealthCheck() { Status = HealthStatus.Passing }
                 }}
             };
             foreach (var test_case in cases)

--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -139,11 +140,10 @@ namespace Consul.Test
                 ulong lastIndex = 0;
                 do
                 {
-                    var q = new QueryOptions { WaitIndex = lastIndex, };
-
+                    var q = new QueryOptions { WaitIndex = lastIndex};
                     // Use the Health.Connect method to query health information for Connect-enabled services
-                    checks = await _client.Health.Connect(destinationServiceID, "", false, q,
-                        null); // Passing null for the filter parameter
+                    checks = await _client.Health.Connect(destinationServiceID, "", false, q, null,
+                        new CancellationTokenSource(TimeSpan.FromMinutes(1)).Token);
                     Assert.Equal(HttpStatusCode.OK, checks.StatusCode);
                     lastIndex = checks.LastIndex;
                 } while (!checks.Response.Any());

--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -150,7 +150,8 @@ namespace Consul.Test
                     lastIndex = checks.LastIndex;
                 } while (!checks.Response.Any());
 
-                Assert.NotEmpty(checks.Response);
+                Assert.Single(checks.Response);
+                Assert.Equal(registration.Connect.SidecarService.Port, checks.Response[0].Service.Port);
             }
             finally
             {

--- a/Consul.Test/HealthTest.cs
+++ b/Consul.Test/HealthTest.cs
@@ -145,6 +145,7 @@ namespace Consul.Test
                     checks = await _client.Health.Connect(destinationServiceID, "", false, q, null,
                         new CancellationTokenSource(TimeSpan.FromMinutes(1)).Token);
                     Assert.Equal(HttpStatusCode.OK, checks.StatusCode);
+                    Assert.True(checks.LastIndex > q.WaitIndex);
                     lastIndex = checks.LastIndex;
                 } while (!checks.Response.Any());
 


### PR DESCRIPTION
`Health_Connect` failed from time to time,
It seems that the "connect" related information is not immediately updated. Hence we need to refer to blocking queries (i.e. set the `waitindex >0`). 