### PR TITLE
Add GenerateDocumentationFile to make summaries show up in IDEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        consul: [1.6.10, 1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.1]
+        consul: [1.6.10, 1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2]
         framework: [net461, net6.0, net7.0, net8.0]
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
       fail-fast: false

--- a/Consul/ACL.cs
+++ b/Consul/ACL.cs
@@ -202,6 +202,7 @@ namespace Consul
         /// [Deprecated] Create is used to generate a new token with the given parameters
         /// </summary>
         /// <param name="acl">The ACL entry to create</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result containing the newly created ACL token</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
         public Task<WriteResult<string>> Create(ACLEntry acl, CancellationToken ct = default)
@@ -214,6 +215,7 @@ namespace Consul
         /// </summary>
         /// <param name="acl">The ACL entry to create</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result containing the newly created ACL token</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
         public async Task<WriteResult<string>> Create(ACLEntry acl, WriteOptions q, CancellationToken ct = default)
@@ -226,6 +228,7 @@ namespace Consul
         /// [Deprecated] Update is used to update the rules of an existing token
         /// </summary>
         /// <param name="acl">The ACL entry to update</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
         public Task<WriteResult> Update(ACLEntry acl, CancellationToken ct = default)
@@ -238,6 +241,7 @@ namespace Consul
         /// </summary>
         /// <param name="acl">The ACL entry to update</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
         public Task<WriteResult> Update(ACLEntry acl, WriteOptions q, CancellationToken ct = default)
@@ -249,6 +253,7 @@ namespace Consul
         /// [Deprecated] Destroy is used to destroy a given ACL token ID
         /// </summary>
         /// <param name="id">The ACL ID to destroy</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
         public Task<WriteResult<bool>> Destroy(string id, CancellationToken ct = default)
@@ -261,6 +266,7 @@ namespace Consul
         /// </summary>
         /// <param name="id">The ACL ID to destroy</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
         public Task<WriteResult<bool>> Destroy(string id, WriteOptions q, CancellationToken ct = default)
@@ -272,6 +278,7 @@ namespace Consul
         /// [Deprecated] Clone is used to return a new token cloned from an existing one
         /// </summary>
         /// <param name="id">The ACL ID to clone</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result containing the newly created ACL token</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
         public Task<WriteResult<string>> Clone(string id, CancellationToken ct = default)
@@ -284,6 +291,7 @@ namespace Consul
         /// </summary>
         /// <param name="id">The ACL ID to clone</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result containing the newly created ACL token</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
         public async Task<WriteResult<string>> Clone(string id, WriteOptions q, CancellationToken ct = default)
@@ -296,6 +304,7 @@ namespace Consul
         /// [Deprecated] Info is used to query for information about an ACL token
         /// </summary>
         /// <param name="id">The ACL ID to request information about</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing the ACL entry matching the provided ID, or a query result with a null response if no token matched the provided ID</returns>
         [Obsolete("The Legacy ACL system has been deprecated, please use Token, Role and Policy instead.")]
         public Task<QueryResult<ACLEntry>> Info(string id, CancellationToken ct = default)

