### PR TITLE
Fixing tests for configuration endpoint

### DIFF
--- a/Consul.Test/ConfigurationTest.cs
+++ b/Consul.Test/ConfigurationTest.cs
@@ -29,16 +29,14 @@ namespace Consul.Test
     [Collection(nameof(ExclusiveCollection))]
     public class ConfigurationTest : BaseFixture
     {
-        [Theory]
-        [InlineData("http")]
-        [InlineData("https")]
-        public async Task Configuration_ApplyConfig(string protocol)
+        [Fact]
+        public async Task Configuration_ApplyConfig()
         {
             var payload = new ServiceDefaultsEntry
             {
                 Kind = "service-defaults",
                 Name = "web",
-                Protocol = protocol
+                Protocol = "http"
             };
 
             var writeResult = await _client.Configuration.ApplyConfig(payload);
@@ -57,14 +55,14 @@ namespace Consul.Test
             {
                 Kind = "service-defaults",
                 Name = "web",
-                Protocol = "https"
+                Protocol = "http"
             };
 
             var secondPayload = new ServiceDefaultsEntry
             {
                 Kind = "service-defaults",
                 Name = "db",
-                Protocol = "https"
+                Protocol = "http"
             };
             var writeResult = await _client.Configuration.ApplyConfig(firstPayload);
             Assert.Equal(HttpStatusCode.OK, writeResult.StatusCode);


### PR DESCRIPTION
Recently, there was a change in consul in the validation of the `protocol` field -> https://github.com/hashicorp/consul/blame/2618fc1bd9894f97a71e2040516bbe21e3d9fecd/agent/structs/config_entry.go#L271-L276 which causes our tests to fail with:
``` 
invalid value for protocol: https
```
