### PR TITLE
Read Specific Intention By Name

### DIFF
--- a/Consul/Connect.cs
+++ b/Consul/Connect.cs
@@ -356,6 +356,36 @@ namespace Consul
         {
             return DeleteIntentionByName(source, destination, WriteOptions.Default, ct);
         }
+
+        /// <summary>
+        /// reads a specific intention by its unique source and destination.
+        /// </summary>
+        /// <typeparam name="ServiceIntention"></typeparam>
+        /// <param name="source"></param>
+        /// <param name="destination"></param>
+        /// <param name="q"></param>
+        /// <param name="ct"></param>
+        /// <returns>A service intention</returns>
+        public Task<QueryResult<ServiceIntention>> ReadSpecificIntentionByName<ServiceIntention>(string source, string destination, QueryOptions q, CancellationToken ct = default)
+        {
+            var req = _client.Get<ServiceIntention>("v1/connect/intentions/exact", q);
+            req.Params["source"] = source;
+            req.Params["destination"] = destination;
+            return req.Execute(ct);
+        }
+
+        /// <summary>
+        /// reads a specific intention by its unique source and destination.
+        /// </summary>
+        /// <typeparam name="ServiceIntention"></typeparam>
+        /// <param name="source"></param>
+        /// <param name="destination"></param>
+        /// <param name="ct"></param>
+        /// <returns>A service intention</returns>
+        public Task<QueryResult<ServiceIntention>> ReadSpecificIntentionByName<ServiceIntention>(string source, string destination, CancellationToken ct = default)
+        {
+            return ReadSpecificIntentionByName<ServiceIntention>(source, destination, QueryOptions.Default, ct);
+        }
     }
 
     public partial class ConsulClient : IConsulClient

--- a/Consul/Interfaces/IConnectEndpoint.cs
+++ b/Consul/Interfaces/IConnectEndpoint.cs
@@ -38,5 +38,7 @@ namespace Consul.Interfaces
         Task<WriteResult<bool>> UpsertIntentionsByName(ServiceIntention intention, CancellationToken ct = default);
         Task<WriteResult> DeleteIntentionByName(string source, string destination, WriteOptions q, CancellationToken ct = default);
         Task<WriteResult> DeleteIntentionByName(string source, string destination, CancellationToken ct = default);
+        Task<QueryResult<ServiceIntention>> ReadSpecificIntentionByName<ServiceIntention>(string source, string destination, QueryOptions q, CancellationToken ct = default);
+        Task<QueryResult<ServiceIntention>> ReadSpecificIntentionByName<ServiceIntention>(string source, string destination, CancellationToken ct = default);
     }
 }


### PR DESCRIPTION
This PR adds supports to [Read Specific Intention By Name](https://developer.hashicorp.com/consul/api-docs/v1.11.x/connect/intentions#read-specific-intention-by-name)