### PR TITLE
Retrieve the current Autopilot configuration

### DIFF
--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -96,18 +96,20 @@ namespace Consul.Test
 
             var config = result.Response;
 
-            Assert.False(string.IsNullOrEmpty(config.LastContactThreshold));
-            Assert.False(string.IsNullOrEmpty(config.ServerStabilizationTime));
+            Assert.True(config.CleanupDeadServers == true || config.CleanupDeadServers == false);
+            Assert.NotEmpty(config.LastContactThreshold);
+            Assert.NotEmpty(config.ServerStabilizationTime);
             Assert.True(config.MaxTrailingLogs >= 0);
-            Assert.True(config.MinQuorum >= 0);
             Assert.True(config.CreateIndex >= 0);
             Assert.True(config.ModifyIndex >= 0);
+
+            Assert.NotNull(config.RedundancyZoneTag);
+            Assert.NotNull(config.UpgradeVersionTag);
+            Assert.True(config.DisableUpgradeMigration == true || config.DisableUpgradeMigration == false);
 
             Assert.True(result.RequestTime > TimeSpan.Zero);
             Assert.True(result.LastIndex >= 0);
         }
-
-
 
         [EnterpriseOnlyFact]
         public async Task Operator_GetLicense()

--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -96,7 +96,6 @@ namespace Consul.Test
 
             var config = result.Response;
 
-            Assert.True(config.CleanupDeadServers == true || config.CleanupDeadServers == false);
             Assert.NotEmpty(config.LastContactThreshold);
             Assert.NotEmpty(config.ServerStabilizationTime);
             Assert.True(config.MaxTrailingLogs >= 0);
@@ -105,7 +104,6 @@ namespace Consul.Test
 
             Assert.NotNull(config.RedundancyZoneTag);
             Assert.NotNull(config.UpgradeVersionTag);
-            Assert.True(config.DisableUpgradeMigration == true || config.DisableUpgradeMigration == false);
 
             Assert.True(result.RequestTime > TimeSpan.Zero);
             Assert.True(result.LastIndex >= 0);

--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -86,7 +86,7 @@ namespace Consul.Test
             }
         }
 
-        [Fact] 
+        [Fact]
         public async Task Operator_AutopilotGetConfiguration_ReturnsConfiguration()
         {
             var result = await _client.Operator.AutopilotGetConfiguration();
@@ -107,7 +107,7 @@ namespace Consul.Test
             Assert.True(result.LastIndex >= 0);
         }
 
-       
+
 
         [EnterpriseOnlyFact]
         public async Task Operator_GetLicense()

--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -86,6 +86,29 @@ namespace Consul.Test
             }
         }
 
+        [Fact] 
+        public async Task Operator_AutopilotGetConfiguration_ReturnsConfiguration()
+        {
+            var result = await _client.Operator.AutopilotGetConfiguration();
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.Response);
+
+            var config = result.Response;
+
+            Assert.False(string.IsNullOrEmpty(config.LastContactThreshold));
+            Assert.False(string.IsNullOrEmpty(config.ServerStabilizationTime));
+            Assert.True(config.MaxTrailingLogs >= 0);
+            Assert.True(config.MinQuorum >= 0);
+            Assert.True(config.CreateIndex >= 0);
+            Assert.True(config.ModifyIndex >= 0);
+
+            Assert.True(result.RequestTime > TimeSpan.Zero);
+            Assert.True(result.LastIndex >= 0);
+        }
+
+       
+
         [EnterpriseOnlyFact]
         public async Task Operator_GetLicense()
         {

--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -99,6 +99,7 @@ namespace Consul.Test
             Assert.NotEmpty(config.LastContactThreshold);
             Assert.NotEmpty(config.ServerStabilizationTime);
             Assert.True(config.MaxTrailingLogs >= 0);
+            Assert.True(config.MinQuorum >= 0);
             Assert.True(config.CreateIndex >= 0);
             Assert.True(config.ModifyIndex >= 0);
 

--- a/Consul/Interfaces/IOperatorEndpoint.cs
+++ b/Consul/Interfaces/IOperatorEndpoint.cs
@@ -55,5 +55,8 @@ namespace Consul
         Task<QueryResult<Area[]>> AreaGet(string areaId, QueryOptions q, CancellationToken cancellationToken = default);
         Task<WriteResult> AreaDelete(string areaId, CancellationToken cancellationToken = default);
         Task<WriteResult> AreaDelete(string areaId, WriteOptions q, CancellationToken cancellationToken = default);
+
+        Task<QueryResult<AutopilotConfiguration>> AutopilotGetConfiguration(CancellationToken cancellationToken = default);
+        Task<QueryResult<AutopilotConfiguration>> AutopilotGetConfiguration(QueryOptions q, CancellationToken cancellationToken = default);
     }
 }

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -356,7 +356,7 @@ namespace Consul
             return _client.Delete($"/v1/operator/area/{areaId}", q).Execute(ct);
         }
 
-         /// <summary>
+        /// <summary>
         /// Retrieves the current Autopilot configuration
         /// </summary>
         /// <param name="cancellationToken">Cancellation token for the request</param>

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -412,22 +412,25 @@ namespace Consul
         public bool CleanupDeadServers { get; set; }
 
         [JsonProperty("LastContactThreshold")]
-        public string LastContactThreshold { get; set; } = string.Empty;
+        public string LastContactThreshold { get; set; } 
 
         [JsonProperty("MaxTrailingLogs")]
         public int MaxTrailingLogs { get; set; }
 
