### PR TITLE
feature: added delete peering token by name

### DIFF
--- a/Consul.Test/ClusterPeeringTest.cs
+++ b/Consul.Test/ClusterPeeringTest.cs
@@ -77,5 +77,28 @@ namespace Consul.Test
             var newResult = await _client.ClusterPeering.GetPeering("cluster-05", QueryOptions.Default);
             Assert.Null(newResult.Response);
         }
+
+        [SkippableFact]
+        public async Task ClusterPeeringTest_DeletePeering()
+        {
+            var cutOffVersion = SemanticVersion.Parse("1.14.0");
+            Skip.If(AgentVersion < cutOffVersion, $"Current version is {AgentVersion}, but this test is only supported from Consul {cutOffVersion}");
+            var clusterPeeringEntry = new ClusterPeeringTokenEntry
+            {
+                PeerName = "cluster-03",
+                Meta = new Dictionary<string, string> { ["env"] = "production" }
+            };
+            var clusterPeeringCreateResponse = await _client.ClusterPeering.GenerateToken(clusterPeeringEntry);
+            var result = await _client.ClusterPeering.GetPeering("cluster-03", QueryOptions.Default);
+            Assert.NotNull(result.Response);
+            Assert.NotNull(result.Response.ID);
+            Assert.NotNull(result.Response.Remote);
+            Assert.NotNull(result.Response.StreamStatus);
+            // Request to delete that peering
+            var deleteResult = await _client.ClusterPeering.DeletePeering("cluster-03", WriteOptions.Default);
+            // Attempt to access the deleted peering
+            var newResult = await _client.ClusterPeering.GetPeering("cluster-03", QueryOptions.Default);
+            Assert.Null(newResult.Response);
+        }
     }
 }

--- a/Consul/ClusterPeering.cs
+++ b/Consul/ClusterPeering.cs
@@ -184,6 +184,30 @@ namespace Consul
             var res = _client.Get<ClusterPeeringStatus>(string.Format("/v1/peering/{0}", name), options);
             return res.Execute(cancellationToken);
         }
+
+        /// <summary>
+        /// DeletePeering is used to delete a specific connection by its name
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>A specific connection instance.</returns>
+        public Task<WriteResult> DeletePeering(string name, CancellationToken cancellationToken)
+        {
+            return DeletePeering(name, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// DeletePeering is used to delete a specific connection by its name
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="options"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>A specific connection instance.</returns>
+        public Task<WriteResult> DeletePeering(string name, WriteOptions options, CancellationToken cancellationToken)
+        {
+            var res = _client.Delete(string.Format("/v1/peering/{0}", name), options);
+            return res.Execute(cancellationToken);
+        }
     }
 
     public partial class ConsulClient : IConsulClient

--- a/Consul/Interfaces/IClusterPeeringEndpoint.cs
+++ b/Consul/Interfaces/IClusterPeeringEndpoint.cs
@@ -36,5 +36,7 @@ namespace Consul.Interfaces
 
         Task<QueryResult<ClusterPeeringStatus>> GetPeering(string name, CancellationToken cancellationToken = default);
         Task<QueryResult<ClusterPeeringStatus>> GetPeering(string name, QueryOptions q, CancellationToken cancellationToken = default);
+        Task<WriteResult> DeletePeering(string name, CancellationToken cancellationToken = default);
+        Task<WriteResult> DeletePeering(string name, WriteOptions q, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Consul.NET! Please provide the following information to help us review and merge
your changes effectively.
 -->

<!-- PR Title format
Please use one of the following formats for the title of your pull request above:
- [FEATURE]: <a one-liner summary of the changes>
- [ENHANCEMENT]: <a one-liner summary of the changes>
- [BUG FIX]: <a one-liner summary of the changes>
-->

## Description
This PR introduces support for a reading peering token in Consul by its name and the following changes were made:

Implemented the DeletePeering method to handle the request DELETE /v1/peering/:name.
Added a test ClusterPeeringTest_DeletePeering to validate changes.

<!-- (required)
A clear and concise description of the changes made in this pull request
-->

## Related Issues

<!-- (optional)
List any related issues, if applicable, using the format `#issue_number`
Example: #123
-->
Addresses issue #522 
## Additional Context

<!-- (optional)
Add any additional context or information about this pull request
-->

## Checklist

<!-- (required) -->
Please make sure to check the following before submitting your pull request:

- [x] Did you read the [contributing guidelines](https://consuldot.net/docs/contributing/guidelines)?
- [ ] Did you update the docs?
- [x] Did you write any tests to validate this change?
