### PR TITLE
[FEATURE]: Add support for PUT /v1/operator/autopilot/configuration

### DIFF
--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -146,8 +146,8 @@ namespace Consul.Test
         }
 
         [Theory]
-        [InlineData(true, "500ms", 100, 3, "30s", "az", false, "v1")]
-        [InlineData(false, "1s", 200, 5, "60s", "zone-b", true, "v2")]
+        [InlineData(true, "500ms", 100, 3, "30s", "az", false, "")]
+        [InlineData(false, "1s", 200, 5, "60s", "zone-b", true, "version")]
         public async Task Operator_AutopilotSetConfiguration_UpdatesConfiguration(
             bool cleanupDeadServers,
             string lastContactThreshold,

--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -147,7 +147,7 @@ namespace Consul.Test
 
         [Theory]
         [InlineData(true, "500ms", 100, 3, "30s", "az", false, "")]
-        [InlineData(false, "1s", 200, 5, "60s", "zone-b", true, "version")]
+        [InlineData(false, "1s", 200, 5, "59s", "zone-b", true, "version")]
         public async Task Operator_AutopilotSetConfiguration_UpdatesConfiguration(
             bool cleanupDeadServers,
             string lastContactThreshold,

--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -144,6 +144,45 @@ namespace Consul.Test
                 }
             }
         }
+        [Fact]
+        public async Task Operator_AutopilotSetConfiguration_UpdatesConfiguration()
+        {
+
+            var configuration = new AutopilotConfiguration
+            {
+                CleanupDeadServers = true,
+                LastContactThreshold = "500ms",
+                MaxTrailingLogs = 100,
+                MinQuorum = 3,
+                ServerStabilizationTime = "30s",
+                RedundancyZoneTag = "az",
+                DisableUpgradeMigration = false,
+                UpgradeVersionTag = "version"
+            };
+
+            var result = await _client.Operator.AutopilotSetConfiguration(configuration);
+
+            Assert.NotNull(result);
+            Assert.True(result.RequestTime > TimeSpan.Zero);
+
+            var getResult = await _client.Operator.AutopilotGetConfiguration();
+            Assert.NotNull(getResult);
+            Assert.NotNull(getResult.Response);
+
+            var retrievedConfig = getResult.Response;
+            Assert.Equal(configuration.CleanupDeadServers, retrievedConfig.CleanupDeadServers);
+            Assert.Equal(configuration.LastContactThreshold, retrievedConfig.LastContactThreshold);
+            Assert.Equal(configuration.MaxTrailingLogs, retrievedConfig.MaxTrailingLogs);
+            Assert.Equal(configuration.MinQuorum, retrievedConfig.MinQuorum);
+            Assert.Equal(configuration.ServerStabilizationTime, retrievedConfig.ServerStabilizationTime);
+            Assert.Equal(configuration.RedundancyZoneTag, retrievedConfig.RedundancyZoneTag);
+            Assert.Equal(configuration.DisableUpgradeMigration, retrievedConfig.DisableUpgradeMigration);
+            Assert.Equal(configuration.UpgradeVersionTag, retrievedConfig.UpgradeVersionTag);
+
+            Assert.True(retrievedConfig.CreateIndex > 0);
+            Assert.True(retrievedConfig.ModifyIndex > 0);
+            Assert.True(retrievedConfig.ModifyIndex >= retrievedConfig.CreateIndex);
+        }
 
         [EnterpriseOnlyFact]
         public async Task Operator_GetLicense()

--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -144,20 +144,30 @@ namespace Consul.Test
                 }
             }
         }
