### PR TITLE
Configure JSON serializer

### DIFF
--- a/Consul/Client.cs
+++ b/Consul/Client.cs
@@ -23,6 +23,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Cryptography.X509Certificates;
 using Consul.Filtering;
+using Newtonsoft.Json;
 
 namespace Consul
 {
@@ -61,6 +62,11 @@ namespace Consul
                 OnUpdated(new EventArgs());
             }
         }
+
+        /// <summary>
+        /// Allows to configure the serialization settings for a Consul client.
+        /// </summary>
+        public Action<JsonSerializerSettings> ConfigureSerializerSettings { get; set; }
 
         /// <summary>
         /// The Uri to connect to the Consul agent.

--- a/Consul/Client_Request.cs
+++ b/Consul/Client_Request.cs
@@ -57,7 +57,7 @@ namespace Consul
         internal Stream ResponseStream { get; set; }
         internal string Endpoint { get; set; }
 
-        internal readonly JsonSerializer _serializer = new JsonSerializer();
+        internal readonly JsonSerializer _serializer;
 
         internal ConsulRequest(ConsulClient client, string url, HttpMethod method)
         {
@@ -77,6 +77,17 @@ namespace Consul
             if (!string.IsNullOrEmpty(client.Config.Namespace))
             {
                 Params["ns"] = client.Config.Namespace;
+            }
+
+            if (client.Config.ConfigureSerializerSettings == null)
+            {
+                _serializer = new JsonSerializer();
+            }
+            else
+            {
+                var settings = new JsonSerializerSettings();
+                client.Config.ConfigureSerializerSettings(settings);
+                _serializer = JsonSerializer.Create(settings);
             }
         }
 


### PR DESCRIPTION
Small change to allow configuration of used JSON serializer, no breaking changes. I know about #43 and #158 but it seems work is stalled. I suggest to do a small step forward on existing serializer to allow configure it. I was faced with the fact that I can’t configure the serialization of some request metadata as it is necessary.