### PR TITLE
Read autopilot health

### DIFF
--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -132,8 +132,8 @@ namespace Consul.Test
                     Assert.False(string.IsNullOrEmpty(server.Name));
                     Assert.False(string.IsNullOrEmpty(server.Address));
                     Assert.False(string.IsNullOrEmpty(server.Version));
-                    Assert.True(server.LastTerm >= 0);
-                    Assert.True(server.LastIndex >= 0);
+                    Assert.True(server.LastTerm > 0);
+                    Assert.True(server.LastIndex > 0);
                     Assert.NotEqual(DateTime.MinValue, server.StableSince);
 
                     if (health.Servers.Count == 1)

--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -145,7 +145,6 @@ namespace Consul.Test
             }
         }
 
-
         [EnterpriseOnlyFact]
         public async Task Operator_GetLicense()
         {

--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -110,6 +110,42 @@ namespace Consul.Test
             Assert.True(result.LastIndex >= 0);
         }
 
+        [Fact]
+        public async Task Operator_AutopilotGetHealth_ReturnsHealthStatus()
+        {
+            var result = await _client.Operator.AutopilotGetHealth();
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.Response);
+            Assert.NotNull(result.Response.Servers);
+
+            var health = result.Response;
+
+            Assert.IsType<List<AutopilotServerHealth>>(health.Servers);
+            Assert.True(health.FailureTolerance >= 0);
+
+            if (health.Servers.Count > 0)
+            {
+                foreach (var server in health.Servers)
+                {
+                    Assert.False(string.IsNullOrEmpty(server.ID));
+                    Assert.False(string.IsNullOrEmpty(server.Name));
+                    Assert.False(string.IsNullOrEmpty(server.Address));
+                    Assert.False(string.IsNullOrEmpty(server.Version));
+                    Assert.True(server.LastTerm >= 0);
+                    Assert.True(server.LastIndex >= 0);
+                    Assert.NotEqual(DateTime.MinValue, server.StableSince);
+
+                    if (health.Servers.Count == 1)
+                    {
+                        Assert.True(server.Leader);
+                        Assert.True(server.Voter);
+                    }
+                }
+            }
+        }
+
+
         [EnterpriseOnlyFact]
         public async Task Operator_GetLicense()
         {

--- a/Consul/Interfaces/IOperatorEndpoint.cs
+++ b/Consul/Interfaces/IOperatorEndpoint.cs
@@ -58,7 +58,6 @@ namespace Consul
 
         Task<QueryResult<AutopilotConfiguration>> AutopilotGetConfiguration(CancellationToken cancellationToken = default);
         Task<QueryResult<AutopilotConfiguration>> AutopilotGetConfiguration(QueryOptions q, CancellationToken cancellationToken = default);
-
         Task<QueryResult<AutopilotHealth>> AutopilotGetHealth(CancellationToken cancellationToken = default);
         Task<QueryResult<AutopilotHealth>> AutopilotGetHealth(QueryOptions q, CancellationToken cancellationToken = default);
 

--- a/Consul/Interfaces/IOperatorEndpoint.cs
+++ b/Consul/Interfaces/IOperatorEndpoint.cs
@@ -58,5 +58,9 @@ namespace Consul
 
         Task<QueryResult<AutopilotConfiguration>> AutopilotGetConfiguration(CancellationToken cancellationToken = default);
         Task<QueryResult<AutopilotConfiguration>> AutopilotGetConfiguration(QueryOptions q, CancellationToken cancellationToken = default);
+
+        Task<QueryResult<AutopilotHealth>> AutopilotGetHealth(CancellationToken cancellationToken = default);
+        Task<QueryResult<AutopilotHealth>> AutopilotGetHealth(QueryOptions q, CancellationToken cancellationToken = default);
+
     }
 }

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -376,6 +376,27 @@ namespace Consul
         {
             return _client.Get<AutopilotConfiguration>("/v1/operator/autopilot/configuration", q).Execute(cancellationToken);
         }