-        [Fact]
-        public async Task Operator_AutopilotSetConfiguration_UpdatesConfiguration()
-        {
 
+        [Theory]
+        [InlineData(true, "500ms", 100, 3, "30s", "az", false, "v1")]
+        [InlineData(false, "1s", 200, 5, "60s", "zone-b", true, "v2")]
+        public async Task Operator_AutopilotSetConfiguration_UpdatesConfiguration(
+            bool cleanupDeadServers,
+            string lastContactThreshold,
+            int maxTrailingLogs,
+            int minQuorum,
+            string serverStabilizationTime,
+            string redundancyZoneTag,
+            bool disableUpgradeMigration,
+            string upgradeVersionTag)
+        {
             var configuration = new AutopilotConfiguration
             {
-                CleanupDeadServers = true,
-                LastContactThreshold = "500ms",
-                MaxTrailingLogs = 100,
-                MinQuorum = 3,
-                ServerStabilizationTime = "30s",
-                RedundancyZoneTag = "az",
-                DisableUpgradeMigration = false,
-                UpgradeVersionTag = "version"
+                CleanupDeadServers = cleanupDeadServers,
+                LastContactThreshold = lastContactThreshold,
+                MaxTrailingLogs = maxTrailingLogs,
+                MinQuorum = minQuorum,
+                ServerStabilizationTime = serverStabilizationTime,
+                RedundancyZoneTag = redundancyZoneTag,
+                DisableUpgradeMigration = disableUpgradeMigration,
+                UpgradeVersionTag = upgradeVersionTag
             };
 
             var result = await _client.Operator.AutopilotSetConfiguration(configuration);

--- a/Consul/Interfaces/IOperatorEndpoint.cs
+++ b/Consul/Interfaces/IOperatorEndpoint.cs
@@ -60,6 +60,7 @@ namespace Consul
         Task<QueryResult<AutopilotConfiguration>> AutopilotGetConfiguration(QueryOptions q, CancellationToken cancellationToken = default);
         Task<QueryResult<AutopilotHealth>> AutopilotGetHealth(CancellationToken cancellationToken = default);
         Task<QueryResult<AutopilotHealth>> AutopilotGetHealth(QueryOptions q, CancellationToken cancellationToken = default);
-
+        Task<WriteResult> AutopilotSetConfiguration(AutopilotConfiguration configuration, CancellationToken cancellationToken = default);
+        Task<WriteResult> AutopilotSetConfiguration(AutopilotConfiguration configuration, WriteOptions q, CancellationToken cancellationToken = default);
     }
 }

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -398,8 +398,7 @@ namespace Consul
         public async Task<WriteResult> AutopilotSetConfiguration(AutopilotConfiguration configuration, WriteOptions q, CancellationToken cancellationToken = default)
         {
             var req = await _client.Put<AutopilotConfiguration>("/v1/operator/autopilot/configuration", configuration, q).Execute(cancellationToken).ConfigureAwait(false);
-            return new WriteResult<AutopilotConfiguration>(req);
-
+            return new WriteResult<AutopilotConfiguration>(req)
         }
 
         /// <summary>

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -398,7 +398,7 @@ namespace Consul
         public async Task<WriteResult> AutopilotSetConfiguration(AutopilotConfiguration configuration, WriteOptions q, CancellationToken cancellationToken = default)
         {
             var req = await _client.Put<AutopilotConfiguration>("/v1/operator/autopilot/configuration", configuration, q).Execute(cancellationToken).ConfigureAwait(false);
-            return new WriteResult<AutopilotConfiguration>(req)
+            return new WriteResult<AutopilotConfiguration>(req);
         }
 
         /// <summary>

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -378,6 +378,31 @@ namespace Consul
         }
 
         /// <summary>
+        /// Updates the autopilot configuration of the cluster (synchronous version)
+        /// </summary>
+        /// <param name="configuration">The autopilot configuration to set</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The write result</returns>
+        public Task<WriteResult> AutopilotSetConfiguration(AutopilotConfiguration configuration, CancellationToken cancellationToken = default)
+        {
+            return AutopilotSetConfiguration(configuration, WriteOptions.Default, cancellationToken);
+        }
+
+        /// <summary>
+        /// Updates the autopilot configuration of the cluster
+        /// </summary>
+        /// <param name="configuration">The autopilot configuration to set</param>
+        /// <param name="q">Write options</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The write result</returns>
+        public async Task<WriteResult> AutopilotSetConfiguration(AutopilotConfiguration configuration, WriteOptions q, CancellationToken cancellationToken = default)
+        {
+            var req = await _client.Put<AutopilotConfiguration>("/v1/operator/autopilot/configuration", configuration, q).Execute(cancellationToken).ConfigureAwait(false);
+            return new WriteResult<AutopilotConfiguration>(req);
+
+        }
+
+        /// <summary>
         /// Retrieves the autopilot health status of the cluster (synchronous version)
         /// </summary>
         /// <param name="cancellationToken">Query parameters</param>


### PR DESCRIPTION
### [FEATURE]: Add support for PUT /v1/operator/autopilot/configuration

## Description

This PR adds support for the Consul Operator Autopilot Configuration API endpoint  
(**PUT /v1/operator/autopilot/configuration**), which allows updating the Autopilot configuration of a Consul cluster.

### Changes include:

- Added `AutopilotSetConfiguration()` method with both default and `WriteOptions` overloads
- Updated the `IOperatorEndpoint` interface with the new method signatures
- Added unit test to verify functionality

## Related Issues

Implements: [Autopilot API – Update Autopilot Configuration](https://developer.hashicorp.com/consul/api-docs/operator/autopilot#update-configuration)
Closes: #485 



## Checklist

- [x] Did you read the [contributing guidelines](https://consuldot.net/docs/contributing/guidelines)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?

