### PR TITLE
[CI] Update .NET versions and reduce test matrix cardinality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,36 +58,33 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        consul: [1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2, 1.20.0]
-        framework: [net461, net7.0, net8.0]
-        os: [ubuntu-latest]
+        # First define both matrices and combine them using their own names
+        primary:
+          - { consul: [1.7.14, 1.20.0], framework: [net461, net8.0], os: [ubuntu-latest, windows-latest] }
+        extended:
+          - { consul: [1.18.2, 1.19.2], framework: [net6.0, net7.0], os: [macos-13] }
+
+        # Then include both sets
         include:
-            - consul: 1.20.0
-              framework: net8.0
-              os: windows-latest
-
-            - consul: 1.20.0
-              framework: net8.0
-              os: macos-latest
-
-            - consul: 1.20.0
-              framework: net8.0
-              os: macos-13 # for x86_x64 arch
-
+          - ${{ matrix.primary[0] }}
+          - ${{ matrix.extended[0] }}
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup .NET SDK v6.0.x
+        if: matrix.framework == 'net6.0'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
       - name: Setup .NET SDK v7.0.x
         if: matrix.framework == 'net7.0'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
-      - name: Setup .NET SDK v8.0.x
+      - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
       - name: Setup Consul Enterprise URL
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,15 @@ jobs:
     strategy:
       matrix:
         consul: [1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2, 1.20.0]
-        framework: [net461, net6.0, net7.0, net8.0]
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
+        framework: [net8.0]
+        os: [ubuntu-latest]
+        include:
+        - consul: 1.9.17 # Lst consul with a free enterprise license
+          framework: [net461, net6.0, net7.0, net8.0]
+          os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
+        - consul: 1.20.0
+          framework: [net461, net6.0, net7.0, net8.0]
+          os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,14 +60,20 @@ jobs:
       matrix:
         consul: [1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2, 1.20.0]
         framework: [net8.0]
-        os: [ubuntu-latest]
-        include:
-        - consul: 1.9.17 # Lst consul with a free enterprise license
-          framework: net461, net6.0
-          os: windows-latest
-        - consul: 1.20.0
-          framework: [net461, net6.0, net7.0, net8.0]
-          os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
+        os: [ubuntu-latest] # macos-13 for x86_x64 arch
+
+        # Additional combinations using a custom property
+        extended:
+          - consul: [1.20.0]
+            framework: [net6.0, net7.0]
+            os: [macos-13]
+    
+        # Create the cartesian product using a shell script or GitHub Actions expression
+        include: ${{fromJson(format('[{0}]', join(',', 
+          github.event.repository.extended[*].consul, 
+          github.event.repository.extended[*].framework,
+          github.event.repository.extended[*].os
+        )))}}
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         exclude:        
           # Exclude all old .NET Framework tests on macOS
           - framework: net461
-            os: macos-*
+
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,15 @@ jobs:
         framework: [net461, net8.0] # Latest LTS
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
+
           - framework: net9.0 # Latest stable release
             consul: 1.20.0            
             os: ubuntu-latest
-        include:
+
           - os: macos-13  # macos-13 for x86_x64 arch
             framework: net8.0
-            consul: 1.20.0     
+            consul: 1.20.0 
+
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,15 +63,15 @@ jobs:
         os: [ubuntu-latest]
         include:
             - consul: 1.20.0
-              framework: net9.0
+              framework: net8.0
               os: windows-latest
 
             - consul: 1.20.0
-              framework: net9.0
+              framework: net8.0
               os: macos-latest
 
             - consul: 1.20.0
-              framework: net9.0
+              framework: net8.0
               os: macos-13 # for x86_x64 arch
 
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
       - name: Setup Consul Enterprise URL
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         exclude:        
           # Exclude all old .NET Framework tests on macOS
           - framework: net461
-            os: macos-
+            os: macos-13
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,20 @@ jobs:
       matrix:
         consul: [1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2, 1.20.0]
         framework: [net461, net8.0] # Latest LTS
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
         include:
 
           - framework: net9.0 # Latest stable release
             consul: 1.20.0            
             os: ubuntu-latest
+
+          - os: windows-latest
+            framework: net8.0
+            consul: 1.20.0 
+
+          - os: macos-latest
+            framework: net8.0
+            consul: 1.20.0 
 
           - os: macos-13  # macos-13 for x86_x64 arch
             framework: net8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,6 @@ jobs:
         extended:
           - { consul: [1.18.2, 1.19.2], framework: [net6.0, net7.0], os: [macos-13] }
 
-        # Then include both sets
-        include:
-          - ${{ matrix.primary[0] }}
-          - ${{ matrix.extended[0] }}
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,9 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Setup .NET SDK v9.0.x
-        if: matrix.framework == 'net9.0'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
       - name: Setup Consul Enterprise URL
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,21 @@ jobs:
     strategy:
       matrix:
         consul: [1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2, 1.20.0]
-        framework: [net8.0, net9.0]
+        framework: [net461, net8.0, net9.0]
         os: [ubuntu-latest]
         include:
