### PR TITLE
Improve CI/CD for documentation website

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "lts/*"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
           cache-dependency-path: docs/yarn.lock
       - name: Setup Pages

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -41,6 +41,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract URL and BASE_URL
+        run: |
+          if [[ "${{ github.repository_owner }}" == "G-Research" ]]; then
+            echo "URL=https://consuldot.net" >> $GITHUB_ENV
+            echo "BASE_URL=/" >> $GITHUB_ENV
+          else
+            echo "URL=https://${{ github.repository_owner }}.github.io" >> $GITHUB_ENV
+            echo "BASE_URL=/${{ github.event.repository.name }}/" >> $GITHUB_ENV
+          fi
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -72,6 +82,8 @@ jobs:
         working-directory: ./docs
         env:
           CONSUL_DOT_NET_VERSION: ${{ steps.version.outputs.tag }}
+          URL: ${{ env.URL }}
+          BASE_URL: ${{ env.BASE_URL }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -21,16 +21,25 @@ defaults: # Default to bash
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      has_pages: ${{ steps.has-pages.outputs.has_pages }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Number of commits to fetch. 0 indicates all history for all branches and tags.
-      - name: Get current version
+
+      - name: Get Consul.NET latest version
         id: version
         uses: WyriHaximus/github-action-get-previous-tag@v1
         with:
           fallback: "vX.X.X.X" # Optional fallback tag to use when no tag can be found
+
+      - name: Set 'has_pages' to output
+        id: has-pages
+        run: echo "has_pages=$(gh api repos/${{ github.repository }} --jq .has_pages)" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -38,9 +47,12 @@ jobs:
           node-version: "lts/*"
           cache: yarn
           cache-dependency-path: docs/yarn.lock
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+        if: github.ref == 'refs/heads/master' && steps.has-pages.outputs.has_pages == 'true'
+
       - name: Restore cache
         uses: actions/cache@v4
         with:
@@ -50,6 +62,7 @@ jobs:
           key: ${{ runner.os }}-docusaurus-build-${{ hashFiles('docs/build') }}
           restore-keys: |
             ${{ runner.os }}-docusaurus-build-
+
       - name: Install dependencies
         run: yarn install
         working-directory: ./docs
@@ -62,6 +75,7 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        if: github.ref == 'refs/heads/master' && steps.has-pages.outputs.has_pages == 'true'
         with:
           path: ./docs/build
 
@@ -71,6 +85,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/master' && needs.build.outputs.has_pages == 'true'
     concurrency: # Allow one concurrent deployment
       group: "pages"
       cancel-in-progress: true

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -14,10 +14,6 @@ permissions: # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHu
   pages: write
   id-token: write
 
-concurrency: # Allow one concurrent deployment
-  group: "pages"
-  cancel-in-progress: true
-
 defaults: # Default to bash
   run:
     shell: bash
@@ -90,6 +86,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    concurrency: # Allow one concurrent deployment
+      group: "pages"
+      cancel-in-progress: true
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,9 +1,12 @@
 name: Deploy website to Pages
 
 on:
-  push: # Runs on pushes targeting the default branch
-    branches:
-      - master
+  push:
+    paths:
+      - 'docs/**'
+  pull_request:
+    paths:
+      - 'docs/**'
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
 
 permissions: # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -31,29 +31,12 @@ jobs:
         uses: WyriHaximus/github-action-get-previous-tag@v1
         with:
           fallback: "vX.X.X.X" # Optional fallback tag to use when no tag can be found
-      - name: Detect package manager
-        id: detect-package-manager
-        working-directory: ./docs
-        run: |
-          if [ -f "yarn.lock" ]; then
-            echo "manager=yarn" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ -f "package.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Unable to determine packager manager"
-            exit 1
-          fi
-      - name: change directory
-        run: cd ./docs
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
-          cache: ${{ steps.detect-package-manager.outputs.manager }}
+          cache: yarn
           cache-dependency-path: docs/yarn.lock
       - name: Setup Pages
         id: pages
@@ -68,13 +51,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-docusaurus-build-
       - name: Install dependencies
+        run: yarn install
         working-directory: ./docs
-        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+
       - name: Build
+        run: yarn run build
         working-directory: ./docs
         env:
           CONSUL_DOT_NET_VERSION: ${{ steps.version.outputs.tag }}
-        run: ${{ steps.detect-package-manager.outputs.manager }} run build
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -30,7 +30,7 @@ jobs:
         id: version
         uses: WyriHaximus/github-action-get-previous-tag@v1
         with:
-          fallback: "X.X.X" # Optional fallback tag to use when no tag can be found
+          fallback: "vX.X.X.X" # Optional fallback tag to use when no tag can be found
       - name: Detect package manager
         id: detect-package-manager
         working-directory: ./docs

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -10,6 +10,8 @@ const dotNetFrameworkMinVersion = `4.6.1`;
 const dotNetCoreMinVersion = `2.0.0`;
 const consulDotNetVersion = clean_version(process.env.CONSUL_DOT_NET_VERSION || `X.X.X.X`);
 const consulAPIVersion = clean_version(extract_consul_version(consulDotNetVersion));
+const url = process.env.URL || `https://consuldot.net`;
+const baseUrl = process.env.BASE_URL || `/`;
 
 function clean_version(version) {
     if (version) {
@@ -41,8 +43,8 @@ const config = {
     onBrokenLinks: 'throw',
     onBrokenMarkdownLinks: 'warn',
 
-    url: 'https://consuldot.net',
-    baseUrl: '/',
+    url: url,
+    baseUrl: baseUrl,
 
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
This PR optimizes the CI/CD workflow for the documentation website:

- Skips deployment steps if GitHub Pages is disabled or the branch is not the default
- Uses `yarn` consistently instead of detecting the package manager
- Updates to the latest Node LTS version
- Adds a more realistic fallback tag for deployment versioning
- Constrains only the deploy job concurrency
- Triggers the workflow only on changes to the `docs/` folder (on push or on pull_request)
- Dynamically set url and baseUrl to allow deploying in forks (for example: https://naskio.github.io/consuldotnet/)