### PR TITLE
feat: add support for explain prepared query API endpoint

### DIFF
--- a/Consul.Test/PreparedQueryTest.cs
+++ b/Consul.Test/PreparedQueryTest.cs
@@ -109,6 +109,19 @@ namespace Consul.Test
             Assert.True(nodes.Length == 1);
             Assert.Equal("foobaz", results.Nodes[0].Node.Name);
 
+            var query = (await _client.PreparedQuery.Explain(id)).Response.Query;
+
+            Assert.NotNull(query);
+            Assert.True(query.Name == "my-query");
+            Assert.True(query.Service.OnlyPassing == true);
+
+            query = null;
+            query = (await _client.PreparedQuery.Explain("my-query")).Response.Query;
+
+            Assert.NotNull(query);
+            Assert.True(query.Name == "my-query");
+            Assert.True(query.Service.OnlyPassing == true);
+
             await _client.PreparedQuery.Delete(id);
 
             defs = null;

--- a/Consul.Test/PreparedQueryTest.cs
+++ b/Consul.Test/PreparedQueryTest.cs
@@ -76,7 +76,6 @@ namespace Consul.Test
             Assert.True(defs.Length == 1);
             Assert.Equal(def.Service.Service, defs[0].Service.Service);
 
-            defs = null;
             defs = (await _client.PreparedQuery.List(mgmtquerytoken)).Response;
 
             Assert.NotNull(defs);
@@ -87,7 +86,6 @@ namespace Consul.Test
 
             await _client.PreparedQuery.Update(def);
 
-            defs = null;
             defs = (await _client.PreparedQuery.Get(id)).Response;
 
             Assert.NotNull(defs);
@@ -101,7 +99,6 @@ namespace Consul.Test
             Assert.True(nodes.Length == 1);
             Assert.Equal("foobaz", nodes[0].Node.Name);
 
-            results = null;
             results = (await _client.PreparedQuery.Execute("my-query")).Response;
 
             Assert.NotNull(results);
@@ -115,7 +112,6 @@ namespace Consul.Test
             Assert.True(query.Name == "my-query");
             Assert.True(query.Service.OnlyPassing == true);
 
-            query = null;
             query = (await _client.PreparedQuery.Explain("my-query")).Response.Query;
 
             Assert.NotNull(query);
@@ -124,7 +120,6 @@ namespace Consul.Test
 
             await _client.PreparedQuery.Delete(id);
 
-            defs = null;
             defs = (await _client.PreparedQuery.List(mgmtquerytoken)).Response;
 
             Assert.True(defs.Length == 0);

--- a/Consul/Interfaces/IPreparedQueryEndpoint.cs
+++ b/Consul/Interfaces/IPreparedQueryEndpoint.cs
@@ -41,5 +41,7 @@ namespace Consul
         Task<QueryResult<PreparedQueryExecuteResponse>> Execute(string queryIDOrName, CancellationToken ct = default);
         Task<QueryResult<PreparedQueryExecuteResponse>> Execute(string queryIDOrName, QueryOptions q, CancellationToken ct = default);
         Task<QueryResult<PreparedQueryExplainResponse>> Explain(string queryIDOrName, QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<PreparedQueryExplainResponse>> Explain(string queryIDOrName, CancellationToken ct = default);
+
     }
 }

--- a/Consul/Interfaces/IPreparedQueryEndpoint.cs
+++ b/Consul/Interfaces/IPreparedQueryEndpoint.cs
@@ -40,5 +40,6 @@ namespace Consul
         Task<WriteResult> Delete(string queryID, WriteOptions q, CancellationToken ct = default);
         Task<QueryResult<PreparedQueryExecuteResponse>> Execute(string queryIDOrName, CancellationToken ct = default);
         Task<QueryResult<PreparedQueryExecuteResponse>> Execute(string queryIDOrName, QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<PreparedQueryExplainResponse>> Explain(string queryIDOrName, QueryOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/PreparedQuery.cs
+++ b/Consul/PreparedQuery.cs
@@ -306,7 +306,19 @@ namespace Consul
         public Task<QueryResult<PreparedQueryExplainResponse>> Explain(string queryIDOrName, QueryOptions q, CancellationToken ct = default)
         {
             return _client.Get<PreparedQueryExplainResponse>(string.Format("/v1/query/{0}/explain", queryIDOrName), q).Execute(ct);
-        } 
+        }
+
+        /// <summary>
+        /// Shows which query a name resolves to, the fully interpolated template (if it's a template), as well as additional info about the execution of a query.
+        /// </summary>
+        /// <param name="queryIDOrName">Specifies the UUID of the query to explain. This can also be the name of an existing prepared query,
+        /// or a name that matches a prefix name for a prepared query template</param>
+        /// <param name="ct">Cancellation Token</param>
+        /// <returns>Returns a single prepared query</returns>
+        public Task<QueryResult<PreparedQueryExplainResponse>> Explain(string queryIDOrName, CancellationToken ct = default)
+        {
+            return Explain(queryIDOrName, QueryOptions.Default, ct);
+        }
     }
 
     public partial class ConsulClient : IConsulClient

--- a/Consul/PreparedQuery.cs
+++ b/Consul/PreparedQuery.cs
@@ -211,6 +211,14 @@ namespace Consul
         public int Failovers { get; set; }
     }
 
+    public class PreparedQueryExplainResponse
+    {
+        /// <summary>
+        /// Query has the fully-rendered query.
+        /// </summary>
+        public PreparedQueryDefinition Query { get; set; }
+    }
+
     public class PreparedQuery : IPreparedQueryEndpoint
     {
         private class PreparedQueryCreationResult
@@ -286,6 +294,19 @@ namespace Consul
         {
             return _client.Put(string.Format("/v1/query/{0}", query.ID), query, q).Execute(ct);
         }
+
+        /// <summary>
+        /// Shows which query a name resolves to, the fully interpolated template (if it's a template), as well as additional info about the execution of a query.
+        /// </summary>
+        /// <param name="queryIDOrName">Specifies the UUID of the query to explain. This can also be the name of an existing prepared query,
+        /// or a name that matches a prefix name for a prepared query template</param>
+        /// <param name="q">Query Options</param>
+        /// <param name="ct">Cancellation Token</param>
+        /// <returns>Returns a single prepared query</returns>
+        public Task<QueryResult<PreparedQueryExplainResponse>> Explain(string queryIDOrName, QueryOptions q, CancellationToken ct = default)
+        {
+            return _client.Get<PreparedQueryExplainResponse>(string.Format("/v1/query/{0}/explain", queryIDOrName), q).Execute(ct);
+        } 
     }
 
     public partial class ConsulClient : IConsulClient


### PR DESCRIPTION
Add support for Explain Prepared Query API endpoint in Consul.Net (implementation only, tests pending)
#367 
@naskio 