-        - os: macos-13
+            - consul: 1.20.0
+              framework: net9.0
+              os: windows-latest
+
+            - consul: 1.20.0
+              framework: net9.0
+              os: macos-latest
+
+            - consul: 1.20.0
+              framework: net9.0
+              os: macos-13 # for x86_x64 arch
+
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
       - name: Setup Consul Enterprise URL
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,10 @@ jobs:
         os: [ubuntu-latest]
         include:
         - consul: 1.9.17 # Lst consul with a free enterprise license
-          framework: [net461, net6.0, net7.0, net8.0]
+          framework: net461
+          framework: net6.0
+          framework: net7.0
+          framework: net8.0
           os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
         - consul: 1.20.0
           framework: [net461, net6.0, net7.0, net8.0]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
         extended:
           - { consul: [1.18.2, 1.19.2], framework: [net6.0, net7.0], os: [macos-13] }
 
+        # Then include both sets
+        include:
+          - ${{ matrix.primary }}
+          - ${{ matrix.extended }}
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,16 +68,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup .NET SDK v6.0.x
-        if: matrix.framework == 'net6.0'
+      - name: Setup .NET SDK v8.0.x
+        if: matrix.framework == 'net8.0'
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
-      - name: Setup .NET SDK v7.0.x
-        if: matrix.framework == 'net7.0'
+          dotnet-version: 8.0.x
+      - name: Setup .NET SDK v9.0.x
+        if: matrix.framework == 'net9.0'
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 9.0.x
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
       - name: Setup Consul Enterprise URL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         os: [ubuntu-latest]
         include:
         - consul: 1.9.17 # Lst consul with a free enterprise license
-          framework: net461
+          framework: net461, net6.0
           os: windows-latest
         - consul: 1.20.0
           framework: [net461, net6.0, net7.0, net8.0]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Setup .NET SDK v9.0.x
-        uses: actions/setup-dotnet@v4          
+        uses: actions/setup-dotnet@v4    
+        with:
+          dotnet-version: 9.0.x
       - name: Build
         run: dotnet build Consul.AspNetCore.Test --configuration=Release --framework=${{ matrix.framework }}
       - name: Run tests
@@ -77,6 +79,8 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Setup .NET SDK v9.0.x
+        with:
+          dotnet-version: 9.0.x
         uses: actions/setup-dotnet@v4
       - name: Setup Consul Enterprise URL
         # Consul enterprise until version 1.10.0 can be run even without a valid license,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         exclude:        
           # Exclude all old .NET Framework tests on macOS
           - framework: net461
-
+            os: macos-
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,7 @@ jobs:
         include:
         - consul: 1.9.17 # Lst consul with a free enterprise license
           framework: net461
-          framework: net6.0
-          framework: net7.0
-          framework: net8.0
-          os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
+          os: windows-latest
         - consul: 1.20.0
           framework: [net461, net6.0, net7.0, net8.0]
           os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,20 +55,12 @@ jobs:
       matrix:
         consul: [1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2, 1.20.0]
         framework: [net461, net8.0] # Latest LTS
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
 
           - framework: net9.0 # Latest stable release
             consul: 1.20.0            
             os: ubuntu-latest
-
-          - os: windows-latest
-            framework: net8.0
-            consul: 1.20.0 
-
-          - os: macos-latest
-            framework: net8.0
-            consul: 1.20.0 
 
           - os: macos-13  # macos-13 for x86_x64 arch
             framework: net8.0
@@ -85,7 +77,7 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Setup .NET SDK v9.0.x
-        uses: actions/setup-dotnet@v4  
+        uses: actions/setup-dotnet@v4
       - name: Setup Consul Enterprise URL
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,16 +58,13 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        # First define both matrices and combine them using their own names
-        primary:
-          - { consul: [1.7.14, 1.20.0], framework: [net461, net8.0], os: [ubuntu-latest, windows-latest] }
-        extended:
-          - { consul: [1.18.2, 1.19.2], framework: [net6.0, net7.0], os: [macos-13] }
-
-        # Then include both sets
-        include:
-          - ${{ matrix.primary }}
-          - ${{ matrix.extended }}
+        consul: [1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2, 1.20.0]
+        framework: [net461, net6.0, net7.0, net8.0]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
+        exclude:        
+          # Exclude all old .NET Framework tests on macOS
+          - framework: net461
+            os: macos-*
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,24 +31,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
-        framework: [net6.0, net7.0, net8.0]
+        framework: [net8.0, net9.0]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup .NET SDK v6.0.x
-        if: matrix.framework == 'net6.0'
+      - name: Setup .NET SDK v8.0.x
+        if: matrix.framework == 'net8.0'
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
-      - name: Setup .NET SDK v7.0.x
-        if: matrix.framework == 'net7.0'
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 7.0.x
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+          dotnet-version: 8.0.x
+      - name: Setup .NET SDK v9.0.x
+        uses: actions/setup-dotnet@v4          
       - name: Build
         run: dotnet build Consul.AspNetCore.Test --configuration=Release --framework=${{ matrix.framework }}
       - name: Run tests
