### PR TITLE
Unblocking consul agent versions updater

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        consul: [1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2, 1.20.0]
+        consul: [1.6.10, 1.7.14, 1.8.19, 1.9.17, 1.10.12, 1.11.11, 1.12.9, 1.13.9, 1.14.11, 1.15.10, 1.16.6, 1.17.3, 1.18.2, 1.19.2, 1.20.0]
         framework: [net461, net6.0, net7.0, net8.0]
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 for x86_x64 arch
       fail-fast: false

--- a/Consul.Test/ConnectTest.cs
+++ b/Consul.Test/ConnectTest.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NuGet.Versioning;
 using Xunit;
 
 namespace Consul.Test
@@ -55,9 +56,12 @@ namespace Consul.Test
             Assert.NotEqual((ulong)0, result.ModifyIndex);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task Connect_CASetConfig()
         {
+            var cutOffVersion = SemanticVersion.Parse("1.7.0");
+            Skip.If(AgentVersion < cutOffVersion, $"Current version is {AgentVersion}, but setting CA config is only supported from Consul {cutOffVersion}");
+
             var req = await _client.Connect.CAGetConfig();
             var config = req.Response;
 


### PR DESCRIPTION
Our updater resurrects version 1.6.10 -> https://github.com/G-Research/consuldotnet/pull/385
I think it makes more sense to add version 1.6 to the test pool instead of changing the updater to avoid re-adding that version.
Additionally, I think it makes sense to reduce the cardinality of our test matrix (see https://github.com/G-Research/consuldotnet/pull/416)