+        [JsonProperty("MinQuorum")]
+        public int MinQuorum { get; set; }
+
         [JsonProperty("ServerStabilizationTime")]
-        public string ServerStabilizationTime { get; set; } = string.Empty;
+        public string ServerStabilizationTime { get; set; }
 
         [JsonProperty("RedundancyZoneTag")]
-        public string RedundancyZoneTag { get; set; } = string.Empty;
+        public string RedundancyZoneTag { get; set; } 
 
         [JsonProperty("DisableUpgradeMigration")]
         public bool DisableUpgradeMigration { get; set; }
 
         [JsonProperty("UpgradeVersionTag")]
-        public string UpgradeVersionTag { get; set; } = string.Empty;
+        public string UpgradeVersionTag { get; set; }
 
         [JsonProperty("CreateIndex")]
         public ulong CreateIndex { get; set; }

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -355,6 +355,27 @@ namespace Consul
         {
             return _client.Delete($"/v1/operator/area/{areaId}", q).Execute(ct);
         }
+
+         /// <summary>
+        /// Retrieves the current Autopilot configuration
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token for the request</param>
+        /// <returns>A query result containing the Autopilot configuration</returns>
+        public Task<QueryResult<AutopilotConfiguration>> AutopilotGetConfiguration(CancellationToken cancellationToken = default)
+        {
+            return AutopilotGetConfiguration(null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Retrieves the current Autopilot configuration with query options
+        /// </summary>
+        /// <param name="q">Query options including datacenter and consistency mode</param>
+        /// <param name="cancellationToken">Cancellation token for the request</param>
+        /// <returns>A query result containing the Autopilot configuration</returns>
+        public Task<QueryResult<AutopilotConfiguration>> AutopilotGetConfiguration(QueryOptions q, CancellationToken cancellationToken = default)
+        {
+            return _client.Get<AutopilotConfiguration>("/v1/operator/autopilot/configuration", q).Execute(cancellationToken);
+        }
     }
 
     public class ConsulLicense
@@ -383,6 +404,39 @@ namespace Consul
         public Flags Flags { get; set; }
         public string[] Features { get; set; }
         public bool Temporary { get; set; }
+    }
+
+    public class AutopilotConfiguration
+    {
+        [JsonProperty("CleanupDeadServers")]
+        public bool CleanupDeadServers { get; set; }
+
+        [JsonProperty("LastContactThreshold")]
+        public string LastContactThreshold { get; set; } = string.Empty;
+
+        [JsonProperty("MaxTrailingLogs")]
+        public int MaxTrailingLogs { get; set; }
+
+        [JsonProperty("MinQuorum")]
+        public int MinQuorum { get; set; }
+
+        [JsonProperty("ServerStabilizationTime")]
+        public string ServerStabilizationTime { get; set; } = string.Empty;
+
+        [JsonProperty("RedundancyZoneTag")]
+        public string RedundancyZoneTag { get; set; } = string.Empty;
+
+        [JsonProperty("DisableUpgradeMigration")]
+        public bool DisableUpgradeMigration { get; set; }
+
+        [JsonProperty("UpgradeVersionTag")]
+        public string UpgradeVersionTag { get; set; } = string.Empty;
+
+        [JsonProperty("CreateIndex")]
+        public ulong CreateIndex { get; set; }
+
+        [JsonProperty("ModifyIndex")]
+        public ulong ModifyIndex { get; set; }
     }
 
     public class Flags

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -412,7 +412,7 @@ namespace Consul
         public bool CleanupDeadServers { get; set; }
 
         [JsonProperty("LastContactThreshold")]
-        public string LastContactThreshold { get; set; } 
+        public string LastContactThreshold { get; set; }
 
         [JsonProperty("MaxTrailingLogs")]
         public int MaxTrailingLogs { get; set; }
@@ -424,7 +424,7 @@ namespace Consul
         public string ServerStabilizationTime { get; set; }
 
         [JsonProperty("RedundancyZoneTag")]
-        public string RedundancyZoneTag { get; set; } 
+        public string RedundancyZoneTag { get; set; }
 
         [JsonProperty("DisableUpgradeMigration")]
         public bool DisableUpgradeMigration { get; set; }

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -417,9 +417,6 @@ namespace Consul
         [JsonProperty("MaxTrailingLogs")]
         public int MaxTrailingLogs { get; set; }
 
-        [JsonProperty("MinQuorum")]
-        public int MinQuorum { get; set; }
-
         [JsonProperty("ServerStabilizationTime")]
         public string ServerStabilizationTime { get; set; } = string.Empty;
 


### PR DESCRIPTION
## Description

This pull request implements the `GET /v1/operator/autopilot/configuration` endpoint under the `Operator` client and adds initial test coverage for it. 

The following changes were made:
- Introduced `AutopilotConfiguration` model to represent the returned configuration structure.
- Implemented `Operator.AutopilotGetConfiguration` method with support for optional query parameters.
- Included a unit test verifying that the method returns valid configuration and query metadata.

Additional test cases (e.g., with query options, stale reads, serialization checks) will be submitted in a follow-up commits.

## Related Issues

Closes #475

## Additional Context

The implementation follows the style and structure of other operator endpoints in the codebase. The test was added to the `OperatorTest` class and uses the shared `_client` instance provided by `BaseFixture`.

## Checklist

- [x] Did you read the [contributing guidelines](https://consuldot.net/docs/contributing/guidelines)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?