@@ -59,29 +54,28 @@ jobs:
     strategy:
       matrix:
         consul: [1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2, 1.20.0]
-        framework: [net461, net6.0, net7.0, net8.0]
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
-        exclude:        
-          # Exclude all old .NET Framework tests on macOS
-          - framework: net461
-            os: macos-13
+        framework: [net461, net8.0] # Latest LTS
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - framework: net9.0 # Latest stable release
+            consul: 1.20.0            
+            os: ubuntu-latest
+        include:
+          - os: macos-13  # macos-13 for x86_x64 arch
+            framework: net8.0
+            consul: 1.20.0     
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup .NET SDK v6.0.x
-        if: matrix.framework == 'net6.0'
+      - name: Setup .NET SDK v8.0.x
+        if: matrix.framework == 'net8.0'
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
-      - name: Setup .NET SDK v7.0.x
-        if: matrix.framework == 'net7.0'
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 7.0.x
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+          dotnet-version: 8.0.x
+      - name: Setup .NET SDK v9.0.x
+        uses: actions/setup-dotnet@v4  
       - name: Setup Consul Enterprise URL
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,21 +59,10 @@ jobs:
     strategy:
       matrix:
         consul: [1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2, 1.20.0]
-        framework: [net8.0]
-        os: [ubuntu-latest] # macos-13 for x86_x64 arch
-
-        # Additional combinations using a custom property
-        extended:
-          - consul: [1.20.0]
-            framework: [net6.0, net7.0]
-            os: [macos-13]
-    
-        # Create the cartesian product using a shell script or GitHub Actions expression
-        include: ${{fromJson(format('[{0}]', join(',', 
-          github.event.repository.extended[*].consul, 
-          github.event.repository.extended[*].framework,
-          github.event.repository.extended[*].os
-        )))}}
+        framework: [net8.0, net9.0]
+        os: [ubuntu-latest]
+        include:
+        - os: macos-13
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         consul: [1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2, 1.20.0]
-        framework: [net461, net8.0, net9.0]
+        framework: [net461, net7.0, net8.0]
         os: [ubuntu-latest]
         include:
             - consul: 1.20.0
@@ -79,15 +79,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup .NET SDK v7.0.x
+        if: matrix.framework == 'net7.0'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 7.0.x
       - name: Setup .NET SDK v8.0.x
-        if: matrix.framework == 'net8.0'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
-      - name: Setup .NET SDK v9.0.x
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.x
       - name: Setup Consul Enterprise URL
         # Consul enterprise until version 1.10.0 can be run even without a valid license,
         # so we take advantage of that and run enterprise tests for versions lower than 1.10.0.

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -13,6 +13,6 @@ jobs:
     environment: nudge
     steps:
       - name: Send notification
-        uses: pavlovic-ivan/octo-nudge@v2
+        uses: pavlovic-ivan/octo-nudge@v3
         with:
           webhooks: ${{ secrets.NUDGE_WEBHOOKS }}

--- a/Consul.AspNetCore.Test/Consul.AspNetCore.Test.csproj
+++ b/Consul.AspNetCore.Test/Consul.AspNetCore.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 

--- a/Consul.Test/BaseFixture.cs
+++ b/Consul.Test/BaseFixture.cs
@@ -85,10 +85,12 @@ namespace Consul.Test
 
         static BaseFixture()
         {
+#if NETFRAMEWORK
             // Some Consul object (e.g. semaphores) use multiple http connections,
             // but on .NETFramework the default limit is sometimes very low (2) so we need to bump it to higher value.
             // E.g. https://github.com/microsoft/referencesource/blob/5697c29004a34d80acdaf5742d7e699022c64ecd/System.Web/HttpRuntime.cs#L1200
             ServicePointManager.DefaultConnectionLimit = int.MaxValue;
+#endif
 
             // As for HTTP connections, we need multiple threads to test semaphores and locks.
             // XUnit sets the initial number of worker threads to the number of CPU cores.

--- a/Consul.Test/Consul.Test.csproj
+++ b/Consul.Test/Consul.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;net7.0;net8.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <CopyLocalLockFileAssemblies Condition="'$(TargetFramework)' == 'netcoreapp2.1'">true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/Consul.Test/Consul.Test.csproj
+++ b/Consul.Test/Consul.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net461;net8.0;net9.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <CopyLocalLockFileAssemblies Condition="'$(TargetFramework)' == 'netcoreapp2.1'">true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,5 +17,6 @@
     <Copyright>Copyright 2020-$([System.DateTime]::Now.ToString('yyyy')) G-Research Limited</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
+    <NuGetAuditMode>direct</NuGetAuditMode>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "9.0.100",
+      "version": "8.0.100",
       "rollForward": "latestMinor"
     }
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "8.0.100",
+      "version": "9.0.100",
       "rollForward": "latestMinor"
     }
   }


### PR DESCRIPTION
- `.NET 8` is the latest LTS
- `.NET 9` is the latest STS (Standard Term Support)
- `.NET 6` and `.NET 7` are out of support
- taking out the `macos-13` from the matrix and adding a single job with it to reduce matrix cardinality