+
+        /// <summary>
+        /// Retrieves the autopilot health status of the cluster (synchronous version)
+        /// </summary>
+        /// <param name="cancellationToken">Query parameters</param>
+        /// <returns>The autopilot health information</returns>
+        public Task<QueryResult<AutopilotHealth>> AAutopilotGetHealth(CancellationToken cancellationToken= default)
+        {
+            return AutopilotGetHealth(null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Retrieves the autopilot health status of the cluster
+        /// </summary>
+        /// <param name="q">Query parameters</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The autopilot health information</returns>
+        public Task<QueryResult<AutopilotHealth>> AutopilotGetHealth(QueryOptions q, CancellationToken cancellationToken = default)
+        {
+            return _client.Get<AutopilotHealth>("/v1/operator/autopilot/health", q).Execute(cancellationToken);
+        }
     }
 
     public class ConsulLicense
@@ -437,6 +458,57 @@ namespace Consul
 
         [JsonProperty("ModifyIndex")]
         public ulong ModifyIndex { get; set; }
+    }
+
+    public class AutopilotHealth
+    {
+        [JsonProperty("Healthy")]
+        public bool Healthy { get; set; }
+
+        [JsonProperty("FailureTolerance")]
+        public int FailureTolerance { get; set; }
+
+        [JsonProperty("Servers")]
+        public List<AutopilotServerHealth> Servers { get; set; }
+    }
+
+    public class AutopilotServerHealth
+    {
+        [JsonProperty("ID")]
+        public string ID { get; set; }
+
+        [JsonProperty("Name")]
+        public string Name { get; set; }
+
+        [JsonProperty("Address")]
+        public string Address { get; set; }
+
+        [JsonProperty("SerfStatus")]
+        public string SerfStatus { get; set; }
+
+        [JsonProperty("Version")]
+        public string Version { get; set; }
+
+        [JsonProperty("Leader")]
+        public bool Leader { get; set; }
+
+        [JsonProperty("LastContact")]
+        public string LastContact { get; set; }
+
+        [JsonProperty("LastTerm")]
+        public long LastTerm { get; set; }
+
+        [JsonProperty("LastIndex")]
+        public long LastIndex { get; set; }
+
+        [JsonProperty("Healthy")]
+        public bool Healthy { get; set; }
+
+        [JsonProperty("Voter")]
+        public bool Voter { get; set; }
+
+        [JsonProperty("StableSince")]
+        public DateTime StableSince { get; set; }
     }
 
     public class Flags

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -382,7 +382,7 @@ namespace Consul
         /// </summary>
         /// <param name="cancellationToken">Query parameters</param>
         /// <returns>The autopilot health information</returns>
-        public Task<QueryResult<AutopilotHealth>> AAutopilotGetHealth(CancellationToken cancellationToken= default)
+        public Task<QueryResult<AutopilotHealth>> AutopilotGetHealth(CancellationToken cancellationToken= default)
         {
             return AutopilotGetHealth(null, cancellationToken);
         }


### PR DESCRIPTION
[FEATURE]: Read autopilot health `GET /v1/operator/autopilot/health`

## Description

This PR introduces full support for the `GET /v1/operator/autopilot/health` endpoint in Consul.NET. It includes:

- Added `AutopilotHealth` and `AutopilotServerHealth` classes to represent the response payload.
- Implemented `AutopilotGetHealth` method to handle the API call.
- Updated `IOperatorEndpoint` to expose the new methods.
- Added test to verify endpoint correctness.

## Related Issues

Fixes #477

## Additional Context

The implementation follows the structure used in other Operator endpoint integrations for consistency. Refer to doc: [Link to Reference Doc](https://developer.hashicorp.com/consul/api-docs/operator/autopilot#read-health)

## Checklist

- [x] Did you read the [contributing guidelines](https://consuldot.net/docs/contributing/guidelines)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?
