### PR TITLE
Setting up server on macOS

### DIFF
--- a/docs/docs/1-getting-started/2-setting-up-server.mdx
+++ b/docs/docs/1-getting-started/2-setting-up-server.mdx
@@ -3,10 +3,23 @@
 You'll need a running Consul Server on your local machine, or a Consul
 Agent connected to a Consul Server cluster. To run a local server:
 
+## On Windows
+
 1. [Download a copy](https://www.consul.io/downloads.html) of the latest Windows
 version and unzip it into the `Consul.Test` folder.
 2. Open a command prompt and `cd` to the `Consul.Test` folder.
 3. Run `.\consul.exe agent -dev -config-file test_config.json`
 
+## On MacOS
+
+1. [Download a copy](https://www.consul.io/downloads.html) of the latest version for your system:
+   - `darwin_amd64` for Intel Macs
+   - `darwin_arm64` for Apple Silicon
+2. Unzip the downloaded archive. It contains the `consul` executable and a `LICENSE` text file.
+3. Copy both the `consul` executable and `LICENSE` file into the `Consul.Test` folder.
+4. Open a command prompt and `cd` to the `Consul.Test` folder.
+5. Run `consul agent -dev -config-file test_config.json`
+
 This creates a 1-server cluster that operates in "dev" mode (does not
 write data to disk) and listens on `127.0.0.1:8500`.
+


### PR DESCRIPTION
[ENHANCEMENT]: Added additional instructions to the "setting up consul server" guide specific to MacOS.

## Description

This PR adds a new instructions under the "Setting up Consul Server" guide that details the steps for setting up a local Consul agent on macOS systems (both Intel and Apple Silicon). The guide mirrors the Windows instructions and is tailored to the macOS environment.

## Related Issues

closes: #482 
Related to: Doc[https://consuldot.net/docs/getting-started/setting-up-server]


## Checklist
- [x] Did you read the [contributing guidelines](https://consuldot.net/docs/contributing/guidelines)?
- [x] Did you update the docs?
- [ ] Did you write any tests to validate this change?
