### PR TITLE
initial commit for raft transfer leader

### DIFF
--- a/Consul.Test/OperatorTest.cs
+++ b/Consul.Test/OperatorTest.cs
@@ -52,6 +52,30 @@ namespace Consul.Test
         }
 
         [Fact]
+        public async Task Operator_RaftTransferLeader()
+        {
+            var result = await _client.Operator.RaftTransferLeader();
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task Operator_RaftTransferLeaderById()
+        {
+            try
+            {
+                var config = await _client.Operator.RaftGetConfiguration();
+                var serverId = config.Response.Servers[0].ID;
+
+                var result = await _client.Operator.RaftTransferLeader(serverId);
+                Assert.NotNull(result);
+            }
+            catch (ConsulRequestException e)
+            {
+                Assert.Contains("cannot transfer leadership to itself", e.Message);
+            }
+        }
+
+        [Fact]
         public async Task Operator_KeyringInstallListPutRemove()
         {
             const string oldKey = "d8wu8CSUrqgtjVsvcBPmhQ==";

--- a/Consul/Interfaces/IOperatorEndpoint.cs
+++ b/Consul/Interfaces/IOperatorEndpoint.cs
@@ -64,5 +64,9 @@ namespace Consul
         Task<QueryResult<AutopilotState>> AutopilotGetState(QueryOptions q, CancellationToken cancellationToken = default);
         Task<WriteResult> AutopilotSetConfiguration(AutopilotConfiguration configuration, CancellationToken cancellationToken = default);
         Task<WriteResult> AutopilotSetConfiguration(AutopilotConfiguration configuration, WriteOptions q, CancellationToken cancellationToken = default);
+        Task<WriteResult> RaftTransferLeader(CancellationToken ct = default);
+        Task<WriteResult> RaftTransferLeader(WriteOptions q, CancellationToken ct = default);
+        Task<WriteResult> RaftTransferLeader(string id, CancellationToken ct = default);
+        Task<WriteResult> RaftTransferLeader(string id, WriteOptions q, CancellationToken ct = default);
     }
 }

--- a/Consul/Operator.cs
+++ b/Consul/Operator.cs
@@ -194,6 +194,51 @@ namespace Consul
 
             return req.Execute(ct);
         }
+        /// <summary>
+        /// Transfers Raft leadership to another server
+        /// </summary>
+        /// <param name="ct">Cancellation token for the request</param>
+        /// <returns>A write result indicating the success of the operation</returns>
+        public Task<WriteResult> RaftTransferLeader(CancellationToken ct = default)
+        {
+            return RaftTransferLeader(WriteOptions.Default, ct);
+        }
+
+        /// <summary>
+        /// Transfers Raft leadership to another server with write options
+        /// </summary>
+        /// <param name="q">Write options including datacenter and token</param>
+        /// <param name="ct">Cancellation token for the request</param>
+        /// <returns>A write result indicating the success of the operation</returns>
+        public Task<WriteResult> RaftTransferLeader(WriteOptions q, CancellationToken ct = default)
+        {
+            return _client.Post<object>("/v1/operator/raft/transfer-leader", null, q).Execute(ct);
+        }
+
+        /// <summary>
+        /// Transfers Raft leadership to another server by ID
+        /// </summary>
+        /// <param name="id">The node ID of the Raft peer to transfer leadership to</param>
+        /// <param name="ct">Cancellation token for the request</param>
+        /// <returns>A write result indicating the success of the operation</returns>
+        public Task<WriteResult> RaftTransferLeader(string id, CancellationToken ct = default)
+        {
+            return RaftTransferLeader(id, WriteOptions.Default, ct);
+        }
+
+        /// <summary>
+        /// Transfers Raft leadership to another server by ID with write options
+        /// </summary>
+        /// <param name="id">The node ID of the Raft peer to transfer leadership to</param>
+        /// <param name="q">Write options including datacenter and token</param>
+        /// <param name="ct">Cancellation token for the request</param>
+        /// <returns>A write result indicating the success of the operation</returns>
+        public Task<WriteResult> RaftTransferLeader(string id, WriteOptions q, CancellationToken ct = default)
+        {
+            var req = _client.Post<object>("/v1/operator/raft/transfer-leader", null, q);
+            req.Params["id"] = id;
+            return req.Execute(ct);
+        }
 
         /// <summary>
         /// KeyringInstall is used to install a new gossip encryption key into the cluster


### PR DESCRIPTION
[FEATURE]: Add support for Raft leadership transfer (POST /v1/operator/raft/transfer-leader)

## Description

This pull request adds support for the `POST /v1/operator/raft/transfer-leader` endpoint in the `Operator` class.

- Implemented `RaftTransferLeader` method to initiate a leadership transfer without specifying a target.
- Implemented `RaftTransferLeader(string id, WriteOptions q, CancellationToken ct = default)` method to transfer leadership to a specific server ID.
- Updated `IOperatorEndpoint` interface to include the new methods.
- Added unit tests to validate the new functionality and error handling for invalid node IDs.

## Related Issues

Closes: #487 

## Additional Context

The implementation was based on the official Consul HTTP API [doc](https://developer.hashicorp.com/consul/api-docs/operator/raft#transfer-leader)

## Checklist

- [x] Did you read the [contributing guidelines](https://consuldot.net/docs/contributing/guidelines)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?