--- a/Consul/Agent.cs
+++ b/Consul/Agent.cs
@@ -794,6 +794,7 @@ namespace Consul
         /// Checks returns the locally registered checks
         /// </summary>
         /// <param name="filter">Specifies the expression used to filter the queries results prior to returning the data</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A map of the registered check names and check data</returns>
         public Task<QueryResult<Dictionary<string, AgentCheck>>> Checks(Filter filter, CancellationToken ct = default)
         {
@@ -813,6 +814,7 @@ namespace Consul
         /// Services returns the locally registered services
         /// </summary>
         /// <param name="filter">Specifies the expression used to filter the queries results prior to returning the data</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A map of the registered services and service data</returns>
         public async Task<QueryResult<Dictionary<string, AgentService>>> Services(Filter filter, CancellationToken ct = default)
         {
@@ -837,6 +839,7 @@ namespace Consul
         /// ServiceRegister is used to register a new service with the local agent
         /// </summary>
         /// <param name="service">A service registration object</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> ServiceRegister(AgentServiceRegistration service, CancellationToken ct = default)
         {
@@ -848,6 +851,7 @@ namespace Consul
         /// </summary>
         /// <param name="service">A service registration object</param>
         /// <param name="replaceExistingChecks">Missing health checks from the request will be deleted from the agent.</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> ServiceRegister(AgentServiceRegistration service, bool replaceExistingChecks, CancellationToken ct = default)
         {
@@ -863,6 +867,7 @@ namespace Consul
         /// ServiceRegister is used to register a new service with the local agent
         /// </summary>
         /// <param name="serviceID">The service ID</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> ServiceDeregister(string serviceID, CancellationToken ct = default)
         {
@@ -874,6 +879,7 @@ namespace Consul
         /// </summary>
         /// <param name="checkID">The check ID</param>
         /// <param name="note">An optional, arbitrary string to write to the check status</param>
+        /// <param name="ct">The cancellation token</param>
         public Task PassTTL(string checkID, string note, CancellationToken ct = default)
         {
             return LegacyUpdateTTL(checkID, note, TTLStatus.Pass, ct);
@@ -884,6 +890,7 @@ namespace Consul
         /// </summary>
         /// <param name="checkID">The check ID</param>
         /// <param name="note">An optional, arbitrary string to write to the check status</param>
+        /// <param name="ct">The cancellation token</param>
         public Task WarnTTL(string checkID, string note, CancellationToken ct = default)
         {
             return LegacyUpdateTTL(checkID, note, TTLStatus.Warn, ct);
@@ -894,6 +901,7 @@ namespace Consul
         /// </summary>
         /// <param name="checkID">The check ID</param>
         /// <param name="note">An optional, arbitrary string to write to the check status</param>
+        /// <param name="ct">The cancellation token</param>
         public Task FailTTL(string checkID, string note, CancellationToken ct = default)
         {
             return LegacyUpdateTTL(checkID, note, TTLStatus.Critical, ct);
@@ -905,6 +913,7 @@ namespace Consul
         /// <param name="checkID">The check ID</param>
         /// <param name="output">An optional, arbitrary string to write to the check status</param>
         /// <param name="status">The state to set the check to</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> UpdateTTL(string checkID, string output, TTLStatus status, CancellationToken ct = default)
         {
@@ -922,6 +931,7 @@ namespace Consul
         /// <param name="checkID">The check ID</param>
         /// <param name="note">An optional, arbitrary string to note on the check status</param>
         /// <param name="status">The state to set the check to</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         private Task<WriteResult> LegacyUpdateTTL(string checkID, string note, TTLStatus status, CancellationToken ct = default)
         {
@@ -937,6 +947,7 @@ namespace Consul
         /// CheckRegister is used to register a new check with the local agent
         /// </summary>
         /// <param name="check">A check registration object</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> CheckRegister(AgentCheckRegistration check, CancellationToken ct = default)
         {
@@ -947,6 +958,7 @@ namespace Consul
         /// CheckDeregister is used to deregister a check with the local agent
         /// </summary>
         /// <param name="checkID">The check ID to deregister</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> CheckDeregister(string checkID, CancellationToken ct = default)
         {
@@ -958,6 +970,7 @@ namespace Consul
         /// </summary>
         /// <param name="addr">The address to join to</param>
         /// <param name="wan">Join the WAN pool</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> Join(string addr, bool wan, CancellationToken ct = default)
         {
@@ -973,6 +986,7 @@ namespace Consul
         /// ForceLeave is used to have the agent eject a failed node
         /// </summary>
         /// <param name="node">The node name to remove</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> ForceLeave(string node, CancellationToken ct = default)
         {
@@ -1001,6 +1015,7 @@ namespace Consul
         /// Reload triggers a configuration reload for the agent we are connected to.
         /// </summary>
         /// <param name="node">The node name to reload</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         [Obsolete]
         public Task<WriteResult> Reload(string node, CancellationToken ct = default)
@@ -1013,6 +1028,7 @@ namespace Consul
         /// </summary>
         /// <param name="serviceID">The service ID</param>
         /// <param name="reason">An optional reason</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> EnableServiceMaintenance(string serviceID, string reason, CancellationToken ct = default)
         {
@@ -1026,6 +1042,7 @@ namespace Consul
         /// DisableServiceMaintenance toggles service maintenance mode off for the given service ID
         /// </summary>
         /// <param name="serviceID">The service ID</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> DisableServiceMaintenance(string serviceID, CancellationToken ct = default)
         {
@@ -1038,6 +1055,7 @@ namespace Consul
         /// EnableNodeMaintenance toggles node maintenance mode on for the agent we are connected to
         /// </summary>
         /// <param name="reason">An optional reason</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> EnableNodeMaintenance(string reason, CancellationToken ct = default)
         {
@@ -1089,6 +1107,8 @@ namespace Consul
         /// GetLocalServiceHealth returns the health info of a service registered on the local agent
         /// </summary>
         /// <param name="serviceName">Name of service</param>
+        /// <param name="q"></param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An array containing the details of each passing, warning, or critical service</returns>
         public async Task<QueryResult<LocalServiceHealth[]>> GetLocalServiceHealth(string serviceName, QueryOptions q, CancellationToken ct = default)
         {
@@ -1099,6 +1119,7 @@ namespace Consul
         /// GetLocalServiceHealth returns the health info of a service registered on the local agent
         /// </summary>
         /// <param name="serviceName">Name of service</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An array containing the details of each passing, warning, or critical service</returns>
         public async Task<QueryResult<LocalServiceHealth[]>> GetLocalServiceHealth(string serviceName, CancellationToken ct = default)
         {
@@ -1109,6 +1130,8 @@ namespace Consul
         /// GetWorstLocalServiceHealth returns the worst aggregated status of a service registered on the local agent
         /// </summary>
         /// <param name="serviceName">Name of service</param>
+        /// <param name="q"></param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>passing, warning, or critical</returns>
         public async Task<QueryResult<string>> GetWorstLocalServiceHealth(string serviceName, QueryOptions q, CancellationToken ct = default)
         {
@@ -1121,6 +1144,7 @@ namespace Consul
         /// GetWorstLocalServiceHealth returns the worst aggregated status of a service registered on the local agent
         /// </summary>
         /// <param name="serviceName">Name of service</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>passing, warning, or critical</returns>
         public async Task<QueryResult<string>> GetWorstLocalServiceHealth(string serviceName, CancellationToken ct = default)
         {
@@ -1131,6 +1155,8 @@ namespace Consul
         /// GetLocalServiceHealthByID returns the health info of a service registered on the local agent by ID
         /// </summary>
         /// <param name="serviceID">ID of the service</param>
+        /// <param name="q"></param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An array containing the details of each passing, warning, or critical service</returns>
         public async Task<QueryResult<LocalServiceHealth>> GetLocalServiceHealthByID(string serviceID, QueryOptions q, CancellationToken ct = default)
         {
@@ -1141,6 +1167,7 @@ namespace Consul
         /// GetLocalServiceHealthByID returns the health info of a service registered on the local agent by ID
         /// </summary>
         /// <param name="serviceID">ID of the service</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An array containing the details of each passing, warning, or critical service</returns>
         public async Task<QueryResult<LocalServiceHealth>> GetLocalServiceHealthByID(string serviceID, CancellationToken ct = default)
         {
@@ -1150,7 +1177,7 @@ namespace Consul
         /// <summary>
         /// GetAgentHostInfo returns the host info of the agent
         /// </summary>
-        /// <param name="ct"></param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>Agent Host Information</returns>
         public async Task<QueryResult<AgentHostInfo>> GetAgentHostInfo(CancellationToken ct = default)
         {
@@ -1160,7 +1187,7 @@ namespace Consul
         /// <summary>
         /// GetAgentVersion returns the version of the agent
         /// </summary>
-        /// <param name="ct"></param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>Version of the agent</returns>
         public async Task<QueryResult<AgentVersion>> GetAgentVersion(CancellationToken ct = default)
         {
@@ -1301,7 +1328,7 @@ namespace Consul
         /// <summary>
         /// GetAgentMetrics returns the metrics of the local agent
         /// </summary>
-        /// <param name="ct"></param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>Metrics of the local agent</returns>
         public async Task<QueryResult<Metrics>> GetAgentMetrics(CancellationToken ct = default)
         {

--- a/Consul/Catalog.cs
+++ b/Consul/Catalog.cs
@@ -157,6 +157,7 @@ namespace Consul
         /// Register a new catalog item
         /// </summary>
         /// <param name="reg">A catalog registration</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> Register(CatalogRegistration reg, CancellationToken ct = default)
         {
@@ -168,6 +169,7 @@ namespace Consul
         /// </summary>
         /// <param name="reg">A catalog registration</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> Register(CatalogRegistration reg, WriteOptions q, CancellationToken ct = default)
         {
@@ -178,6 +180,7 @@ namespace Consul
         /// Deregister an existing catalog item
         /// </summary>
         /// <param name="reg">A catalog deregistration</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> Deregister(CatalogDeregistration reg, CancellationToken ct = default)
         {
@@ -189,6 +192,7 @@ namespace Consul
         /// </summary>
         /// <param name="reg">A catalog deregistration</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> Deregister(CatalogDeregistration reg, WriteOptions q, CancellationToken ct = default)
         {

--- a/Consul/Client_Request.cs
+++ b/Consul/Client_Request.cs
@@ -28,7 +28,9 @@ namespace Consul
     /// <summary>
     /// The consistency mode of a request.
     /// </summary>
-    /// <see cref="http://www.consul.io/docs/agent/http.html"/>
+    /// <remarks>
+    /// <seealso href="http://www.consul.io/docs/agent/http.html"/>
+    /// </remarks>
     public enum ConsistencyMode
     {
         /// <summary>

--- a/Consul/Configuration.cs
+++ b/Consul/Configuration.cs
@@ -18,7 +18,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Consul.Interfaces;
@@ -1677,6 +1676,7 @@ namespace Consul
         /// </summary>
         /// <param name="q">Write Options</param>
         /// <param name="configurationEntry">The configuration entry</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> ApplyConfig<TConfig>(WriteOptions q, TConfig configurationEntry, CancellationToken ct = default) where TConfig : IConfigurationEntry
         {
@@ -1688,6 +1688,7 @@ namespace Consul
         ///  This creates or updates the given config entry.
         /// </summary>
         /// <param name="configurationEntry">The configuration entry</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An empty write result</returns>
         public Task<WriteResult> ApplyConfig<TConfig>(TConfig configurationEntry, CancellationToken ct = default) where TConfig : IConfigurationEntry
         {
@@ -1750,7 +1751,6 @@ namespace Consul
         /// <summary>
         /// This Deletes the given config entry.
         /// </summary>
-        /// <typeparam name="TConfig"></typeparam>
         /// <param name="kind">The kind of config entry</param>
         /// <param name="name">The name of config entry</param>
         /// <param name="q">Write Options</param>
@@ -1765,7 +1765,6 @@ namespace Consul
         /// <summary>
         /// This Deletes the given config entry.
         /// </summary>
-        /// <typeparam name="TConfig"></typeparam>
         /// <param name="kind">The kind of config entry</param>
         /// <param name="name">The name of config entry</param>
         /// <param name="ct">Cancellation Token</param>

--- a/Consul/Coordinate.cs
+++ b/Consul/Coordinate.cs
@@ -84,6 +84,7 @@ namespace Consul
         /// Nodes is used to return the coordinates of all the nodes in the LAN pool.
         /// </summary>
         /// <param name="q">Customized query options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing coordinates of all the nodes in the LAN pool</returns>
         public Task<QueryResult<CoordinateEntry[]>> Nodes(QueryOptions q, CancellationToken ct = default)
         {
@@ -96,7 +97,7 @@ namespace Consul
         /// <param name="node">The node to query</param>"
         /// <param name="ct">The cancellation token</param>"
         /// <param name="q">Customized query options</param>"
-        /// <remarks>Node is used to return the coordinates of a given node in the LAN pool.</returns>
+        /// <returns>Node is used to return the coordinates of a given node in the LAN pool.</returns>
         public Task<QueryResult<CoordinateEntry[]>> Node(string node, QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<CoordinateEntry[]>(string.Format("/v1/coordinate/node/{0}", node), q).Execute(ct);

--- a/Consul/Event.cs
+++ b/Consul/Event.cs
@@ -65,6 +65,7 @@ namespace Consul
         /// </summary>
         /// <param name="ue">A User Event definition</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns></returns>
         public async Task<WriteResult<string>> Fire(UserEvent ue, WriteOptions q, CancellationToken ct = default)
         {
@@ -98,6 +99,7 @@ namespace Consul
         /// List is used to get the most recent events an agent has received. This list can be optionally filtered by the name. This endpoint supports quasi-blocking queries. The index is not monotonic, nor does it provide provide LastContact or KnownLeader.
         /// </summary>
         /// <param name="name">The name of the event to filter for</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An array of events</returns>
         public Task<QueryResult<UserEvent[]>> List(string name, CancellationToken ct = default)
         {

--- a/Consul/Health.cs
+++ b/Consul/Health.cs
@@ -189,6 +189,7 @@ namespace Consul
         /// Checks is used to return the checks associated with a service
         /// </summary>
         /// <param name="service">The service ID</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing the health checks matching the provided service ID, or a query result with a null response if no service matched the provided ID</returns>
         public Task<QueryResult<HealthCheck[]>> Checks(string service, CancellationToken ct = default)
         {
@@ -211,6 +212,7 @@ namespace Consul
         /// Node is used to query for checks belonging to a given node
         /// </summary>
         /// <param name="node">The node name</param>
+        /// <param name="ct">The cancellation token</param>"
         /// <returns>A query result containing the health checks matching the provided node ID, or a query result with a null response if no node matched the provided ID</returns>
         public Task<QueryResult<HealthCheck[]>> Node(string node, CancellationToken ct = default)
         {
@@ -233,6 +235,7 @@ namespace Consul
         /// Service is used to query health information along with service info for a given service. It can optionally do server-side filtering on a tag or nodes with passing health checks only.
         /// </summary>
         /// <param name="service">The service ID</param>
+        /// <param name="ct">The cancellation token</param>"
         /// <returns>A query result containing the service members matching the provided service ID, or a query result with a null response if no service members matched the filters provided</returns>
         public Task<QueryResult<ServiceEntry[]>> Service(string service, CancellationToken ct = default)
         {
@@ -244,6 +247,7 @@ namespace Consul
         /// </summary>
         /// <param name="service">The service ID</param>
         /// <param name="tag">The service member tag</param>
+        /// <param name="ct">The cancellation token</param>"
         /// <returns>A query result containing the service members matching the provided service ID and tag, or a query result with a null response if no service members matched the filters provided</returns>
         public Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, CancellationToken ct = default)
         {
@@ -256,6 +260,7 @@ namespace Consul
         /// <param name="service">The service ID</param>
         /// <param name="tag">The service member tag</param>
         /// <param name="passingOnly">Only return if the health check is in the Passing state</param>
+        /// <param name="ct">The cancellation token</param>"
         /// <returns>A query result containing the service members matching the provided service ID, tag, and health status, or a query result with a null response if no service members matched the filters provided</returns>
         public Task<QueryResult<ServiceEntry[]>> Service(string service, string tag, bool passingOnly, CancellationToken ct = default)
         {
@@ -302,6 +307,7 @@ namespace Consul
 
         /// <summary>
         /// Connect is equivalent to Service, except that it will only return services which are Connect-enabled
+        /// </summary>
         /// <param name="service">The service ID</param>
         /// <param name="tag">The service member tag</param>
         /// <param name="passingOnly">Only return if the health check is in the Passing state</param>
@@ -325,11 +331,11 @@ namespace Consul
 
         /// <summary>
         /// Service is used to query health information along with service info for a given service. It can optionally do server-side filtering on a tag or nodes with passing health checks only.
+        /// </summary>
         /// <param name="service">The service ID</param>
         /// <param name="tag">The service member tag</param>
         /// <param name="passingOnly">Only return if the health check is in the Passing state</param>
         /// <param name="q">Customized query options</param>
-        /// <param name="filter">Specifies the expression used to filter the queries results prior to returning the data</param>
         /// <param name="ct">Cancellation token for long poll request. If set, OperationCanceledException will be thrown if the request is cancelled before completing</param>
         /// <returns>This endpoint returns the nodes providing a Connect-capable service in a given datacenter, or a query result with a null response</returns>
         public Task<QueryResult<ServiceEntry[]>> Connect(string service, string tag, bool passingOnly, QueryOptions q, CancellationToken ct = default)
@@ -339,6 +345,7 @@ namespace Consul
 
         /// <summary>
         /// Ingress is equivalent to Service and Connect, except that it will only return ingress services
+        /// </summary>
         /// <param name="service">The service ID</param>
         /// <param name="tag">The service member tag</param>
         /// <param name="passingOnly">Only return if the health check is in the Passing state</param>
@@ -362,6 +369,7 @@ namespace Consul
 
         /// <summary>
         /// Ingress is equivalent to Service and Connect, except that it will only return ingress services
+        /// </summary>
         /// <param name="service">The service ID</param>
         /// <param name="tag">The service member tag</param>
         /// <param name="passingOnly">Only return if the health check is in the Passing state</param>
@@ -375,6 +383,7 @@ namespace Consul
 
         /// <summary>
         /// Ingress is equivalent to Service and Connect, except that it will only return ingress services
+        /// </summary>
         /// <param name="service">The service ID</param>
         /// <param name="tag">The service member tag</param>
         /// <param name="passingOnly">Only return if the health check is in the Passing state</param>
@@ -389,6 +398,7 @@ namespace Consul
         /// State is used to retrieve all the checks in a given state. The wildcard "any" state can also be used for all checks.
         /// </summary>
         /// <param name="status">The health status to filter for</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing a list of health checks in the specified state, or a query result with a null response if no health checks matched the provided state</returns>
         public Task<QueryResult<HealthCheck[]>> State(HealthStatus status, CancellationToken ct = default)
         {

--- a/Consul/KV.cs
+++ b/Consul/KV.cs
@@ -252,6 +252,7 @@ namespace Consul
         /// Acquire is used for a lock acquisition operation. The Key, Flags, Value and Session are respected.
         /// </summary>p.Validate();
         /// <param name="p">The key/value pair to store in Consul</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the acquisition attempt succeeded</returns>
         public Task<WriteResult<bool>> Acquire(KVPair p, CancellationToken ct = default)
         {
@@ -263,6 +264,7 @@ namespace Consul
         /// </summary>
         /// <param name="p">The key/value pair to store in Consul</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the acquisition attempt succeeded</returns>
         public Task<WriteResult<bool>> Acquire(KVPair p, WriteOptions q, CancellationToken ct = default)
         {
@@ -280,6 +282,7 @@ namespace Consul
         /// CAS is used for a Check-And-Set operation. The Key, ModifyIndex, Flags and Value are respected. Returns true on success or false on failures.
         /// </summary>
         /// <param name="p">The key/value pair to store in Consul</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the write attempt succeeded</returns>
         public Task<WriteResult<bool>> CAS(KVPair p, CancellationToken ct = default)
         {
@@ -291,6 +294,7 @@ namespace Consul
         /// </summary>
         /// <param name="p">The key/value pair to store in Consul</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the write attempt succeeded</returns>
         public Task<WriteResult<bool>> CAS(KVPair p, WriteOptions q, CancellationToken ct = default)
         {
@@ -308,6 +312,7 @@ namespace Consul
         /// Delete is used to delete a single key.
         /// </summary>
         /// <param name="key">The key name to delete</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the delete attempt succeeded</returns>
         public Task<WriteResult<bool>> Delete(string key, CancellationToken ct = default)
         {
@@ -319,6 +324,7 @@ namespace Consul
         /// </summary>
         /// <param name="key">The key name to delete</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the delete attempt succeeded</returns>
         public Task<WriteResult<bool>> Delete(string key, WriteOptions q, CancellationToken ct = default)
         {
@@ -330,6 +336,7 @@ namespace Consul
         /// DeleteCAS is used for a Delete Check-And-Set operation. The Key and ModifyIndex are respected. Returns true on success or false on failures.
         /// </summary>
         /// <param name="p">The key/value pair to delete</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the delete attempt succeeded</returns>
         public Task<WriteResult<bool>> DeleteCAS(KVPair p, CancellationToken ct = default)
         {
@@ -341,6 +348,7 @@ namespace Consul
         /// </summary>
         /// <param name="p">The key/value pair to delete</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the delete attempt succeeded</returns>
         public Task<WriteResult<bool>> DeleteCAS(KVPair p, WriteOptions q, CancellationToken ct = default)
         {
@@ -354,6 +362,7 @@ namespace Consul
         /// DeleteTree is used to delete all keys under a prefix
         /// </summary>
         /// <param name="prefix">The key prefix to delete from</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the recursive delete attempt succeeded</returns>
         public Task<WriteResult<bool>> DeleteTree(string prefix, CancellationToken ct = default)
         {
@@ -365,6 +374,7 @@ namespace Consul
         /// </summary>
         /// <param name="prefix">The key prefix to delete from</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the recursiv edelete attempt succeeded</returns>
         public Task<WriteResult<bool>> DeleteTree(string prefix, WriteOptions q, CancellationToken ct = default)
         {
@@ -378,6 +388,7 @@ namespace Consul
         /// Get is used to lookup a single key
         /// </summary>
         /// <param name="key">The key name</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing the requested key/value pair, or a query result with a null response if the key does not exist</returns>
         public Task<QueryResult<KVPair>> Get(string key, CancellationToken ct = default)
         {
@@ -402,6 +413,7 @@ namespace Consul
         /// Keys is used to list all the keys under a prefix.
         /// </summary>
         /// <param name="prefix">The key prefix to filter on</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing a list of key names</returns>
         public Task<QueryResult<string[]>> Keys(string prefix, CancellationToken ct = default)
         {
@@ -413,6 +425,7 @@ namespace Consul
         /// </summary>
         /// <param name="prefix">The key prefix to filter on</param>
         /// <param name="separator">The terminating suffix of the filter - e.g. a separator of "/" and a prefix of "/web/" will match "/web/foo" and "/web/foo/" but not "/web/foo/baz"</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing a list of key names</returns>
         public Task<QueryResult<string[]>> Keys(string prefix, string separator, CancellationToken ct = default)
         {
@@ -442,6 +455,7 @@ namespace Consul
         /// List is used to lookup all keys under a prefix
         /// </summary>
         /// <param name="prefix">The prefix to search under. Does not have to be a full path - e.g. a prefix of "ab" will find keys "abcd" and "ab11" but not "acdc"</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing the keys matching the prefix</returns>
         public Task<QueryResult<KVPair[]>> List(string prefix, CancellationToken ct = default)
         {
@@ -466,6 +480,7 @@ namespace Consul
         /// Put is used to write a new value. Only the Key, Flags and Value properties are respected.
         /// </summary>
         /// <param name="p">The key/value pair to store in Consul</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the write attempt succeeded</returns>
         public Task<WriteResult<bool>> Put(KVPair p, CancellationToken ct = default)
         {
@@ -477,6 +492,7 @@ namespace Consul
         /// </summary>
         /// <param name="p">The key/value pair to store in Consul</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the write attempt succeeded</returns>
         public Task<WriteResult<bool>> Put(KVPair p, WriteOptions q, CancellationToken ct = default)
         {
@@ -493,6 +509,7 @@ namespace Consul
         /// Release is used for a lock release operation. The Key, Flags, Value and Session are respected.
         /// </summary>
         /// <param name="p">The key/value pair to store in Consul</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the release attempt succeeded</returns>
         public Task<WriteResult<bool>> Release(KVPair p, CancellationToken ct = default)
         {
@@ -504,6 +521,7 @@ namespace Consul
         /// </summary>
         /// <param name="p">The key/value pair to store in Consul</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result indicating if the release attempt succeeded</returns>
         public Task<WriteResult<bool>> Release(KVPair p, WriteOptions q, CancellationToken ct = default)
         {

--- a/Consul/Lock.cs
+++ b/Consul/Lock.cs
@@ -612,9 +612,9 @@ namespace Consul
         public TimeSpan MonitorRetryTime { get; set; }
 
         /// <summary>
-        /// When set to false, <see cref="Lock.Acquire"/> will block forever until the lock is acquired. LockWaitTime is ignored in this case.
+        /// When set to false, <see cref="Lock.Acquire()"/> will block forever until the lock is acquired. LockWaitTime is ignored in this case.
         /// <br/>
-        /// When set to true, <see cref="Lock.Acquire"/> the lock within a timestamp (It is analogous to <c>SemaphoreSlim.Wait(Timespan timeout)</c>.
+        /// When set to true, <see cref="Lock.Acquire()"/> the lock within a timestamp (It is analogous to <c>SemaphoreSlim.Wait(Timespan timeout)</c>.
         /// Under the hood, it attempts to acquire the lock multiple times if needed (due to the HTTP Long Poll returning early),
         /// and will do so as many times as it can within the bounds set by LockWaitTime.
         /// If LockWaitTime is set to 0, there will be only single attempt to acquire the lock.
@@ -666,7 +666,7 @@ namespace Consul
         /// AcquireLock creates a lock that is already acquired when this call returns.
         /// </summary>
         /// <param name="key"></param>
-        /// <param name="ct"></param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns></returns>
         public Task<IDistributedLock> AcquireLock(string key, CancellationToken ct = default)
         {
@@ -681,7 +681,7 @@ namespace Consul
         /// AcquireLock creates a lock that is already acquired when this call returns.
         /// </summary>
         /// <param name="opts"></param>
-        /// <param name="ct"></param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns></returns>
         public async Task<IDistributedLock> AcquireLock(LockOptions opts, CancellationToken ct = default)
         {
@@ -700,6 +700,7 @@ namespace Consul
         /// </summary>
         /// <param name="key"></param>
         /// <param name="action"></param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns></returns>
         public Task ExecuteLocked(string key, Action action, CancellationToken ct = default)
         {
@@ -715,6 +716,7 @@ namespace Consul
         /// </summary>
         /// <param name="opts"></param>
         /// <param name="action"></param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns></returns>
         public async Task ExecuteLocked(LockOptions opts, Action action, CancellationToken ct = default)
         {
@@ -747,7 +749,7 @@ namespace Consul
         /// ExecuteLock accepts a delegate to execute in the context of a lock, releasing the lock when completed.
         /// </summary>
         /// <param name="key"></param>
-        /// <param name="ct"></param>
+        /// <param name="ct">The cancellation token</param>
         /// <param name="action"></param>
         /// <returns></returns>
         [Obsolete("This method will be removed in a future release. Replace calls with the method signature ExecuteLocked(string, Action, CancellationToken)")]
@@ -768,7 +770,7 @@ namespace Consul
         /// ExecuteLock accepts a delegate to execute in the context of a lock, releasing the lock when completed.
         /// </summary>
         /// <param name="opts"></param>
-        /// <param name="ct"></param>
+        /// <param name="ct">The cancellation token</param>
         /// <param name="action"></param>
         /// <returns></returns>
         [Obsolete("This method will be removed in a future release. Replace calls with the method signature ExecuteLocked(LockOptions, Action, CancellationToken)")]

--- a/Consul/Raw.cs
+++ b/Consul/Raw.cs
@@ -52,6 +52,7 @@ namespace Consul
         /// <param name="endpoint">The URL endpoint to access</param>
         /// <param name="obj">The object to serialize and send to the endpoint. Must be able to be JSON serialized, or be an object of type byte[], which is sent without serialzation.</param>
         /// <param name="q">Custom write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>The data returned by the custom endpoint in response to the write request</returns>
         public Task<WriteResult<dynamic>> Write(string endpoint, object obj, WriteOptions q, CancellationToken ct = default)
         {

--- a/Consul/Session.cs
+++ b/Consul/Session.cs
@@ -261,7 +261,7 @@ namespace Consul
         /// <summary>
         /// Create makes a new session. Providing a session entry can customize the session. It can also be null to use defaults.
         /// </summary>
-        /// <param name="se">The SessionEntry options to use</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result containing the new session ID</returns>
 
         public Task<WriteResult<string>> Create(CancellationToken ct = default)
@@ -283,6 +283,7 @@ namespace Consul
         /// </summary>
         /// <param name="se">The SessionEntry options to use</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result containing the new session ID</returns>
         public async Task<WriteResult<string>> Create(SessionEntry se, WriteOptions q, CancellationToken ct = default)
         {
@@ -301,6 +302,7 @@ namespace Consul
         /// CreateNoChecks is like Create but is used specifically to create a session with no associated health checks.
         /// </summary>
         /// <param name="se">The SessionEntry options to use</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result containing the new session ID</returns>
         public Task<WriteResult<string>> CreateNoChecks(SessionEntry se, CancellationToken ct = default)
         {
@@ -312,6 +314,7 @@ namespace Consul
         /// </summary>
         /// <param name="se">The SessionEntry options to use</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result containing the new session ID</returns>
         public Task<WriteResult<string>> CreateNoChecks(SessionEntry se, WriteOptions q, CancellationToken ct = default)
         {
@@ -335,6 +338,7 @@ namespace Consul
         /// Destroy invalidates a given session
         /// </summary>
         /// <param name="id">The session ID to destroy</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result containing the result of the session destruction</returns>
         public Task<WriteResult<bool>> Destroy(string id, CancellationToken ct = default)
         {
@@ -346,6 +350,7 @@ namespace Consul
         /// </summary>
         /// <param name="id">The session ID to destroy</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A write result containing the result of the session destruction</returns>
         public Task<WriteResult<bool>> Destroy(string id, WriteOptions q, CancellationToken ct = default)
         {
@@ -356,6 +361,7 @@ namespace Consul
         /// Info looks up a single session
         /// </summary>
         /// <param name="id">The session ID to look up</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing the session information, or an empty query result if the session entry does not exist</returns>
         public Task<QueryResult<SessionEntry>> Info(string id, CancellationToken ct = default)
         {
@@ -367,6 +373,7 @@ namespace Consul
         /// </summary>
         /// <param name="id">The session ID to look up</param>
         /// <param name="q">Customized query options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing the session information, or an empty query result if the session entry does not exist</returns>
         public async Task<QueryResult<SessionEntry>> Info(string id, QueryOptions q, CancellationToken ct = default)
         {
@@ -387,6 +394,7 @@ namespace Consul
         /// List gets all active sessions
         /// </summary>
         /// <param name="q">Customized query options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing the list of sessions, or an empty query result if no sessions exist</returns>
         public Task<QueryResult<SessionEntry[]>> List(QueryOptions q, CancellationToken ct = default)
         {
@@ -397,6 +405,7 @@ namespace Consul
         /// Node gets all sessions for a node
         /// </summary>
         /// <param name="node">The node ID</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing the list of sessions, or an empty query result if no sessions exist</returns>
         public Task<QueryResult<SessionEntry[]>> Node(string node, CancellationToken ct = default)
         {
@@ -408,6 +417,7 @@ namespace Consul
         /// </summary>
         /// <param name="node">The node ID</param>
         /// <param name="q">Customized query options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>A query result containing the list of sessions, or an empty query result if no sessions exist</returns>
         public Task<QueryResult<SessionEntry[]>> Node(string node, QueryOptions q, CancellationToken ct = default)
         {
@@ -418,6 +428,7 @@ namespace Consul
         /// Renew renews the TTL on a given session
         /// </summary>
         /// <param name="id">The session ID to renew</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An updated session entry</returns>
         public Task<WriteResult<SessionEntry>> Renew(string id, CancellationToken ct = default)
         {
@@ -429,6 +440,7 @@ namespace Consul
         /// </summary>
         /// <param name="id">The session ID to renew</param>
         /// <param name="q">Customized write options</param>
+        /// <param name="ct">The cancellation token</param>
         /// <returns>An updated session entry</returns>
         public async Task<WriteResult<SessionEntry>> Renew(string id, WriteOptions q, CancellationToken ct = default)
         {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,5 +16,6 @@
     <SignAssembly>true</SignAssembly>
     <Copyright>Copyright 2020-$([System.DateTime]::Now.ToString('yyyy')) G-Research Limited</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,5 +15,6 @@
     <AssemblyOriginatorKeyFile>../assets/consuldotnet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <Copyright>Copyright 2020-$([System.DateTime]::Now.ToString('yyyy')) G-Research Limited</Copyright>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
     <SignAssembly>true</SignAssembly>
     <Copyright>Copyright 2020-$([System.DateTime]::Now.ToString('yyyy')) G-Research Limited</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Without `GenerateDocumentationFile` set to true, your great code summaries never make it to the developer using the nuget.