### PR TITLE
Fix parsing the string based host name

### DIFF
--- a/Consul.Test/ClientTest.cs
+++ b/Consul.Test/ClientTest.cs
@@ -33,14 +33,30 @@ namespace Consul.Test
     public class ClientTest : BaseFixture
     {
         [Theory]
-        [InlineData("1.2.3.4:5678", "https://1.2.3.4:5678/")]
-        [InlineData("1.2.3.4:5678/sub-path", "https://1.2.3.4:5678/sub-path")]
-        [InlineData("http://1.2.3.4:5678/sub-path", "https://1.2.3.4:5678/sub-path")]
-        [InlineData("127.0.0.1", "https://127.0.0.1:8500/")]
-        [InlineData("http://127.0.0.1", "https://127.0.0.1:8500/")]
-        [InlineData("http://127.0.0.1:8500", "https://127.0.0.1:8500/")]
-        [InlineData("http://127.0.0.1:80", "https://127.0.0.1:80/")]
-        public void Client_DefaultConfig_env(string addr, string expected)
+        [InlineData("1.2.3.4:5678", "", "http://1.2.3.4:5678/")]
+        [InlineData("http://1.2.3.4:5678/sub-path", "", "http://1.2.3.4:5678/sub-path")]
+        [InlineData("127.0.0.1", "", "http://127.0.0.1:8500/")]
+        [InlineData("http://127.0.0.1", "", "http://127.0.0.1:8500/")]
+        [InlineData("http://127.0.0.1:8500", "", "http://127.0.0.1:8500/")]
+        [InlineData("http://127.0.0.1:80", "", "http://127.0.0.1/")]
+        [InlineData("my.consul.com:5678", "", "http://my.consul.com:5678/")]
+        [InlineData("http://my.consul.com:5678", "", "http://my.consul.com:5678/")]
+        [InlineData("my.consul.com", "", "http://my.consul.com:8500/")]
+
+        [InlineData("https://127.0.0.1:80", "", "https://127.0.0.1/")]
+        [InlineData("https://my.consul.com:5678", "", "https://my.consul.com:5678/")]
+
+        [InlineData("1.2.3.4:5678", "1", "https://1.2.3.4:5678/")]
+        [InlineData("1.2.3.4:5678/sub-path", "1", "https://1.2.3.4:5678/sub-path")]
+        [InlineData("http://1.2.3.4:5678/sub-path", "1", "https://1.2.3.4:5678/sub-path")]
+        [InlineData("127.0.0.1", "1", "https://127.0.0.1:8500/")]
+        [InlineData("http://127.0.0.1", "1", "https://127.0.0.1:8500/")]
+        [InlineData("http://127.0.0.1:8500", "1", "https://127.0.0.1:8500/")]
+        [InlineData("http://127.0.0.1:80", "1", "https://127.0.0.1:80/")]
+        [InlineData("my.consul.com:5678", "1", "https://my.consul.com:5678/")]
+        [InlineData("http://my.consul.com:5678", "1", "https://my.consul.com:5678/")]
+        [InlineData("my.consul.com", "1", "https://my.consul.com:8500/")]
+        public void Client_DefaultConfig_env(string addr, string ssl, string expected)
         {
             const string token = "abcd1234";
             const string auth = "username:password";
@@ -56,7 +72,7 @@ namespace Consul.Test
                 Environment.SetEnvironmentVariable("CONSUL_HTTP_ADDR", addr);
                 Environment.SetEnvironmentVariable("CONSUL_HTTP_TOKEN", token);
                 Environment.SetEnvironmentVariable("CONSUL_HTTP_AUTH", auth);
-                Environment.SetEnvironmentVariable("CONSUL_HTTP_SSL", "1");
+                Environment.SetEnvironmentVariable("CONSUL_HTTP_SSL", ssl);
                 Environment.SetEnvironmentVariable("CONSUL_HTTP_SSL_VERIFY", "0");
 
                 var client = new ConsulClient();
@@ -68,8 +84,6 @@ namespace Consul.Test
                 Assert.NotNull(config.HttpAuth);
                 Assert.Equal("username", config.HttpAuth.UserName);
                 Assert.Equal("password", config.HttpAuth.Password);
-#pragma warning restore CS0618 // Type or member is obsolete
-                Assert.Equal("https", config.Address.Scheme);
 
 #if !(NETSTANDARD || NETCOREAPP)
                 Assert.True((client.HttpHandler as WebRequestHandler).ServerCertificateValidationCallback(null, null, null,

--- a/Consul.Test/ClientTest.cs
+++ b/Consul.Test/ClientTest.cs
@@ -43,7 +43,7 @@ namespace Consul.Test
         [InlineData("http://my.consul.com:5678", "", "http://my.consul.com:5678/")]
         [InlineData("my.consul.com", "", "http://my.consul.com:8500/")]
 
-        [InlineData("https://127.0.0.1:80", "", "https://127.0.0.1/")]
+        [InlineData("https://127.0.0.1:80", "", "https://127.0.0.1:80/")]
         [InlineData("https://my.consul.com:5678", "", "https://my.consul.com:5678/")]
 
         [InlineData("1.2.3.4:5678", "1", "https://1.2.3.4:5678/")]

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -177,6 +177,7 @@ namespace Consul
                     consulAddress.Port = uri.Port;
                 }
                 consulAddress.Path = uri.AbsolutePath;
+                consulAddress.Scheme = uri.Scheme;
             }
 
             var useSsl = (Environment.GetEnvironmentVariable("CONSUL_HTTP_SSL") ?? string.Empty).Trim().ToLowerInvariant();

--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -164,16 +164,14 @@ namespace Consul
             var envAddr = (Environment.GetEnvironmentVariable("CONSUL_HTTP_ADDR") ?? string.Empty).Trim().ToLowerInvariant();
             if (!string.IsNullOrEmpty(envAddr))
             {
-                if (!Uri.TryCreate(envAddr, UriKind.Absolute, out Uri uri))
+                if (!Uri.TryCreate(envAddr, UriKind.Absolute, out Uri uri) ||
+                    string.IsNullOrEmpty(uri.Host))
                 {
-                    // If the URI cannot be parsed it probably lacks the schema, use http as a default
-                    uri = new Uri($"http://{envAddr}");
+                    uri = new Uri($"http://{envAddr}", UriKind.Absolute);
                 }
 
-                if (!string.IsNullOrEmpty(uri.Host))
-                {
-                    consulAddress.Host = uri.Host;
-                }
+                consulAddress.Host = uri.Host;
+
                 if (envAddr.Contains($"{uri.Host}:{uri.Port}"))
                 {
                     consulAddress.Port = uri.Port;


### PR DESCRIPTION
Fix for consul address parsing for cases like:`my.consul.com:5678`, `http://my.consul.com:5678`, `my.consul.com` 
fixes https://github.com/G-Research/consuldotnet/issues/359