### PR TITLE
[FEATURE] Suppress RS0041 warnings

### DIFF
--- a/Consul/Consul.csproj
+++ b/Consul/Consul.csproj
@@ -8,7 +8,6 @@
     <PackageOutputPath>../dist/consul</PackageOutputPath>
     <AssemblyTitle>Consul.NET</AssemblyTitle>
     <AssemblyProduct>Consul.NET</AssemblyProduct>
-    <NoWarn>$(NoWarn);RS0041</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Consul/PublicAPI/PublicAPI.Shipped.txt
+++ b/Consul/PublicAPI/PublicAPI.Shipped.txt
@@ -1,1 +1,0 @@
-#nullable enable

--- a/Consul/PublicAPI/PublicAPI.Unshipped.txt
+++ b/Consul/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,4 +1,3 @@
-#nullable enable
 Consul.AccessLogsConfig
 Consul.AccessLogsConfig.AccessLogsConfig() -> void
 Consul.AccessLogsConfig.DisableListenerLogs.get -> bool
@@ -1254,3033 +1253,3033 @@ static readonly Consul.Semaphore.DefaultSemaphoreRetryTime -> System.TimeSpan
 static readonly Consul.Semaphore.DefaultSemaphoreWaitTime -> System.TimeSpan
 virtual Consul.Agent.LogStream.Dispose(bool disposing) -> void
 virtual Consul.ConsulClient.Dispose(bool disposing) -> void
-~abstract Consul.Filtering.Filter.Encode() -> string
-~abstract Consul.Filtering.Selector.Encode() -> string
-~const Consul.DiscoveryChain.DiscoveryGraphNodeTypeResolver = "resolver" -> string
-~const Consul.DiscoveryChain.DiscoveryGraphNodeTypeRouter = "router" -> string
-~const Consul.DiscoveryChain.DiscoveryGraphNodeTypeSplitter = "splitter" -> string
-~const Consul.HealthStatus.NodeMaintenance = "_node_maintenance" -> string
-~const Consul.HealthStatus.ServiceMaintenancePrefix = "_service_maintenance:" -> string
-~Consul.AccessLogsConfig.JSONFormat.get -> string
-~Consul.AccessLogsConfig.JSONFormat.set -> void
-~Consul.AccessLogsConfig.Path.get -> string
-~Consul.AccessLogsConfig.Path.set -> void
-~Consul.AccessLogsConfig.TextFormat.get -> string
-~Consul.AccessLogsConfig.TextFormat.set -> void
-~Consul.AccessLogsConfig.Type.get -> string
-~Consul.AccessLogsConfig.Type.set -> void
-~Consul.ACL.Clone(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ACL.Clone(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ACL.Create(Consul.ACLEntry acl, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ACL.Create(Consul.ACLEntry acl, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ACL.Destroy(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.ACL.Destroy(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.ACL.Info(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry>>
-~Consul.ACL.Info(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry>>
-~Consul.ACL.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry[]>>
-~Consul.ACL.List(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry[]>>
-~Consul.ACL.TranslateLegacyTokenRules(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
-~Consul.ACL.TranslateLegacyTokenRules(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
-~Consul.ACL.TranslateRules(string rules, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ACL.TranslateRules(string rules, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ACL.Update(Consul.ACLEntry acl, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ACL.Update(Consul.ACLEntry acl, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ACLBindingRule.AuthMethod.get -> string
-~Consul.ACLBindingRule.AuthMethod.set -> void
-~Consul.ACLBindingRule.BindName.get -> string
-~Consul.ACLBindingRule.BindName.set -> void
-~Consul.ACLBindingRule.BindType.get -> string
-~Consul.ACLBindingRule.BindType.set -> void
-~Consul.ACLBindingRule.BindVars.get -> Consul.ACLTemplatedPolicyVariables
-~Consul.ACLBindingRule.BindVars.set -> void
-~Consul.ACLBindingRule.Description.get -> string
-~Consul.ACLBindingRule.Description.set -> void
-~Consul.ACLBindingRule.ID.get -> string
-~Consul.ACLBindingRule.ID.set -> void
-~Consul.ACLBindingRule.Selector.get -> string
-~Consul.ACLBindingRule.Selector.set -> void
-~Consul.ACLEntry.ACLEntry(string id, string name, string rules) -> void
-~Consul.ACLEntry.ACLEntry(string name, string rules) -> void
-~Consul.ACLEntry.ID.get -> string
-~Consul.ACLEntry.ID.set -> void
-~Consul.ACLEntry.Name.get -> string
-~Consul.ACLEntry.Name.set -> void
-~Consul.ACLEntry.Rules.get -> string
-~Consul.ACLEntry.Rules.set -> void
-~Consul.ACLEntry.Type.get -> Consul.ACLType
-~Consul.ACLEntry.Type.set -> void
-~Consul.ACLReplication.Status() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLReplicationEntry>>
-~Consul.ACLReplication.Status(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLReplicationEntry>>
-~Consul.ACLReplication.Status(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLReplicationEntry>>
-~Consul.ACLReplicationEntry.ACLReplicationEntry(bool enabled, bool running, string sourceDatacenter, string replicationType, ulong replicatedIndex, ulong replicatedRoleIndex, ulong replicatedTokenIndex, System.DateTime lastSuccess, System.DateTime lastError) -> void
-~Consul.ACLReplicationEntry.ReplicationType.get -> string
-~Consul.ACLReplicationEntry.ReplicationType.set -> void
-~Consul.ACLReplicationEntry.SourceDatacenter.get -> string
-~Consul.ACLReplicationEntry.SourceDatacenter.set -> void
-~Consul.ACLTemplatedPolicyVariables.Name.get -> string
-~Consul.ACLTemplatedPolicyVariables.Name.set -> void
-~Consul.ACLType.Equals(Consul.ACLType other) -> bool
-~Consul.ACLType.Type.get -> string
-~Consul.AddressDetails.Address.get -> string
-~Consul.AddressDetails.Address.set -> void
-~Consul.Agent.CheckDeregister(string checkID, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.CheckRegister(Consul.AgentCheckRegistration check, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.Checks() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentCheck>>>
-~Consul.Agent.Checks(Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentCheck>>>
-~Consul.Agent.Checks(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentCheck>>>
-~Consul.Agent.ConnectAuthorize(Consul.AgentAuthorizeParameters parameters) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AgentAuthorizeResponse>>
-~Consul.Agent.ConnectAuthorize(Consul.AgentAuthorizeParameters parameters, Consul.WriteOptions w, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AgentAuthorizeResponse>>
-~Consul.Agent.ConnectAuthorize(Consul.AgentAuthorizeParameters parameters, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AgentAuthorizeResponse>>
-~Consul.Agent.DisableNodeMaintenance(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.DisableServiceMaintenance(string serviceID, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.EnableNodeMaintenance(string reason, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.EnableServiceMaintenance(string serviceID, string reason, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.FailTTL(string checkID, string note, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.Agent.ForceLeave(string node, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.GetAgentHostInfo(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AgentHostInfo>>
-~Consul.Agent.GetAgentMetrics(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Metrics>>
-~Consul.Agent.GetAgentVersion(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AgentVersion>>
-~Consul.Agent.GetCALeaf(string serviceId) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CALeaf>>
-~Consul.Agent.GetCALeaf(string serviceId, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CALeaf>>
-~Consul.Agent.GetCALeaf(string serviceId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CALeaf>>
-~Consul.Agent.GetCARoots() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
-~Consul.Agent.GetCARoots(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
-~Consul.Agent.GetCARoots(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
-~Consul.Agent.GetLocalServiceHealth(string serviceName) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth[]>>
-~Consul.Agent.GetLocalServiceHealth(string serviceName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth[]>>
-~Consul.Agent.GetLocalServiceHealth(string serviceName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth[]>>
-~Consul.Agent.GetLocalServiceHealthByID(string serviceID) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth>>
-~Consul.Agent.GetLocalServiceHealthByID(string serviceID, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth>>
-~Consul.Agent.GetLocalServiceHealthByID(string serviceID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth>>
-~Consul.Agent.GetNodeName(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
-~Consul.Agent.GetServiceConfiguration(string serviceId) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceConfiguration>>
-~Consul.Agent.GetServiceConfiguration(string serviceId, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceConfiguration>>
-~Consul.Agent.GetServiceConfiguration(string serviceId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceConfiguration>>
-~Consul.Agent.GetWorstLocalServiceHealth(string serviceName) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
-~Consul.Agent.GetWorstLocalServiceHealth(string serviceName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
-~Consul.Agent.GetWorstLocalServiceHealth(string serviceName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
-~Consul.Agent.Join(string addr, bool wan, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.Leave(string node, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.LogStream.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Threading.Tasks.Task<string>>
-~Consul.Agent.Members(bool wan, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AgentMember[]>>
-~Consul.Agent.Monitor(Consul.LogLevel level = Consul.LogLevel.Info, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.Agent.LogStream>
-~Consul.Agent.MonitorJSON(Consul.LogLevel level = Consul.LogLevel.Info, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.Agent.LogStream>
-~Consul.Agent.NodeName.get -> string
-~Consul.Agent.PassTTL(string checkID, string note, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.Agent.Reload() -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.Reload(string node, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.Reload(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.Self(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, dynamic>>>>
-~Consul.Agent.ServiceDeregister(string serviceID, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.ServiceRegister(Consul.AgentServiceRegistration service) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.ServiceRegister(Consul.AgentServiceRegistration service, bool replaceExistingChecks, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.ServiceRegister(Consul.AgentServiceRegistration service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.Services() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentService>>>
-~Consul.Agent.Services(Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentService>>>
-~Consul.Agent.Services(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentService>>>
-~Consul.Agent.UpdateTTL(string checkID, string output, Consul.TTLStatus status, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Agent.WarnTTL(string checkID, string note, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.AgentAuthorizeParameters.ClientCertSerial.get -> string
-~Consul.AgentAuthorizeParameters.ClientCertSerial.set -> void
-~Consul.AgentAuthorizeParameters.ClientCertURI.get -> string
-~Consul.AgentAuthorizeParameters.ClientCertURI.set -> void
-~Consul.AgentAuthorizeParameters.Target.get -> string
-~Consul.AgentAuthorizeParameters.Target.set -> void
-~Consul.AgentAuthorizeResponse.Reason.get -> string
-~Consul.AgentAuthorizeResponse.Reason.set -> void
-~Consul.AgentCheck.CheckID.get -> string
-~Consul.AgentCheck.CheckID.set -> void
-~Consul.AgentCheck.Name.get -> string
-~Consul.AgentCheck.Name.set -> void
-~Consul.AgentCheck.Node.get -> string
-~Consul.AgentCheck.Node.set -> void
-~Consul.AgentCheck.Notes.get -> string
-~Consul.AgentCheck.Notes.set -> void
-~Consul.AgentCheck.Output.get -> string
-~Consul.AgentCheck.Output.set -> void
-~Consul.AgentCheck.ServiceID.get -> string
-~Consul.AgentCheck.ServiceID.set -> void
-~Consul.AgentCheck.ServiceName.get -> string
-~Consul.AgentCheck.ServiceName.set -> void
-~Consul.AgentCheck.Status.get -> Consul.HealthStatus
-~Consul.AgentCheck.Status.set -> void
-~Consul.AgentCheck.Type.get -> string
-~Consul.AgentCheck.Type.set -> void
-~Consul.AgentCheckRegistration.ServiceID.get -> string
-~Consul.AgentCheckRegistration.ServiceID.set -> void
-~Consul.AgentHostInfo.CPU.get -> System.Collections.Generic.List<Consul.CPUInfo>
-~Consul.AgentHostInfo.CPU.set -> void
-~Consul.AgentHostInfo.Disk.get -> Consul.DiskInfo
-~Consul.AgentHostInfo.Disk.set -> void
-~Consul.AgentHostInfo.Host.get -> Consul.HostInfo
-~Consul.AgentHostInfo.Host.set -> void
-~Consul.AgentHostInfo.Memory.get -> Consul.MemoryInfo
-~Consul.AgentHostInfo.Memory.set -> void
-~Consul.AgentMember.Addr.get -> string
-~Consul.AgentMember.Addr.set -> void
-~Consul.AgentMember.Name.get -> string
-~Consul.AgentMember.Name.set -> void
-~Consul.AgentMember.Tags.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.AgentMember.Tags.set -> void
-~Consul.AgentService.Address.get -> string
-~Consul.AgentService.Address.set -> void
-~Consul.AgentService.ID.get -> string
-~Consul.AgentService.ID.set -> void
-~Consul.AgentService.Kind.get -> Consul.ServiceKind
-~Consul.AgentService.Kind.set -> void
-~Consul.AgentService.Meta.get -> System.Collections.Generic.IDictionary<string, string>
-~Consul.AgentService.Meta.set -> void
-~Consul.AgentService.Proxy.get -> Consul.AgentServiceProxy
-~Consul.AgentService.Proxy.set -> void
-~Consul.AgentService.Service.get -> string
-~Consul.AgentService.Service.set -> void
-~Consul.AgentService.TaggedAddresses.get -> System.Collections.Generic.IDictionary<string, Consul.ServiceTaggedAddress>
-~Consul.AgentService.TaggedAddresses.set -> void
-~Consul.AgentService.Tags.get -> string[]
-~Consul.AgentService.Tags.set -> void
-~Consul.AgentServiceCheck.AliasNode.get -> string
-~Consul.AgentServiceCheck.AliasNode.set -> void
-~Consul.AgentServiceCheck.AliasService.get -> string
-~Consul.AgentServiceCheck.AliasService.set -> void
-~Consul.AgentServiceCheck.Args.get -> string[]
-~Consul.AgentServiceCheck.Args.set -> void
-~Consul.AgentServiceCheck.Body.get -> string
-~Consul.AgentServiceCheck.Body.set -> void
-~Consul.AgentServiceCheck.CheckID.get -> string
-~Consul.AgentServiceCheck.CheckID.set -> void
-~Consul.AgentServiceCheck.DockerContainerID.get -> string
-~Consul.AgentServiceCheck.DockerContainerID.set -> void
-~Consul.AgentServiceCheck.GRPC.get -> string
-~Consul.AgentServiceCheck.GRPC.set -> void
-~Consul.AgentServiceCheck.Header.get -> System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>>
-~Consul.AgentServiceCheck.Header.set -> void
-~Consul.AgentServiceCheck.HTTP.get -> string
-~Consul.AgentServiceCheck.HTTP.set -> void
-~Consul.AgentServiceCheck.ID.get -> string
-~Consul.AgentServiceCheck.ID.set -> void
-~Consul.AgentServiceCheck.Method.get -> string
-~Consul.AgentServiceCheck.Method.set -> void
-~Consul.AgentServiceCheck.Name.get -> string
-~Consul.AgentServiceCheck.Name.set -> void
-~Consul.AgentServiceCheck.Notes.get -> string
-~Consul.AgentServiceCheck.Notes.set -> void
-~Consul.AgentServiceCheck.Script.get -> string
-~Consul.AgentServiceCheck.Script.set -> void
-~Consul.AgentServiceCheck.Shell.get -> string
-~Consul.AgentServiceCheck.Shell.set -> void
-~Consul.AgentServiceCheck.Status.get -> Consul.HealthStatus
-~Consul.AgentServiceCheck.Status.set -> void
-~Consul.AgentServiceCheck.TCP.get -> string
-~Consul.AgentServiceCheck.TCP.set -> void
-~Consul.AgentServiceConnect.SidecarService.get -> Consul.AgentServiceRegistration
-~Consul.AgentServiceConnect.SidecarService.set -> void
-~Consul.AgentServiceProxy.DestinationServiceID.get -> string
-~Consul.AgentServiceProxy.DestinationServiceID.set -> void
-~Consul.AgentServiceProxy.DestinationServiceName.get -> string
-~Consul.AgentServiceProxy.DestinationServiceName.set -> void
-~Consul.AgentServiceProxy.LocalServiceAddress.get -> string
-~Consul.AgentServiceProxy.LocalServiceAddress.set -> void
-~Consul.AgentServiceProxy.Upstreams.get -> Consul.AgentServiceProxyUpstream[]
-~Consul.AgentServiceProxy.Upstreams.set -> void
-~Consul.AgentServiceProxyUpstream.DestinationName.get -> string
-~Consul.AgentServiceProxyUpstream.DestinationName.set -> void
-~Consul.AgentServiceRegistration.Address.get -> string
-~Consul.AgentServiceRegistration.Address.set -> void
-~Consul.AgentServiceRegistration.Check.get -> Consul.AgentServiceCheck
-~Consul.AgentServiceRegistration.Check.set -> void
-~Consul.AgentServiceRegistration.Checks.get -> Consul.AgentServiceCheck[]
-~Consul.AgentServiceRegistration.Checks.set -> void
-~Consul.AgentServiceRegistration.Connect.get -> Consul.AgentServiceConnect
-~Consul.AgentServiceRegistration.Connect.set -> void
-~Consul.AgentServiceRegistration.ID.get -> string
-~Consul.AgentServiceRegistration.ID.set -> void
-~Consul.AgentServiceRegistration.Kind.get -> Consul.ServiceKind
-~Consul.AgentServiceRegistration.Kind.set -> void
-~Consul.AgentServiceRegistration.Meta.get -> System.Collections.Generic.IDictionary<string, string>
-~Consul.AgentServiceRegistration.Meta.set -> void
-~Consul.AgentServiceRegistration.Name.get -> string
-~Consul.AgentServiceRegistration.Name.set -> void
-~Consul.AgentServiceRegistration.Proxy.get -> Consul.AgentServiceProxy
-~Consul.AgentServiceRegistration.Proxy.set -> void
-~Consul.AgentServiceRegistration.TaggedAddresses.get -> System.Collections.Generic.IDictionary<string, Consul.ServiceTaggedAddress>
-~Consul.AgentServiceRegistration.TaggedAddresses.set -> void
-~Consul.AgentServiceRegistration.Tags.get -> string[]
-~Consul.AgentServiceRegistration.Tags.set -> void
-~Consul.AgentVersion.FIPS.get -> string
-~Consul.AgentVersion.FIPS.set -> void
-~Consul.AgentVersion.HumanVersion.get -> string
-~Consul.AgentVersion.HumanVersion.set -> void
-~Consul.AgentVersion.SHA.get -> string
-~Consul.AgentVersion.SHA.set -> void
-~Consul.ApiGatewayCertificate.Kind.get -> string
-~Consul.ApiGatewayCertificate.Kind.set -> void
-~Consul.ApiGatewayCertificate.Name.get -> string
-~Consul.ApiGatewayCertificate.Name.set -> void
-~Consul.ApiGatewayCertificate.Namespace.get -> string
-~Consul.ApiGatewayCertificate.Namespace.set -> void
-~Consul.ApiGatewayCertificate.Partition.get -> string
-~Consul.ApiGatewayCertificate.Partition.set -> void
-~Consul.ApiGatewayEntry.Kind.get -> string
-~Consul.ApiGatewayEntry.Kind.set -> void
-~Consul.ApiGatewayEntry.Listeners.get -> System.Collections.Generic.List<Consul.ApiGatewayListener>
-~Consul.ApiGatewayEntry.Listeners.set -> void
-~Consul.ApiGatewayEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ApiGatewayEntry.Meta.set -> void
-~Consul.ApiGatewayEntry.Name.get -> string
-~Consul.ApiGatewayEntry.Name.set -> void
-~Consul.ApiGatewayEntry.Namespace.get -> string
-~Consul.ApiGatewayEntry.Namespace.set -> void
-~Consul.ApiGatewayEntry.Partition.get -> string
-~Consul.ApiGatewayEntry.Partition.set -> void
-~Consul.ApiGatewayJWTProvider.Name.get -> string
-~Consul.ApiGatewayJWTProvider.Name.set -> void
-~Consul.ApiGatewayJWTProvider.VerifyClaims.get -> Consul.ApiGatewayVerifyClaims
-~Consul.ApiGatewayJWTProvider.VerifyClaims.set -> void
-~Consul.ApiGatewayJWTSettings.Providers.get -> System.Collections.Generic.List<Consul.ApiGatewayJWTProvider>
-~Consul.ApiGatewayJWTSettings.Providers.set -> void
-~Consul.ApiGatewayListener.Default.get -> Consul.ApiGatewayOverrideSettings
-~Consul.ApiGatewayListener.Default.set -> void
-~Consul.ApiGatewayListener.Name.get -> string
-~Consul.ApiGatewayListener.Name.set -> void
-~Consul.ApiGatewayListener.Override.get -> Consul.ApiGatewayOverrideSettings
-~Consul.ApiGatewayListener.Override.set -> void
-~Consul.ApiGatewayListener.Protocol.get -> string
-~Consul.ApiGatewayListener.Protocol.set -> void
-~Consul.ApiGatewayListener.TLS.get -> Consul.ApiGatewayTLS
-~Consul.ApiGatewayListener.TLS.set -> void
-~Consul.ApiGatewayOverrideSettings.JWT.get -> Consul.ApiGatewayJWTSettings
-~Consul.ApiGatewayOverrideSettings.JWT.set -> void
-~Consul.ApiGatewayReference.Kind.get -> string
-~Consul.ApiGatewayReference.Kind.set -> void
-~Consul.ApiGatewayReference.Name.get -> string
-~Consul.ApiGatewayReference.Name.set -> void
-~Consul.ApiGatewayReference.Namespace.get -> string
-~Consul.ApiGatewayReference.Namespace.set -> void
-~Consul.ApiGatewayReference.Partition.get -> string
-~Consul.ApiGatewayReference.Partition.set -> void
-~Consul.ApiGatewayReference.SectionName.get -> string
-~Consul.ApiGatewayReference.SectionName.set -> void
-~Consul.ApiGatewayTLS.Certificates.get -> System.Collections.Generic.List<Consul.ApiGatewayCertificate>
-~Consul.ApiGatewayTLS.Certificates.set -> void
-~Consul.ApiGatewayTLS.CipherSuites.get -> System.Collections.Generic.List<string>
-~Consul.ApiGatewayTLS.CipherSuites.set -> void
-~Consul.ApiGatewayTLS.MaxVersion.get -> string
-~Consul.ApiGatewayTLS.MaxVersion.set -> void
-~Consul.ApiGatewayTLS.MinVersion.get -> string
-~Consul.ApiGatewayTLS.MinVersion.set -> void
-~Consul.ApiGatewayVerifyClaims.Path.get -> System.Collections.Generic.List<string>
-~Consul.ApiGatewayVerifyClaims.Path.set -> void
-~Consul.ApiGatewayVerifyClaims.Value.get -> string
-~Consul.ApiGatewayVerifyClaims.Value.set -> void
-~Consul.Area.ID.get -> string
-~Consul.Area.ID.set -> void
-~Consul.AreaRequest.PeerDatacenter.get -> string
-~Consul.AreaRequest.PeerDatacenter.set -> void
-~Consul.AreaRequest.RetryJoin.get -> string[]
-~Consul.AreaRequest.RetryJoin.set -> void
-~Consul.AuthMethod.Create(Consul.AuthMethodEntry authMethod) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
-~Consul.AuthMethod.Create(Consul.AuthMethodEntry authMethod, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
-~Consul.AuthMethod.Create(Consul.AuthMethodEntry authMethod, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
-~Consul.AuthMethod.Delete(string name) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.AuthMethod.Delete(string name, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.AuthMethod.Delete(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.AuthMethod.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry[]>>
-~Consul.AuthMethod.List(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry[]>>
-~Consul.AuthMethod.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry[]>>
-~Consul.AuthMethod.Login() -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.AuthMethod.Login(Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.AuthMethod.Login(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.AuthMethod.Logout() -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.AuthMethod.Logout(Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.AuthMethod.Logout(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.AuthMethod.Read(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry>>
-~Consul.AuthMethod.Read(string name, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry>>
-~Consul.AuthMethod.Read(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry>>
-~Consul.AuthMethod.Update(Consul.AuthMethodEntry authMethod) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
-~Consul.AuthMethod.Update(Consul.AuthMethodEntry authMethod, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
-~Consul.AuthMethod.Update(Consul.AuthMethodEntry authMethod, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
-~Consul.AuthMethodEntry.AuthMethodEntry(string name, string type, string description, System.Collections.Generic.Dictionary<string, string> config) -> void
-~Consul.AuthMethodEntry.AuthMethodEntry(string name, string type, System.Collections.Generic.Dictionary<string, string> config) -> void
-~Consul.AuthMethodEntry.Config.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.AuthMethodEntry.Config.set -> void
-~Consul.AuthMethodEntry.Description.get -> string
-~Consul.AuthMethodEntry.Description.set -> void
-~Consul.AuthMethodEntry.Name.get -> string
-~Consul.AuthMethodEntry.Name.set -> void
-~Consul.AuthMethodEntry.Type.get -> string
-~Consul.AuthMethodEntry.Type.set -> void
-~Consul.AutopilotConfiguration.LastContactThreshold.get -> string
-~Consul.AutopilotConfiguration.LastContactThreshold.set -> void
-~Consul.AutopilotConfiguration.RedundancyZoneTag.get -> string
-~Consul.AutopilotConfiguration.RedundancyZoneTag.set -> void
-~Consul.AutopilotConfiguration.ServerStabilizationTime.get -> string
-~Consul.AutopilotConfiguration.ServerStabilizationTime.set -> void
-~Consul.AutopilotConfiguration.UpgradeVersionTag.get -> string
-~Consul.AutopilotConfiguration.UpgradeVersionTag.set -> void
-~Consul.AutopilotHealth.Servers.get -> System.Collections.Generic.List<Consul.AutopilotServerHealth>
-~Consul.AutopilotHealth.Servers.set -> void
-~Consul.AutopilotServerHealth.Address.get -> string
-~Consul.AutopilotServerHealth.Address.set -> void
-~Consul.AutopilotServerHealth.ID.get -> string
-~Consul.AutopilotServerHealth.ID.set -> void
-~Consul.AutopilotServerHealth.LastContact.get -> string
-~Consul.AutopilotServerHealth.LastContact.set -> void
-~Consul.AutopilotServerHealth.Name.get -> string
-~Consul.AutopilotServerHealth.Name.set -> void
-~Consul.AutopilotServerHealth.SerfStatus.get -> string
-~Consul.AutopilotServerHealth.SerfStatus.set -> void
-~Consul.AutopilotServerHealth.Version.get -> string
-~Consul.AutopilotServerHealth.Version.set -> void
-~Consul.AutopilotServerState.Address.get -> string
-~Consul.AutopilotServerState.Address.set -> void
-~Consul.AutopilotServerState.ID.get -> string
-~Consul.AutopilotServerState.ID.set -> void
-~Consul.AutopilotServerState.LastContact.get -> string
-~Consul.AutopilotServerState.LastContact.set -> void
-~Consul.AutopilotServerState.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.AutopilotServerState.Meta.set -> void
-~Consul.AutopilotServerState.Name.get -> string
-~Consul.AutopilotServerState.Name.set -> void
-~Consul.AutopilotServerState.NodeStatus.get -> string
-~Consul.AutopilotServerState.NodeStatus.set -> void
-~Consul.AutopilotServerState.NodeType.get -> string
-~Consul.AutopilotServerState.NodeType.set -> void
-~Consul.AutopilotServerState.RedundancyZone.get -> string
-~Consul.AutopilotServerState.RedundancyZone.set -> void
-~Consul.AutopilotServerState.Status.get -> string
-~Consul.AutopilotServerState.Status.set -> void
-~Consul.AutopilotServerState.UpgradeVersion.get -> string
-~Consul.AutopilotServerState.UpgradeVersion.set -> void
-~Consul.AutopilotServerState.Version.get -> string
-~Consul.AutopilotServerState.Version.set -> void
-~Consul.AutopilotState.Leader.get -> string
-~Consul.AutopilotState.Leader.set -> void
-~Consul.AutopilotState.ReadReplicas.get -> System.Collections.Generic.List<string>
-~Consul.AutopilotState.ReadReplicas.set -> void
-~Consul.AutopilotState.RedundancyZones.get -> System.Collections.Generic.Dictionary<string, object>
-~Consul.AutopilotState.RedundancyZones.set -> void
-~Consul.AutopilotState.Servers.get -> System.Collections.Generic.Dictionary<string, Consul.AutopilotServerState>
-~Consul.AutopilotState.Servers.set -> void
-~Consul.AutopilotState.Upgrade.get -> object
-~Consul.AutopilotState.Upgrade.set -> void
-~Consul.AutopilotState.Voters.get -> System.Collections.Generic.List<string>
-~Consul.AutopilotState.Voters.set -> void
-~Consul.BindingRule.Create(Consul.ACLBindingRule entry) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
-~Consul.BindingRule.Create(Consul.ACLBindingRule entry, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
-~Consul.BindingRule.Create(Consul.ACLBindingRule entry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
-~Consul.BindingRule.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.BindingRule.Delete(string id, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.BindingRule.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.BindingRule.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse[]>>
-~Consul.BindingRule.List(Consul.QueryOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse[]>>
-~Consul.BindingRule.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse[]>>
-~Consul.BindingRule.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse>>
-~Consul.BindingRule.Read(string id, Consul.QueryOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse>>
-~Consul.BindingRule.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse>>
-~Consul.BindingRule.Update(Consul.ACLBindingRule entry) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
-~Consul.BindingRule.Update(Consul.ACLBindingRule entry, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
-~Consul.BindingRule.Update(Consul.ACLBindingRule entry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
-~Consul.CaCertificateProviderInstanceConfig.CertificateName.get -> string
-~Consul.CaCertificateProviderInstanceConfig.CertificateName.set -> void
-~Consul.CaCertificateProviderInstanceConfig.InstanceName.get -> string
-~Consul.CaCertificateProviderInstanceConfig.InstanceName.set -> void
-~Consul.CacheConfig.Size.get -> string
-~Consul.CacheConfig.Size.set -> void
-~Consul.CAConfig.Config.get -> System.Collections.Generic.Dictionary<string, object>
-~Consul.CAConfig.Config.set -> void
-~Consul.CAConfig.Provider.get -> string
-~Consul.CAConfig.Provider.set -> void
-~Consul.CAConfig.State.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.CAConfig.State.set -> void
-~Consul.CALeaf.CertPEM.get -> string
-~Consul.CALeaf.CertPEM.set -> void
-~Consul.CALeaf.PrivateKeyPEM.get -> string
-~Consul.CALeaf.PrivateKeyPEM.set -> void
-~Consul.CALeaf.SerialNumber.get -> string
-~Consul.CALeaf.SerialNumber.set -> void
-~Consul.CALeaf.Service.get -> string
-~Consul.CALeaf.Service.set -> void
-~Consul.CALeaf.ServiceURI.get -> string
-~Consul.CALeaf.ServiceURI.set -> void
-~Consul.CARoots.ActiveRootID.get -> string
-~Consul.CARoots.ActiveRootID.set -> void
-~Consul.CARoots.Roots.get -> System.Collections.Generic.List<Consul.Root>
-~Consul.CARoots.Roots.set -> void
-~Consul.CARoots.TrustDomain.get -> string
-~Consul.CARoots.TrustDomain.set -> void
-~Consul.Catalog.Datacenters() -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.Catalog.Datacenters(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.Catalog.Datacenters(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.Catalog.Deregister(Consul.CatalogDeregistration reg) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Catalog.Deregister(Consul.CatalogDeregistration reg, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Catalog.Deregister(Consul.CatalogDeregistration reg, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Catalog.GatewayService(string gateway) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.GatewayService[]>>
-~Consul.Catalog.GatewayService(string gateway, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.GatewayService[]>>
-~Consul.Catalog.GatewayService(string gateway, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.GatewayService[]>>
-~Consul.Catalog.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogNode>>
-~Consul.Catalog.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogNode>>
-~Consul.Catalog.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogNode>>
-~Consul.Catalog.Nodes() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Node[]>>
-~Consul.Catalog.Nodes(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Node[]>>
-~Consul.Catalog.Nodes(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Node[]>>
-~Consul.Catalog.NodesForMeshCapableService(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.Catalog.NodesForMeshCapableService(string service, Consul.Filtering.Filter filter) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.Catalog.NodesForMeshCapableService(string service, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.Catalog.NodesForMeshCapableService(string service, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.Catalog.NodesForMeshCapableService(string service, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.Catalog.NodesForMeshCapableService(string service, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.Catalog.NodesForMeshCapableService(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.Catalog.Register(Consul.CatalogRegistration reg) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Catalog.Register(Consul.CatalogRegistration reg, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Catalog.Register(Consul.CatalogRegistration reg, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Catalog.Service(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.Catalog.Service(string service, string tag) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.Catalog.Service(string service, string tag, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.Catalog.Service(string service, string tag, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.Catalog.Service(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.Catalog.Services() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.Catalog.Services(Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.Catalog.Services(Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.Catalog.Services(string dc, Consul.Filtering.Filter filter) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.Catalog.Services(string dc, Consul.Filtering.Filter filter, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.Catalog.Services(string dc, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.Catalog.Services(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.Catalog.ServicesForNode(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NodeService>>
-~Consul.Catalog.ServicesForNode(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NodeService>>
-~Consul.Catalog.ServicesForNode(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NodeService>>
-~Consul.CatalogDeregistration.Address.get -> string
-~Consul.CatalogDeregistration.Address.set -> void
-~Consul.CatalogDeregistration.CheckID.get -> string
-~Consul.CatalogDeregistration.CheckID.set -> void
-~Consul.CatalogDeregistration.Datacenter.get -> string
-~Consul.CatalogDeregistration.Datacenter.set -> void
-~Consul.CatalogDeregistration.Node.get -> string
-~Consul.CatalogDeregistration.Node.set -> void
-~Consul.CatalogDeregistration.ServiceID.get -> string
-~Consul.CatalogDeregistration.ServiceID.set -> void
-~Consul.CatalogNode.Node.get -> Consul.Node
-~Consul.CatalogNode.Node.set -> void
-~Consul.CatalogNode.Services.get -> System.Collections.Generic.Dictionary<string, Consul.AgentService>
-~Consul.CatalogNode.Services.set -> void
-~Consul.CatalogRegistration.Address.get -> string
-~Consul.CatalogRegistration.Address.set -> void
-~Consul.CatalogRegistration.Check.get -> Consul.AgentCheck
-~Consul.CatalogRegistration.Check.set -> void
-~Consul.CatalogRegistration.Datacenter.get -> string
-~Consul.CatalogRegistration.Datacenter.set -> void
-~Consul.CatalogRegistration.Node.get -> string
-~Consul.CatalogRegistration.Node.set -> void
-~Consul.CatalogRegistration.Service.get -> Consul.AgentService
-~Consul.CatalogRegistration.Service.set -> void
-~Consul.CatalogService.Address.get -> string
-~Consul.CatalogService.Address.set -> void
-~Consul.CatalogService.Node.get -> string
-~Consul.CatalogService.Node.set -> void
-~Consul.CatalogService.ServiceAddress.get -> string
-~Consul.CatalogService.ServiceAddress.set -> void
-~Consul.CatalogService.ServiceID.get -> string
-~Consul.CatalogService.ServiceID.set -> void
-~Consul.CatalogService.ServiceMeta.get -> System.Collections.Generic.IDictionary<string, string>
-~Consul.CatalogService.ServiceMeta.set -> void
-~Consul.CatalogService.ServiceName.get -> string
-~Consul.CatalogService.ServiceName.set -> void
-~Consul.CatalogService.ServiceTaggedAddresses.get -> System.Collections.Generic.Dictionary<string, Consul.ServiceTaggedAddress>
-~Consul.CatalogService.ServiceTaggedAddresses.set -> void
-~Consul.CatalogService.ServiceTags.get -> string[]
-~Consul.CatalogService.ServiceTags.set -> void
-~Consul.ClusterPeering.DeletePeering(string name, Consul.WriteOptions options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ClusterPeering.DeletePeering(string name, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ClusterPeering.GenerateToken(Consul.ClusterPeeringTokenEntry tokenEntry) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ClusterPeeringTokenResponse>>
-~Consul.ClusterPeering.GenerateToken(Consul.ClusterPeeringTokenEntry tokenEntry, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ClusterPeeringTokenResponse>>
-~Consul.ClusterPeering.GenerateToken(Consul.ClusterPeeringTokenEntry tokenEntry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ClusterPeeringTokenResponse>>
-~Consul.ClusterPeering.GetPeering(string name, Consul.QueryOptions options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus>>
-~Consul.ClusterPeering.GetPeering(string name, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus>>
-~Consul.ClusterPeering.ListPeerings() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus[]>>
-~Consul.ClusterPeering.ListPeerings(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus[]>>
-~Consul.ClusterPeering.ListPeerings(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus[]>>
-~Consul.ClusterPeeringStatus.ID.get -> string
-~Consul.ClusterPeeringStatus.ID.set -> void
-~Consul.ClusterPeeringStatus.Name.get -> string
-~Consul.ClusterPeeringStatus.Name.set -> void
-~Consul.ClusterPeeringStatus.PeerID.get -> string
-~Consul.ClusterPeeringStatus.PeerID.set -> void
-~Consul.ClusterPeeringStatus.PeerServerAddresses.get -> string[]
-~Consul.ClusterPeeringStatus.PeerServerAddresses.set -> void
-~Consul.ClusterPeeringStatus.PeerServerName.get -> string
-~Consul.ClusterPeeringStatus.PeerServerName.set -> void
-~Consul.ClusterPeeringStatus.Remote.get -> Consul.PeeringRemoteInfo
-~Consul.ClusterPeeringStatus.Remote.set -> void
-~Consul.ClusterPeeringStatus.State.get -> string
-~Consul.ClusterPeeringStatus.State.set -> void
-~Consul.ClusterPeeringStatus.StreamStatus.get -> Consul.PeeringStreamStatus
-~Consul.ClusterPeeringStatus.StreamStatus.set -> void
-~Consul.ClusterPeeringTokenEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ClusterPeeringTokenEntry.Meta.set -> void
-~Consul.ClusterPeeringTokenEntry.PeerName.get -> string
-~Consul.ClusterPeeringTokenEntry.PeerName.set -> void
-~Consul.ClusterPeeringTokenResponse.PeeringToken.get -> string
-~Consul.ClusterPeeringTokenResponse.PeeringToken.set -> void
-~Consul.CompiledDiscoveryChain.CustomizationHash.get -> string
-~Consul.CompiledDiscoveryChain.CustomizationHash.set -> void
-~Consul.CompiledDiscoveryChain.Datacenter.get -> string
-~Consul.CompiledDiscoveryChain.Datacenter.set -> void
-~Consul.CompiledDiscoveryChain.Namespace.get -> string
-~Consul.CompiledDiscoveryChain.Namespace.set -> void
-~Consul.CompiledDiscoveryChain.Nodes.get -> System.Collections.Generic.Dictionary<string, Consul.DiscoveryGraphNode>
-~Consul.CompiledDiscoveryChain.Nodes.set -> void
-~Consul.CompiledDiscoveryChain.Protocol.get -> string
-~Consul.CompiledDiscoveryChain.Protocol.set -> void
-~Consul.CompiledDiscoveryChain.ServiceName.get -> string
-~Consul.CompiledDiscoveryChain.ServiceName.set -> void
-~Consul.CompiledDiscoveryChain.StartNode.get -> string
-~Consul.CompiledDiscoveryChain.StartNode.set -> void
-~Consul.CompiledDiscoveryChain.Targets.get -> System.Collections.Generic.Dictionary<string, Consul.DiscoveryTarget>
-~Consul.CompiledDiscoveryChain.Targets.set -> void
-~Consul.CompoundServiceName.Name.get -> string
-~Consul.CompoundServiceName.Name.set -> void
-~Consul.CompoundServiceName.Namespace.get -> string
-~Consul.CompoundServiceName.Namespace.set -> void
-~Consul.CompoundServiceName.Partition.get -> string
-~Consul.CompoundServiceName.Partition.set -> void
-~Consul.Configuration.ApplyConfig<TConfig>(Consul.WriteOptions q, TConfig configurationEntry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Configuration.ApplyConfig<TConfig>(TConfig configurationEntry) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Configuration.ApplyConfig<TConfig>(TConfig configurationEntry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Configuration.DeleteConfig(string kind, string name) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Configuration.DeleteConfig(string kind, string name, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Configuration.DeleteConfig(string kind, string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Configuration.GetConfig<TConfig>(string kind, string name) -> System.Threading.Tasks.Task<Consul.QueryResult<TConfig>>
-~Consul.Configuration.GetConfig<TConfig>(string kind, string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<TConfig>>
-~Consul.Configuration.GetConfig<TConfig>(string kind, string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<TConfig>>
-~Consul.Configuration.ListConfig<TConfig>(string kind) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<TConfig>>>
-~Consul.Configuration.ListConfig<TConfig>(string kind, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<TConfig>>>
-~Consul.Configuration.ListConfig<TConfig>(string kind, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<TConfig>>>
-~Consul.Connect.CAGetConfig() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CAConfig>>
-~Consul.Connect.CAGetConfig(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CAConfig>>
-~Consul.Connect.CAGetConfig(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CAConfig>>
-~Consul.Connect.CARoots() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
-~Consul.Connect.CARoots(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
-~Consul.Connect.CARoots(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
-~Consul.Connect.CASetConfig(Consul.CAConfig config) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Connect.CASetConfig(Consul.CAConfig config, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Connect.CASetConfig(Consul.CAConfig config, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Connect.CheckIntentionResult(string source, string destination) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceIntentionResultResponse>>
-~Consul.Connect.CheckIntentionResult(string source, string destination, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceIntentionResultResponse>>
-~Consul.Connect.CheckIntentionResult(string source, string destination, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceIntentionResultResponse>>
-~Consul.Connect.DeleteIntentionByName(string source, string destination) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Connect.DeleteIntentionByName(string source, string destination, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Connect.DeleteIntentionByName(string source, string destination, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Connect.ListIntentions<ServiceIntention>() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<ServiceIntention>>>
-~Consul.Connect.ListIntentions<ServiceIntention>(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<ServiceIntention>>>
-~Consul.Connect.ListIntentions<ServiceIntention>(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<ServiceIntention>>>
-~Consul.Connect.ListMatchingIntentions(string by, string name) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Consul.ServiceIntention>>>>
-~Consul.Connect.ListMatchingIntentions(string by, string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Consul.ServiceIntention>>>>
-~Consul.Connect.ListMatchingIntentions(string by, string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Consul.ServiceIntention>>>>
-~Consul.Connect.ReadSpecificIntentionByName<ServiceIntention>(string source, string destination) -> System.Threading.Tasks.Task<Consul.QueryResult<ServiceIntention>>
-~Consul.Connect.ReadSpecificIntentionByName<ServiceIntention>(string source, string destination, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<ServiceIntention>>
-~Consul.Connect.ReadSpecificIntentionByName<ServiceIntention>(string source, string destination, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<ServiceIntention>>
-~Consul.Connect.UpsertIntentionsByName(Consul.ServiceIntention intention) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Connect.UpsertIntentionsByName(Consul.ServiceIntention intention, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Connect.UpsertIntentionsByName(Consul.ServiceIntention intention, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.ConsulClient.ACL.get -> Consul.IACLEndpoint
-~Consul.ConsulClient.ACLReplication.get -> Consul.IACLReplicationEndpoint
-~Consul.ConsulClient.AcquireLock(Consul.LockOptions opts) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
-~Consul.ConsulClient.AcquireLock(Consul.LockOptions opts, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
-~Consul.ConsulClient.AcquireLock(string key) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
-~Consul.ConsulClient.AcquireLock(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
-~Consul.ConsulClient.AcquireSemaphore(Consul.SemaphoreOptions opts) -> System.Threading.Tasks.Task<Consul.IDistributedSemaphore>
-~Consul.ConsulClient.AcquireSemaphore(Consul.SemaphoreOptions opts, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.IDistributedSemaphore>
-~Consul.ConsulClient.AcquireSemaphore(string prefix, int limit, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.IDistributedSemaphore>
-~Consul.ConsulClient.Agent.get -> Consul.IAgentEndpoint
-~Consul.ConsulClient.AuthMethod.get -> Consul.IAuthMethodEndpoint
-~Consul.ConsulClient.BindingRule.get -> Consul.Interfaces.IBindingRuleEndpoint
-~Consul.ConsulClient.Catalog.get -> Consul.ICatalogEndpoint
-~Consul.ConsulClient.ClusterPeering.get -> Consul.Interfaces.IClusterPeeringEndpoint
-~Consul.ConsulClient.Config.get -> Consul.ConsulClientConfiguration
-~Consul.ConsulClient.Configuration.get -> Consul.Interfaces.IConfigurationEndpoint
-~Consul.ConsulClient.Connect.get -> Consul.Interfaces.IConnectEndpoint
-~Consul.ConsulClient.ConsulClient(Consul.ConsulClientConfiguration config) -> void
-~Consul.ConsulClient.ConsulClient(Consul.ConsulClientConfiguration config, System.Net.Http.HttpClient client) -> void
-~Consul.ConsulClient.ConsulClient(System.Action<Consul.ConsulClientConfiguration> configOverride) -> void
-~Consul.ConsulClient.ConsulClient(System.Action<Consul.ConsulClientConfiguration> configOverride, System.Action<System.Net.Http.HttpClient> clientOverride) -> void
-~Consul.ConsulClient.Coordinate.get -> Consul.ICoordinateEndpoint
-~Consul.ConsulClient.CreateLock(Consul.LockOptions opts) -> Consul.IDistributedLock
-~Consul.ConsulClient.CreateLock(string key) -> Consul.IDistributedLock
-~Consul.ConsulClient.DiscoveryChain.get -> Consul.Interfaces.IDiscoveryChainEndpoint
-~Consul.ConsulClient.Event.get -> Consul.IEventEndpoint
-~Consul.ConsulClient.ExecuteInSemaphore(Consul.SemaphoreOptions opts, System.Action a) -> System.Threading.Tasks.Task
-~Consul.ConsulClient.ExecuteInSemaphore(Consul.SemaphoreOptions opts, System.Action a, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
-~Consul.ConsulClient.ExecuteInSemaphore(string prefix, int limit, System.Action a, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.ConsulClient.ExecuteLocked(Consul.LockOptions opts, System.Action action) -> System.Threading.Tasks.Task
-~Consul.ConsulClient.ExecuteLocked(Consul.LockOptions opts, System.Action action, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
-~Consul.ConsulClient.ExecuteLocked(Consul.LockOptions opts, System.Threading.CancellationToken ct, System.Action action) -> System.Threading.Tasks.Task
-~Consul.ConsulClient.ExecuteLocked(string key, System.Action action) -> System.Threading.Tasks.Task
-~Consul.ConsulClient.ExecuteLocked(string key, System.Action action, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
-~Consul.ConsulClient.ExecuteLocked(string key, System.Threading.CancellationToken ct, System.Action action) -> System.Threading.Tasks.Task
-~Consul.ConsulClient.ExportedServices.get -> Consul.Interfaces.IExportedServicesEndpoint
-~Consul.ConsulClient.Health.get -> Consul.IHealthEndpoint
-~Consul.ConsulClient.KV.get -> Consul.IKVEndpoint
-~Consul.ConsulClient.Namespaces.get -> Consul.INamespacesEndpoint
-~Consul.ConsulClient.Operator.get -> Consul.IOperatorEndpoint
-~Consul.ConsulClient.Policy.get -> Consul.IPolicyEndpoint
-~Consul.ConsulClient.PreparedQuery.get -> Consul.IPreparedQueryEndpoint
-~Consul.ConsulClient.Raw.get -> Consul.IRawEndpoint
-~Consul.ConsulClient.Role.get -> Consul.IRoleEndpoint
-~Consul.ConsulClient.Semaphore(Consul.SemaphoreOptions opts) -> Consul.IDistributedSemaphore
-~Consul.ConsulClient.Semaphore(string prefix, int limit) -> Consul.IDistributedSemaphore
-~Consul.ConsulClient.Session.get -> Consul.ISessionEndpoint
-~Consul.ConsulClient.Snapshot.get -> Consul.ISnapshotEndpoint
-~Consul.ConsulClient.Status.get -> Consul.IStatusEndpoint
-~Consul.ConsulClient.Token.get -> Consul.ITokenEndpoint
-~Consul.ConsulClientConfiguration.Address.get -> System.Uri
-~Consul.ConsulClientConfiguration.Address.set -> void
-~Consul.ConsulClientConfiguration.ClientCertificate.set -> void
-~Consul.ConsulClientConfiguration.Datacenter.get -> string
-~Consul.ConsulClientConfiguration.Datacenter.set -> void
-~Consul.ConsulClientConfiguration.HttpAuth.set -> void
-~Consul.ConsulClientConfiguration.Namespace.get -> string
-~Consul.ConsulClientConfiguration.Namespace.set -> void
-~Consul.ConsulClientConfiguration.Token.get -> string
-~Consul.ConsulClientConfiguration.Token.set -> void
-~Consul.ConsulConfigurationException.ConsulConfigurationException(string message) -> void
-~Consul.ConsulConfigurationException.ConsulConfigurationException(string message, System.Exception inner) -> void
-~Consul.ConsulLicense.License.get -> Consul.License
-~Consul.ConsulLicense.License.set -> void
-~Consul.ConsulLicense.Warnings.get -> string[]
-~Consul.ConsulLicense.Warnings.set -> void
-~Consul.ConsulRequestException.ConsulRequestException(string message, System.Net.HttpStatusCode statusCode) -> void
-~Consul.ConsulRequestException.ConsulRequestException(string message, System.Net.HttpStatusCode statusCode, System.Exception inner) -> void
-~Consul.ConsulResult.ConsulResult(Consul.ConsulResult other) -> void
-~Consul.ConsumerDefinition.Partition.get -> string
-~Consul.ConsumerDefinition.Partition.set -> void
-~Consul.ConsumerDefinition.Peer.get -> string
-~Consul.ConsumerDefinition.Peer.set -> void
-~Consul.ConsumerDefinition.SamenessGroup.get -> string
-~Consul.ConsumerDefinition.SamenessGroup.set -> void
-~Consul.ControlPlaneRequestLimitEntry.ACL.get -> Consul.ACLRateLimit
-~Consul.ControlPlaneRequestLimitEntry.ACL.set -> void
-~Consul.ControlPlaneRequestLimitEntry.Catalog.get -> Consul.CatalogRateLimit
-~Consul.ControlPlaneRequestLimitEntry.Catalog.set -> void
-~Consul.ControlPlaneRequestLimitEntry.Kind.get -> string
-~Consul.ControlPlaneRequestLimitEntry.Kind.set -> void
-~Consul.ControlPlaneRequestLimitEntry.KV.get -> Consul.KVRateLimit
-~Consul.ControlPlaneRequestLimitEntry.KV.set -> void
-~Consul.ControlPlaneRequestLimitEntry.Mode.get -> string
-~Consul.ControlPlaneRequestLimitEntry.Mode.set -> void
-~Consul.ControlPlaneRequestLimitEntry.Name.get -> string
-~Consul.ControlPlaneRequestLimitEntry.Name.set -> void
-~Consul.CookieConfig.Path.get -> string
-~Consul.CookieConfig.Path.set -> void
-~Consul.CookieConfig.TTL.get -> string
-~Consul.CookieConfig.TTL.set -> void
-~Consul.CookieLocation.Name.get -> string
-~Consul.CookieLocation.Name.set -> void
-~Consul.Coordinate.Datacenters(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateDatacenterMap[]>>
-~Consul.Coordinate.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
-~Consul.Coordinate.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
-~Consul.Coordinate.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
-~Consul.Coordinate.Nodes() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
-~Consul.Coordinate.Nodes(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
-~Consul.Coordinate.Nodes(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
-~Consul.Coordinate.Update(Consul.CoordinateEntry entry) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Coordinate.Update(Consul.CoordinateEntry entry, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Coordinate.Update(Consul.CoordinateEntry entry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.CoordinateDatacenterMap.Coordinates.get -> System.Collections.Generic.List<Consul.CoordinateEntry>
-~Consul.CoordinateDatacenterMap.Coordinates.set -> void
-~Consul.CoordinateDatacenterMap.Datacenter.get -> string
-~Consul.CoordinateDatacenterMap.Datacenter.set -> void
-~Consul.CoordinateEntry.Coord.get -> Consul.SerfCoordinate
-~Consul.CoordinateEntry.Coord.set -> void
-~Consul.CoordinateEntry.Node.get -> string
-~Consul.CoordinateEntry.Node.set -> void
-~Consul.CoordinateEntry.Segment.get -> string
-~Consul.CoordinateEntry.Segment.set -> void
-~Consul.Counter.Labels.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.Counter.Labels.set -> void
-~Consul.Counter.Name.get -> string
-~Consul.Counter.Name.set -> void
-~Consul.CPUInfo.CoreId.get -> string
-~Consul.CPUInfo.CoreId.set -> void
-~Consul.CPUInfo.Family.get -> string
-~Consul.CPUInfo.Family.set -> void
-~Consul.CPUInfo.Flags.get -> System.Collections.Generic.List<string>
-~Consul.CPUInfo.Flags.set -> void
-~Consul.CPUInfo.Microcode.get -> string
-~Consul.CPUInfo.Microcode.set -> void
-~Consul.CPUInfo.Model.get -> string
-~Consul.CPUInfo.Model.set -> void
-~Consul.CPUInfo.ModelName.get -> string
-~Consul.CPUInfo.ModelName.set -> void
-~Consul.CPUInfo.PhysicalId.get -> string
-~Consul.CPUInfo.PhysicalId.set -> void
-~Consul.CPUInfo.VendorId.get -> string
-~Consul.CPUInfo.VendorId.set -> void
-~Consul.DatacenterUsage.ConnectServiceInstances.get -> Consul.ConnectServiceInstances
-~Consul.DatacenterUsage.ConnectServiceInstances.set -> void
-~Consul.DefaultsConfig.BalanceOutboundConnections.get -> string
-~Consul.DefaultsConfig.BalanceOutboundConnections.set -> void
-~Consul.DefaultsConfig.Limits.get -> Consul.LimitsConfig
-~Consul.DefaultsConfig.Limits.set -> void
-~Consul.DefaultsConfig.MeshGateway.get -> Consul.MeshGatewayConfig
-~Consul.DefaultsConfig.MeshGateway.set -> void
-~Consul.DefaultsConfig.PassiveHealthCheck.get -> Consul.PassiveHealthCheckConfig
-~Consul.DefaultsConfig.PassiveHealthCheck.set -> void
-~Consul.DefaultsConfig.Protocol.get -> string
-~Consul.DefaultsConfig.Protocol.set -> void
-~Consul.DeleteAcceptingRequest<TIn>.DeleteAcceptingRequest(Consul.ConsulClient client, string url, TIn body, Consul.WriteOptions options = null) -> void
-~Consul.DeleteAcceptingRequest<TIn>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.DeleteAcceptingRequest<TIn>.Options.get -> Consul.WriteOptions
-~Consul.DeleteAcceptingRequest<TIn>.Options.set -> void
-~Consul.DeleteRequest.DeleteRequest(Consul.ConsulClient client, string url, Consul.WriteOptions options = null) -> void
-~Consul.DeleteRequest.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.DeleteRequest.Options.get -> Consul.WriteOptions
-~Consul.DeleteRequest.Options.set -> void
-~Consul.DeleteReturnRequest<TOut>.DeleteReturnRequest(Consul.ConsulClient client, string url, Consul.WriteOptions options = null) -> void
-~Consul.DeleteReturnRequest<TOut>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<TOut>>
-~Consul.DeleteReturnRequest<TOut>.Options.get -> Consul.WriteOptions
-~Consul.DeleteReturnRequest<TOut>.Options.set -> void
-~Consul.DestinationConfig.Addresses.get -> System.Collections.Generic.List<string>
-~Consul.DestinationConfig.Addresses.set -> void
-~Consul.DiscoveryChain.Get(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
-~Consul.DiscoveryChain.Get(string name, Consul.DiscoveryChainOptions options) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
-~Consul.DiscoveryChain.Get(string name, Consul.DiscoveryChainOptions options, Consul.WriteOptions q, string compileDataCenter = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
-~Consul.DiscoveryChain.Get(string name, Consul.DiscoveryChainOptions options, string compileDataCenter) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
-~Consul.DiscoveryChain.Get(string name, Consul.DiscoveryChainOptions options, string compileDataCenter, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
-~Consul.DiscoveryChain.Get(string name, Consul.DiscoveryChainOptions options, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
-~Consul.DiscoveryChain.Get(string name, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
-~Consul.DiscoveryChain.Get(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
-~Consul.DiscoveryChain.Get(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
-~Consul.DiscoveryChainOptions.OverrideMeshGateway.get -> Consul.MeshGatewayConfig
-~Consul.DiscoveryChainOptions.OverrideMeshGateway.set -> void
-~Consul.DiscoveryChainOptions.OverrideProtocol.get -> string
-~Consul.DiscoveryChainOptions.OverrideProtocol.set -> void
-~Consul.DiscoveryChainResponse.Chain.get -> Consul.CompiledDiscoveryChain
-~Consul.DiscoveryChainResponse.Chain.set -> void
-~Consul.DiscoveryFailover.Targets.get -> System.Collections.Generic.List<string>
-~Consul.DiscoveryFailover.Targets.set -> void
-~Consul.DiscoveryGraphNode.LoadBalancer.get -> Consul.LoadBalancerConfig
-~Consul.DiscoveryGraphNode.LoadBalancer.set -> void
-~Consul.DiscoveryGraphNode.Name.get -> string
-~Consul.DiscoveryGraphNode.Name.set -> void
-~Consul.DiscoveryGraphNode.Resolver.get -> Consul.DiscoveryResolver
-~Consul.DiscoveryGraphNode.Resolver.set -> void
-~Consul.DiscoveryGraphNode.Routes.get -> System.Collections.Generic.List<Consul.DiscoveryRoute>
-~Consul.DiscoveryGraphNode.Routes.set -> void
-~Consul.DiscoveryGraphNode.Splits.get -> System.Collections.Generic.List<Consul.DiscoverySplit>
-~Consul.DiscoveryGraphNode.Splits.set -> void
-~Consul.DiscoveryGraphNode.Type.get -> string
-~Consul.DiscoveryGraphNode.Type.set -> void
-~Consul.DiscoveryResolver.Failover.get -> Consul.DiscoveryFailover
-~Consul.DiscoveryResolver.Failover.set -> void
-~Consul.DiscoveryResolver.Target.get -> string
-~Consul.DiscoveryResolver.Target.set -> void
-~Consul.DiscoveryRoute.Definition.get -> Consul.Routes
-~Consul.DiscoveryRoute.Definition.set -> void
-~Consul.DiscoveryRoute.NextNode.get -> string
-~Consul.DiscoveryRoute.NextNode.set -> void
-~Consul.DiscoverySplit.NextNode.get -> string
-~Consul.DiscoverySplit.NextNode.set -> void
-~Consul.DiscoveryTarget.Datacenter.get -> string
-~Consul.DiscoveryTarget.Datacenter.set -> void
-~Consul.DiscoveryTarget.ID.get -> string
-~Consul.DiscoveryTarget.ID.set -> void
-~Consul.DiscoveryTarget.MeshGateway.get -> Consul.MeshGatewayConfig
-~Consul.DiscoveryTarget.MeshGateway.set -> void
-~Consul.DiscoveryTarget.Name.get -> string
-~Consul.DiscoveryTarget.Name.set -> void
-~Consul.DiscoveryTarget.Namespace.get -> string
-~Consul.DiscoveryTarget.Namespace.set -> void
-~Consul.DiscoveryTarget.Service.get -> string
-~Consul.DiscoveryTarget.Service.set -> void
-~Consul.DiscoveryTarget.ServiceSubset.get -> string
-~Consul.DiscoveryTarget.ServiceSubset.set -> void
-~Consul.DiscoveryTarget.SNI.get -> string
-~Consul.DiscoveryTarget.SNI.set -> void
-~Consul.DiscoveryTarget.Subset.get -> Consul.ServiceResolverEntry
-~Consul.DiscoveryTarget.Subset.set -> void
-~Consul.DiskInfo.Fstype.get -> string
-~Consul.DiskInfo.Fstype.set -> void
-~Consul.DiskInfo.Path.get -> string
-~Consul.DiskInfo.Path.set -> void
-~Consul.EnvoyExtension.Arguments.get -> string
-~Consul.EnvoyExtension.Arguments.set -> void
-~Consul.EnvoyExtension.ConsulVersion.get -> string
-~Consul.EnvoyExtension.ConsulVersion.set -> void
-~Consul.EnvoyExtension.EnvoyVersion.get -> string
-~Consul.EnvoyExtension.EnvoyVersion.set -> void
-~Consul.EnvoyExtension.Name.get -> string
-~Consul.EnvoyExtension.Name.set -> void
-~Consul.EnvoyExtension.Required.get -> string
-~Consul.EnvoyExtension.Required.set -> void
-~Consul.EnvoyExtensionConfig.Arguments.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.EnvoyExtensionConfig.Arguments.set -> void
-~Consul.EnvoyExtensionConfig.ConsulVersion.get -> string
-~Consul.EnvoyExtensionConfig.ConsulVersion.set -> void
-~Consul.EnvoyExtensionConfig.EnvoyVersion.get -> string
-~Consul.EnvoyExtensionConfig.EnvoyVersion.set -> void
-~Consul.EnvoyExtensionConfig.Name.get -> string
-~Consul.EnvoyExtensionConfig.Name.set -> void
-~Consul.Event.Fire(Consul.UserEvent ue) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Event.Fire(Consul.UserEvent ue, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Event.Fire(Consul.UserEvent ue, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Event.IDToIndex(string uuid) -> ulong
-~Consul.Event.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
-~Consul.Event.List(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
-~Consul.Event.List(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
-~Consul.Event.List(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
-~Consul.Event.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
-~Consul.ExportedServiceEntry.Kind.get -> string
-~Consul.ExportedServiceEntry.Kind.set -> void
-~Consul.ExportedServiceEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ExportedServiceEntry.Meta.set -> void
-~Consul.ExportedServiceEntry.Name.get -> string
-~Consul.ExportedServiceEntry.Name.set -> void
-~Consul.ExportedServiceEntry.Partition.get -> string
-~Consul.ExportedServiceEntry.Partition.set -> void
-~Consul.ExportedServiceEntry.Services.get -> System.Collections.Generic.List<Consul.ServiceDefinition>
-~Consul.ExportedServiceEntry.Services.set -> void
-~Consul.ExportedServices.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ResolvedExportedService[]>>
-~Consul.ExportedServices.List(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ResolvedExportedService[]>>
-~Consul.ExportedServices.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ResolvedExportedService[]>>
-~Consul.ExposeConfig.Paths.get -> System.Collections.Generic.List<Consul.PathConfig>
-~Consul.ExposeConfig.Paths.set -> void
-~Consul.ExternalService.Defaults.get -> Consul.GatewayDefaults
-~Consul.ExternalService.Defaults.set -> void
-~Consul.ExternalService.Hosts.get -> System.Collections.Generic.List<string>
-~Consul.ExternalService.Hosts.set -> void
-~Consul.ExternalService.Name.get -> string
-~Consul.ExternalService.Name.set -> void
-~Consul.ExternalService.Namespace.get -> string
-~Consul.ExternalService.Namespace.set -> void
-~Consul.ExternalService.Partition.get -> string
-~Consul.ExternalService.Partition.set -> void
-~Consul.ExternalService.RequestHeaders.get -> Consul.HeaderModification
-~Consul.ExternalService.RequestHeaders.set -> void
-~Consul.ExternalService.ResponseHeaders.get -> Consul.HeaderModification
-~Consul.ExternalService.ResponseHeaders.set -> void
-~Consul.ExternalService.TLS.get -> Consul.TLSConfig
-~Consul.ExternalService.TLS.set -> void
-~Consul.Filtering.IEncodable.Encode() -> string
-~Consul.Filtering.MetaSelector.IsEmpty() -> Consul.Filtering.Filter
-~Consul.Filtering.MetaSelector.MetaSelector(string prefix) -> void
-~Consul.Filtering.MetaSelector.Prefix.get -> string
-~Consul.Filtering.MetaSelector.this[string name].get -> Consul.Filtering.ServiceMetaEntrySelector
-~Consul.Filtering.NodeSelector.Id.get -> Consul.Filtering.StringFieldSelector
-~Consul.Filtering.NodeSelector.Meta.get -> Consul.Filtering.MetaSelector
-~Consul.Filtering.NodeSelector.Node.get -> Consul.Filtering.StringFieldSelector
-~Consul.Filtering.ServiceMetaEntrySelector.Contains(string value) -> Consul.Filtering.Filter
-~Consul.Filtering.ServiceMetaEntrySelector.Name.get -> string
-~Consul.Filtering.ServiceMetaEntrySelector.Prefix.get -> string
-~Consul.Filtering.ServiceMetaEntrySelector.ServiceMetaEntrySelector(string prefix, string name) -> void
-~Consul.Filtering.ServiceSelector.Id.get -> Consul.Filtering.StringFieldSelector
-~Consul.Filtering.ServiceSelector.Meta.get -> Consul.Filtering.MetaSelector
-~Consul.Filtering.ServiceSelector.Tags.get -> Consul.Filtering.TagsSelector
-~Consul.Filtering.StringFieldSelector.Contains(string value) -> Consul.Filtering.Filter
-~Consul.Filtering.StringFieldSelector.IsEmpty() -> Consul.Filtering.Filter
-~Consul.Filtering.StringFieldSelector.Name.get -> string
-~Consul.Filtering.StringFieldSelector.Prefix.get -> string
-~Consul.Filtering.StringFieldSelector.StringFieldSelector(string name) -> void
-~Consul.Filtering.StringFieldSelector.StringFieldSelector(string prefix, string name) -> void
-~Consul.Filtering.TagsSelector.Contains(string value) -> Consul.Filtering.Filter
-~Consul.Filtering.TagsSelector.IsEmpty() -> Consul.Filtering.Filter
-~Consul.Filtering.TagsSelector.Prefix.get -> string
-~Consul.Filtering.TagsSelector.TagsSelector(string prefix) -> void
-~Consul.Flags.Package.get -> string
-~Consul.Flags.Package.set -> void
-~Consul.ForwardingConfig.HeaderName.get -> string
-~Consul.ForwardingConfig.HeaderName.set -> void
-~Consul.GatewayDefaults.PassiveHealthCheck.get -> Consul.PassiveHealthCheckConfig
-~Consul.GatewayDefaults.PassiveHealthCheck.set -> void
-~Consul.GatewayListener.Protocol.get -> string
-~Consul.GatewayListener.Protocol.set -> void
-~Consul.GatewayListener.Services.get -> System.Collections.Generic.List<Consul.ExternalService>
-~Consul.GatewayListener.Services.set -> void
-~Consul.GatewayListener.TLS.get -> Consul.TLSConfig
-~Consul.GatewayListener.TLS.set -> void
-~Consul.GatewayService.CAFile.get -> string
-~Consul.GatewayService.CAFile.set -> void
-~Consul.GatewayService.CertFile.get -> string
-~Consul.GatewayService.CertFile.set -> void
-~Consul.GatewayService.Gateway.get -> Consul.CompoundServiceName
-~Consul.GatewayService.Gateway.set -> void
-~Consul.GatewayService.GatewayKind.get -> Consul.ServiceKind
-~Consul.GatewayService.GatewayKind.set -> void
-~Consul.GatewayService.Hosts.get -> System.Collections.Generic.List<string>
-~Consul.GatewayService.Hosts.set -> void
-~Consul.GatewayService.KeyFile.get -> string
-~Consul.GatewayService.KeyFile.set -> void
-~Consul.GatewayService.Protocol.get -> string
-~Consul.GatewayService.Protocol.set -> void
-~Consul.GatewayService.Service.get -> Consul.CompoundServiceName
-~Consul.GatewayService.Service.set -> void
-~Consul.GatewayService.SNI.get -> string
-~Consul.GatewayService.SNI.set -> void
-~Consul.Gauge.Labels.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.Gauge.Labels.set -> void
-~Consul.Gauge.Name.get -> string
-~Consul.Gauge.Name.set -> void
-~Consul.GetRequest.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
-~Consul.GetRequest.GetRequest(Consul.ConsulClient client, string url, Consul.QueryOptions options = null) -> void
-~Consul.GetRequest.Options.get -> Consul.QueryOptions
-~Consul.GetRequest.Options.set -> void
-~Consul.GetRequest<TOut>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<TOut>>
-~Consul.GetRequest<TOut>.ExecuteStreaming(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
-~Consul.GetRequest<TOut>.Filter.get -> Consul.Filtering.IEncodable
-~Consul.GetRequest<TOut>.GetRequest(Consul.ConsulClient client, string url) -> void
-~Consul.GetRequest<TOut>.GetRequest(Consul.ConsulClient client, string url, Consul.QueryOptions options) -> void
-~Consul.GetRequest<TOut>.GetRequest(Consul.ConsulClient client, string url, Consul.QueryOptions options, Consul.Filtering.IEncodable filter) -> void
-~Consul.GetRequest<TOut>.Options.get -> Consul.QueryOptions
-~Consul.GetRequest<TOut>.Options.set -> void
-~Consul.GetRequest<TOut>.ParseQueryHeaders(System.Net.Http.HttpResponseMessage res, Consul.QueryResult<TOut> meta) -> void
-~Consul.Header.Description.get -> string
-~Consul.Header.Description.set -> void
-~Consul.Header.Exact.get -> string
-~Consul.Header.Exact.set -> void
-~Consul.Header.LegacyCreateTime.get -> string
-~Consul.Header.LegacyCreateTime.set -> void
-~Consul.Header.LegacyID.get -> string
-~Consul.Header.LegacyID.set -> void
-~Consul.Header.LegacyMeta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.Header.LegacyMeta.set -> void
-~Consul.Header.LegacyUpdateTime.get -> string
-~Consul.Header.LegacyUpdateTime.set -> void
-~Consul.Header.Name.get -> string
-~Consul.Header.Name.set -> void
-~Consul.Header.Prefix.get -> string
-~Consul.Header.Prefix.set -> void
-~Consul.Header.Regex.get -> string
-~Consul.Header.Regex.set -> void
-~Consul.Header.Suffix.get -> string
-~Consul.Header.Suffix.set -> void
-~Consul.Header.Type.get -> string
-~Consul.Header.Type.set -> void
-~Consul.HeaderConfig.Exact.get -> string
-~Consul.HeaderConfig.Exact.set -> void
-~Consul.HeaderConfig.Name.get -> string
-~Consul.HeaderConfig.Name.set -> void
-~Consul.HeaderConfig.Prefix.get -> string
-~Consul.HeaderConfig.Prefix.set -> void
-~Consul.HeaderConfig.Regex.get -> string
-~Consul.HeaderConfig.Regex.set -> void
-~Consul.HeaderConfig.Suffix.get -> string
-~Consul.HeaderConfig.Suffix.set -> void
-~Consul.HeaderKeyValuePair.Key.get -> string
-~Consul.HeaderKeyValuePair.Key.set -> void
-~Consul.HeaderKeyValuePair.Value.get -> string
-~Consul.HeaderKeyValuePair.Value.set -> void
-~Consul.HeaderLocation.Name.get -> string
-~Consul.HeaderLocation.Name.set -> void
-~Consul.HeaderLocation.ValuePrefix.get -> string
-~Consul.HeaderLocation.ValuePrefix.set -> void
-~Consul.HeaderModification.Add.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.HeaderModification.Add.set -> void
-~Consul.HeaderModification.Remove.get -> System.Collections.Generic.List<string>
-~Consul.HeaderModification.Remove.set -> void
-~Consul.HeaderModification.Set.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.HeaderModification.Set.set -> void
-~Consul.Health.Checks(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.Health.Checks(string service, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.Health.Checks(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.Health.Connect(string service, string tag, bool passingOnly, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Connect(string service, string tag, bool passingOnly, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Connect(string service, string tag, bool passingOnly, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Ingress(string service, string tag, bool passingOnly) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Ingress(string service, string tag, bool passingOnly, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Ingress(string service, string tag, bool passingOnly, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Ingress(string service, string tag, bool passingOnly, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Ingress(string service, string tag, bool passingOnly, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.Health.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.Health.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.Health.Service(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Service(string service, string tag) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Service(string service, string tag, bool passingOnly) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Service(string service, string tag, bool passingOnly, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Service(string service, string tag, bool passingOnly, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Service(string service, string tag, bool passingOnly, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Service(string service, string tag, bool passingOnly, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Service(string service, string tag, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.Service(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.Health.State(Consul.HealthStatus status) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.Health.State(Consul.HealthStatus status, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.Health.State(Consul.HealthStatus status, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.HealthCheck.CheckID.get -> string
-~Consul.HealthCheck.CheckID.set -> void
-~Consul.HealthCheck.Name.get -> string
-~Consul.HealthCheck.Name.set -> void
-~Consul.HealthCheck.Node.get -> string
-~Consul.HealthCheck.Node.set -> void
-~Consul.HealthCheck.Notes.get -> string
-~Consul.HealthCheck.Notes.set -> void
-~Consul.HealthCheck.Output.get -> string
-~Consul.HealthCheck.Output.set -> void
-~Consul.HealthCheck.ServiceID.get -> string
-~Consul.HealthCheck.ServiceID.set -> void
-~Consul.HealthCheck.ServiceName.get -> string
-~Consul.HealthCheck.ServiceName.set -> void
-~Consul.HealthCheck.ServiceTags.get -> string[]
-~Consul.HealthCheck.ServiceTags.set -> void
-~Consul.HealthCheck.Status.get -> Consul.HealthStatus
-~Consul.HealthCheck.Status.set -> void
-~Consul.HealthCheck.Type.get -> string
-~Consul.HealthCheck.Type.set -> void
-~Consul.HealthStatus.Equals(Consul.HealthStatus other) -> bool
-~Consul.HealthStatus.Status.get -> string
-~Consul.HostInfo.HostId.get -> string
-~Consul.HostInfo.HostId.set -> void
-~Consul.HostInfo.Hostname.get -> string
-~Consul.HostInfo.Hostname.set -> void
-~Consul.HostInfo.KernelArch.get -> string
-~Consul.HostInfo.KernelArch.set -> void
-~Consul.HostInfo.KernelVersion.get -> string
-~Consul.HostInfo.KernelVersion.set -> void
-~Consul.HostInfo.Os.get -> string
-~Consul.HostInfo.Os.set -> void
-~Consul.HostInfo.Platform.get -> string
-~Consul.HostInfo.Platform.set -> void
-~Consul.HostInfo.PlatformFamily.get -> string
-~Consul.HostInfo.PlatformFamily.set -> void
-~Consul.HostInfo.PlatformVersion.get -> string
-~Consul.HostInfo.PlatformVersion.set -> void
-~Consul.HostInfo.VirtualizationRole.get -> string
-~Consul.HostInfo.VirtualizationRole.set -> void
-~Consul.HostInfo.VirtualizationSystem.get -> string
-~Consul.HostInfo.VirtualizationSystem.set -> void
-~Consul.HTTPConfig.PrefixRewrite.get -> string
-~Consul.HTTPConfig.PrefixRewrite.set -> void
-~Consul.HTTPConfig.RequestHeaders.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.HTTPConfig.RequestHeaders.set -> void
-~Consul.HTTPConfig.ResponseHeaders.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.HTTPConfig.ResponseHeaders.set -> void
-~Consul.HTTPConfig.RetryOn.get -> System.Collections.Generic.List<string>
-~Consul.HTTPConfig.RetryOn.set -> void
-~Consul.HTTPConfig.RetryOnStatusCodes.get -> System.Collections.Generic.List<int?>
-~Consul.HTTPConfig.RetryOnStatusCodes.set -> void
-~Consul.HttpHeaderMatch.Match.get -> string
-~Consul.HttpHeaderMatch.Match.set -> void
-~Consul.HttpHeaderMatch.Name.get -> string
-~Consul.HttpHeaderMatch.Name.set -> void
-~Consul.HttpHeaderMatch.Value.get -> string
-~Consul.HttpHeaderMatch.Value.set -> void
-~Consul.HttpHeaderOperation.Add.get -> System.Collections.Generic.List<Consul.HeaderKeyValuePair>
-~Consul.HttpHeaderOperation.Add.set -> void
-~Consul.HttpHeaderOperation.Remove.get -> System.Collections.Generic.List<string>
-~Consul.HttpHeaderOperation.Remove.set -> void
-~Consul.HttpHeaderOperation.Set.get -> System.Collections.Generic.List<Consul.HeaderKeyValuePair>
-~Consul.HttpHeaderOperation.Set.set -> void
-~Consul.HttpPathMatch.Match.get -> string
-~Consul.HttpPathMatch.Match.set -> void
-~Consul.HttpPathMatch.Value.get -> string
-~Consul.HttpPathMatch.Value.set -> void
-~Consul.HttpQueryMatch.Match.get -> string
-~Consul.HttpQueryMatch.Match.set -> void
-~Consul.HttpQueryMatch.Name.get -> string
-~Consul.HttpQueryMatch.Name.set -> void
-~Consul.HttpQueryMatch.Value.get -> string
-~Consul.HttpQueryMatch.Value.set -> void
-~Consul.HttpRouteEntry.Hostnames.get -> System.Collections.Generic.List<string>
-~Consul.HttpRouteEntry.Hostnames.set -> void
-~Consul.HttpRouteEntry.Kind.get -> string
-~Consul.HttpRouteEntry.Kind.set -> void
-~Consul.HttpRouteEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.HttpRouteEntry.Meta.set -> void
-~Consul.HttpRouteEntry.Name.get -> string
-~Consul.HttpRouteEntry.Name.set -> void
-~Consul.HttpRouteEntry.Namespace.get -> string
-~Consul.HttpRouteEntry.Namespace.set -> void
-~Consul.HttpRouteEntry.Parents.get -> System.Collections.Generic.List<Consul.ApiGatewayReference>
-~Consul.HttpRouteEntry.Parents.set -> void
-~Consul.HttpRouteEntry.Partition.get -> string
-~Consul.HttpRouteEntry.Partition.set -> void
-~Consul.HttpRouteEntry.Rules.get -> System.Collections.Generic.List<Consul.HttpRouteRule>
-~Consul.HttpRouteEntry.Rules.set -> void
-~Consul.HttpRouteFilter.Headers.get -> System.Collections.Generic.List<Consul.HttpHeaderOperation>
-~Consul.HttpRouteFilter.Headers.set -> void
-~Consul.HttpRouteFilter.JWT.get -> Consul.JWTSettings
-~Consul.HttpRouteFilter.JWT.set -> void
-~Consul.HttpRouteFilter.URLRewrite.get -> System.Collections.Generic.List<Consul.HttpURLRewriteOperation>
-~Consul.HttpRouteFilter.URLRewrite.set -> void
-~Consul.HttpRouteMatch.Headers.get -> System.Collections.Generic.List<Consul.HttpHeaderMatch>
-~Consul.HttpRouteMatch.Headers.set -> void
-~Consul.HttpRouteMatch.Method.get -> string
-~Consul.HttpRouteMatch.Method.set -> void
-~Consul.HttpRouteMatch.Path.get -> System.Collections.Generic.List<Consul.HttpPathMatch>
-~Consul.HttpRouteMatch.Path.set -> void
-~Consul.HttpRouteMatch.Query.get -> System.Collections.Generic.List<Consul.HttpQueryMatch>
-~Consul.HttpRouteMatch.Query.set -> void
-~Consul.HttpRouteRule.Filters.get -> System.Collections.Generic.List<Consul.HttpRouteFilter>
-~Consul.HttpRouteRule.Filters.set -> void
-~Consul.HttpRouteRule.Matches.get -> System.Collections.Generic.List<Consul.HttpRouteMatch>
-~Consul.HttpRouteRule.Matches.set -> void
-~Consul.HttpRouteRule.Services.get -> System.Collections.Generic.List<Consul.HttpRouteService>
-~Consul.HttpRouteRule.Services.set -> void
-~Consul.HttpRouteService.Filters.get -> System.Collections.Generic.List<Consul.HttpRouteFilter>
-~Consul.HttpRouteService.Filters.set -> void
-~Consul.HttpRouteService.Name.get -> string
-~Consul.HttpRouteService.Name.set -> void
-~Consul.HttpRouteService.Namespace.get -> string
-~Consul.HttpRouteService.Namespace.set -> void
-~Consul.HttpRouteService.Partition.get -> string
-~Consul.HttpRouteService.Partition.set -> void
-~Consul.HttpRouteService.ResponseFilters.get -> System.Collections.Generic.List<Consul.HttpRouteFilter>
-~Consul.HttpRouteService.ResponseFilters.set -> void
-~Consul.HttpURLRewriteOperation.Path.get -> string
-~Consul.HttpURLRewriteOperation.Path.set -> void
-~Consul.IACLEndpoint.Clone(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IACLEndpoint.Clone(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IACLEndpoint.Create(Consul.ACLEntry acl, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IACLEndpoint.Create(Consul.ACLEntry acl, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IACLEndpoint.Destroy(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IACLEndpoint.Destroy(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IACLEndpoint.Info(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry>>
-~Consul.IACLEndpoint.Info(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry>>
-~Consul.IACLEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry[]>>
-~Consul.IACLEndpoint.List(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry[]>>
-~Consul.IACLEndpoint.TranslateLegacyTokenRules(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
-~Consul.IACLEndpoint.TranslateLegacyTokenRules(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
-~Consul.IACLEndpoint.TranslateRules(string rules, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IACLEndpoint.TranslateRules(string rules, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IACLEndpoint.Update(Consul.ACLEntry acl, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IACLEndpoint.Update(Consul.ACLEntry acl, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IACLReplicationEndpoint.Status() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLReplicationEntry>>
-~Consul.IACLReplicationEndpoint.Status(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLReplicationEntry>>
-~Consul.IACLReplicationEndpoint.Status(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLReplicationEntry>>
-~Consul.IAgentEndpoint.CheckDeregister(string checkID, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.CheckRegister(Consul.AgentCheckRegistration check, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.Checks() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentCheck>>>
-~Consul.IAgentEndpoint.Checks(Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentCheck>>>
-~Consul.IAgentEndpoint.Checks(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentCheck>>>
-~Consul.IAgentEndpoint.ConnectAuthorize(Consul.AgentAuthorizeParameters parameters) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AgentAuthorizeResponse>>
-~Consul.IAgentEndpoint.ConnectAuthorize(Consul.AgentAuthorizeParameters parameters, Consul.WriteOptions w, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AgentAuthorizeResponse>>
-~Consul.IAgentEndpoint.ConnectAuthorize(Consul.AgentAuthorizeParameters parameters, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AgentAuthorizeResponse>>
-~Consul.IAgentEndpoint.DisableNodeMaintenance(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.DisableServiceMaintenance(string serviceID, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.EnableNodeMaintenance(string reason, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.EnableServiceMaintenance(string serviceID, string reason, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.FailTTL(string checkID, string note, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.IAgentEndpoint.ForceLeave(string node, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.GetAgentHostInfo(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AgentHostInfo>>
-~Consul.IAgentEndpoint.GetAgentMetrics(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Metrics>>
-~Consul.IAgentEndpoint.GetAgentVersion(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AgentVersion>>
-~Consul.IAgentEndpoint.GetCALeaf(string serviceId) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CALeaf>>
-~Consul.IAgentEndpoint.GetCALeaf(string serviceId, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CALeaf>>
-~Consul.IAgentEndpoint.GetCALeaf(string serviceId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CALeaf>>
-~Consul.IAgentEndpoint.GetCARoots() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
-~Consul.IAgentEndpoint.GetCARoots(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
-~Consul.IAgentEndpoint.GetCARoots(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
-~Consul.IAgentEndpoint.GetLocalServiceHealth(string serviceName) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth[]>>
-~Consul.IAgentEndpoint.GetLocalServiceHealth(string serviceName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth[]>>
-~Consul.IAgentEndpoint.GetLocalServiceHealth(string serviceName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth[]>>
-~Consul.IAgentEndpoint.GetLocalServiceHealthByID(string serviceID) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth>>
-~Consul.IAgentEndpoint.GetLocalServiceHealthByID(string serviceID, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth>>
-~Consul.IAgentEndpoint.GetLocalServiceHealthByID(string serviceID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth>>
-~Consul.IAgentEndpoint.GetNodeName(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
-~Consul.IAgentEndpoint.GetServiceConfiguration(string serviceID) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceConfiguration>>
-~Consul.IAgentEndpoint.GetServiceConfiguration(string serviceID, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceConfiguration>>
-~Consul.IAgentEndpoint.GetServiceConfiguration(string serviceID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceConfiguration>>
-~Consul.IAgentEndpoint.GetWorstLocalServiceHealth(string serviceName) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
-~Consul.IAgentEndpoint.GetWorstLocalServiceHealth(string serviceName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
-~Consul.IAgentEndpoint.GetWorstLocalServiceHealth(string serviceName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
-~Consul.IAgentEndpoint.Join(string addr, bool wan, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.Leave(string node, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.Members(bool wan, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AgentMember[]>>
-~Consul.IAgentEndpoint.Monitor(Consul.LogLevel level = Consul.LogLevel.Info, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.Agent.LogStream>
-~Consul.IAgentEndpoint.MonitorJSON(Consul.LogLevel level = Consul.LogLevel.Info, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.Agent.LogStream>
-~Consul.IAgentEndpoint.NodeName.get -> string
-~Consul.IAgentEndpoint.PassTTL(string checkID, string note, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.IAgentEndpoint.Reload() -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.Reload(string node, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.Reload(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.Self(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, dynamic>>>>
-~Consul.IAgentEndpoint.ServiceDeregister(string serviceID, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.ServiceRegister(Consul.AgentServiceRegistration service) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.ServiceRegister(Consul.AgentServiceRegistration service, bool replaceExistingChecks, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.ServiceRegister(Consul.AgentServiceRegistration service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.Services() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentService>>>
-~Consul.IAgentEndpoint.Services(Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentService>>>
-~Consul.IAgentEndpoint.Services(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentService>>>
-~Consul.IAgentEndpoint.UpdateTTL(string checkID, string output, Consul.TTLStatus status, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAgentEndpoint.WarnTTL(string checkID, string note, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.IAuthMethodEndpoint.Create(Consul.AuthMethodEntry authMethod) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
-~Consul.IAuthMethodEndpoint.Create(Consul.AuthMethodEntry authMethod, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
-~Consul.IAuthMethodEndpoint.Create(Consul.AuthMethodEntry authMethod, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
-~Consul.IAuthMethodEndpoint.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IAuthMethodEndpoint.Delete(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IAuthMethodEndpoint.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IAuthMethodEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry[]>>
-~Consul.IAuthMethodEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry[]>>
-~Consul.IAuthMethodEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry[]>>
-~Consul.IAuthMethodEndpoint.Login() -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.IAuthMethodEndpoint.Login(Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.IAuthMethodEndpoint.Login(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.IAuthMethodEndpoint.Logout() -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAuthMethodEndpoint.Logout(Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAuthMethodEndpoint.Logout(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IAuthMethodEndpoint.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry>>
-~Consul.IAuthMethodEndpoint.Read(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry>>
-~Consul.IAuthMethodEndpoint.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry>>
-~Consul.IAuthMethodEndpoint.Update(Consul.AuthMethodEntry authMethod) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
-~Consul.IAuthMethodEndpoint.Update(Consul.AuthMethodEntry authMethod, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
-~Consul.IAuthMethodEndpoint.Update(Consul.AuthMethodEntry authMethod, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
-~Consul.ICatalogEndpoint.Datacenters() -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.ICatalogEndpoint.Datacenters(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.ICatalogEndpoint.Datacenters(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.ICatalogEndpoint.Deregister(Consul.CatalogDeregistration reg) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ICatalogEndpoint.Deregister(Consul.CatalogDeregistration reg, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ICatalogEndpoint.Deregister(Consul.CatalogDeregistration reg, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ICatalogEndpoint.GatewayService(string gateway) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.GatewayService[]>>
-~Consul.ICatalogEndpoint.GatewayService(string gateway, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.GatewayService[]>>
-~Consul.ICatalogEndpoint.GatewayService(string gateway, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.GatewayService[]>>
-~Consul.ICatalogEndpoint.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogNode>>
-~Consul.ICatalogEndpoint.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogNode>>
-~Consul.ICatalogEndpoint.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogNode>>
-~Consul.ICatalogEndpoint.Nodes() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Node[]>>
-~Consul.ICatalogEndpoint.Nodes(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Node[]>>
-~Consul.ICatalogEndpoint.Nodes(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Node[]>>
-~Consul.ICatalogEndpoint.NodesForMeshCapableService(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.ICatalogEndpoint.NodesForMeshCapableService(string service, Consul.Filtering.Filter filter) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.ICatalogEndpoint.NodesForMeshCapableService(string service, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.ICatalogEndpoint.NodesForMeshCapableService(string service, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.ICatalogEndpoint.NodesForMeshCapableService(string service, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.ICatalogEndpoint.NodesForMeshCapableService(string service, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.ICatalogEndpoint.NodesForMeshCapableService(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.ICatalogEndpoint.Register(Consul.CatalogRegistration reg) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ICatalogEndpoint.Register(Consul.CatalogRegistration reg, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ICatalogEndpoint.Register(Consul.CatalogRegistration reg, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ICatalogEndpoint.Service(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.ICatalogEndpoint.Service(string service, string tag) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.ICatalogEndpoint.Service(string service, string tag, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.ICatalogEndpoint.Service(string service, string tag, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.ICatalogEndpoint.Service(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
-~Consul.ICatalogEndpoint.Services() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.ICatalogEndpoint.Services(Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.ICatalogEndpoint.Services(Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.ICatalogEndpoint.Services(string dc, Consul.Filtering.Filter filter) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.ICatalogEndpoint.Services(string dc, Consul.Filtering.Filter filter, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.ICatalogEndpoint.Services(string dc, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.ICatalogEndpoint.Services(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
-~Consul.ICatalogEndpoint.ServicesForNode(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NodeService>>
-~Consul.ICatalogEndpoint.ServicesForNode(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NodeService>>
-~Consul.ICatalogEndpoint.ServicesForNode(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NodeService>>
-~Consul.IConfigurationEntry.Kind.get -> string
-~Consul.IConfigurationEntry.Kind.set -> void
-~Consul.IConsulClient.ACL.get -> Consul.IACLEndpoint
-~Consul.IConsulClient.AcquireLock(Consul.LockOptions opts) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
-~Consul.IConsulClient.AcquireLock(Consul.LockOptions opts, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
-~Consul.IConsulClient.AcquireLock(string key) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
-~Consul.IConsulClient.AcquireLock(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
-~Consul.IConsulClient.AcquireSemaphore(Consul.SemaphoreOptions opts) -> System.Threading.Tasks.Task<Consul.IDistributedSemaphore>
-~Consul.IConsulClient.AcquireSemaphore(Consul.SemaphoreOptions opts, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.IDistributedSemaphore>
-~Consul.IConsulClient.AcquireSemaphore(string prefix, int limit, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.IDistributedSemaphore>
-~Consul.IConsulClient.Agent.get -> Consul.IAgentEndpoint
-~Consul.IConsulClient.Catalog.get -> Consul.ICatalogEndpoint
-~Consul.IConsulClient.Configuration.get -> Consul.Interfaces.IConfigurationEndpoint
-~Consul.IConsulClient.Coordinate.get -> Consul.ICoordinateEndpoint
-~Consul.IConsulClient.CreateLock(Consul.LockOptions opts) -> Consul.IDistributedLock
-~Consul.IConsulClient.CreateLock(string key) -> Consul.IDistributedLock
-~Consul.IConsulClient.DiscoveryChain.get -> Consul.Interfaces.IDiscoveryChainEndpoint
-~Consul.IConsulClient.Event.get -> Consul.IEventEndpoint
-~Consul.IConsulClient.ExecuteInSemaphore(Consul.SemaphoreOptions opts, System.Action a) -> System.Threading.Tasks.Task
-~Consul.IConsulClient.ExecuteInSemaphore(Consul.SemaphoreOptions opts, System.Action a, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
-~Consul.IConsulClient.ExecuteInSemaphore(string prefix, int limit, System.Action a, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.IConsulClient.ExecuteLocked(Consul.LockOptions opts, System.Action action) -> System.Threading.Tasks.Task
-~Consul.IConsulClient.ExecuteLocked(Consul.LockOptions opts, System.Action action, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
-~Consul.IConsulClient.ExecuteLocked(Consul.LockOptions opts, System.Threading.CancellationToken ct, System.Action action) -> System.Threading.Tasks.Task
-~Consul.IConsulClient.ExecuteLocked(string key, System.Action action) -> System.Threading.Tasks.Task
-~Consul.IConsulClient.ExecuteLocked(string key, System.Action action, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
-~Consul.IConsulClient.ExecuteLocked(string key, System.Threading.CancellationToken ct, System.Action action) -> System.Threading.Tasks.Task
-~Consul.IConsulClient.ExportedServices.get -> Consul.Interfaces.IExportedServicesEndpoint
-~Consul.IConsulClient.Health.get -> Consul.IHealthEndpoint
-~Consul.IConsulClient.KV.get -> Consul.IKVEndpoint
-~Consul.IConsulClient.Operator.get -> Consul.IOperatorEndpoint
-~Consul.IConsulClient.Policy.get -> Consul.IPolicyEndpoint
-~Consul.IConsulClient.PreparedQuery.get -> Consul.IPreparedQueryEndpoint
-~Consul.IConsulClient.Raw.get -> Consul.IRawEndpoint
-~Consul.IConsulClient.Role.get -> Consul.IRoleEndpoint
-~Consul.IConsulClient.Semaphore(Consul.SemaphoreOptions opts) -> Consul.IDistributedSemaphore
-~Consul.IConsulClient.Semaphore(string prefix, int limit) -> Consul.IDistributedSemaphore
-~Consul.IConsulClient.Session.get -> Consul.ISessionEndpoint
-~Consul.IConsulClient.Snapshot.get -> Consul.ISnapshotEndpoint
-~Consul.IConsulClient.Status.get -> Consul.IStatusEndpoint
-~Consul.IConsulClient.Token.get -> Consul.ITokenEndpoint
-~Consul.ICoordinateEndpoint.Datacenters(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateDatacenterMap[]>>
-~Consul.ICoordinateEndpoint.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
-~Consul.ICoordinateEndpoint.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
-~Consul.ICoordinateEndpoint.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
-~Consul.ICoordinateEndpoint.Nodes() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
-~Consul.ICoordinateEndpoint.Nodes(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
-~Consul.ICoordinateEndpoint.Nodes(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
-~Consul.ICoordinateEndpoint.Update(Consul.CoordinateEntry entry) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ICoordinateEndpoint.Update(Consul.CoordinateEntry entry, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ICoordinateEndpoint.Update(Consul.CoordinateEntry entry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IDistributedLock.Acquire(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Threading.CancellationToken>
-~Consul.IDistributedLock.Destroy(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.IDistributedLock.Release(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.IDistributedSemaphore.Acquire(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Threading.CancellationToken>
-~Consul.IDistributedSemaphore.Destroy(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.IDistributedSemaphore.Release(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.IEventEndpoint.Fire(Consul.UserEvent ue) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IEventEndpoint.Fire(Consul.UserEvent ue, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IEventEndpoint.Fire(Consul.UserEvent ue, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IEventEndpoint.IDToIndex(string uuid) -> ulong
-~Consul.IEventEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
-~Consul.IEventEndpoint.List(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
-~Consul.IEventEndpoint.List(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
-~Consul.IEventEndpoint.List(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
-~Consul.IEventEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
-~Consul.IHealthEndpoint.Checks(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.IHealthEndpoint.Checks(string service, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.IHealthEndpoint.Checks(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.IHealthEndpoint.Connect(string service, string tag, bool passingOnly, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Connect(string service, string tag, bool passingOnly, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Connect(string service, string tag, bool passingOnly, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Ingress(string service, string tag, bool passingOnly) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Ingress(string service, string tag, bool passingOnly, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Ingress(string service, string tag, bool passingOnly, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Ingress(string service, string tag, bool passingOnly, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Ingress(string service, string tag, bool passingOnly, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.IHealthEndpoint.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.IHealthEndpoint.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.IHealthEndpoint.Service(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Service(string service, string tag) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Service(string service, string tag, bool passingOnly) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Service(string service, string tag, bool passingOnly, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Service(string service, string tag, bool passingOnly, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Service(string service, string tag, bool passingOnly, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Service(string service, string tag, bool passingOnly, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Service(string service, string tag, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.Service(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
-~Consul.IHealthEndpoint.State(Consul.HealthStatus status) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.IHealthEndpoint.State(Consul.HealthStatus status, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.IHealthEndpoint.State(Consul.HealthStatus status, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
-~Consul.IKVEndpoint.Acquire(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.Acquire(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.Acquire(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.CAS(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.CAS(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.CAS(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.Delete(string key) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.Delete(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.Delete(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.DeleteCAS(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.DeleteCAS(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.DeleteCAS(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.DeleteTree(string prefix) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.DeleteTree(string prefix, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.DeleteTree(string prefix, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.Get(string key) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair>>
-~Consul.IKVEndpoint.Get(string key, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair>>
-~Consul.IKVEndpoint.Get(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair>>
-~Consul.IKVEndpoint.Keys(string prefix) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.IKVEndpoint.Keys(string prefix, string separator) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.IKVEndpoint.Keys(string prefix, string separator, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.IKVEndpoint.Keys(string prefix, string separator, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.IKVEndpoint.Keys(string prefix, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.IKVEndpoint.List(string prefix) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair[]>>
-~Consul.IKVEndpoint.List(string prefix, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair[]>>
-~Consul.IKVEndpoint.List(string prefix, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair[]>>
-~Consul.IKVEndpoint.Put(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.Put(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.Put(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.Release(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.Release(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.Release(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IKVEndpoint.Txn(System.Collections.Generic.List<Consul.KVTxnOp> txn) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.KVTxnResponse>>
-~Consul.IKVEndpoint.Txn(System.Collections.Generic.List<Consul.KVTxnOp> txn, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.KVTxnResponse>>
-~Consul.IKVEndpoint.Txn(System.Collections.Generic.List<Consul.KVTxnOp> txn, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.KVTxnResponse>>
-~Consul.INamespacesEndpoint.Create(Consul.Namespace ns) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
-~Consul.INamespacesEndpoint.Create(Consul.Namespace ns, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
-~Consul.INamespacesEndpoint.Create(Consul.Namespace ns, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
-~Consul.INamespacesEndpoint.Delete(string name) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.INamespacesEndpoint.Delete(string name, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.INamespacesEndpoint.Delete(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.INamespacesEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse[]>>
-~Consul.INamespacesEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse[]>>
-~Consul.INamespacesEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse[]>>
-~Consul.INamespacesEndpoint.Read(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse>>
-~Consul.INamespacesEndpoint.Read(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse>>
-~Consul.INamespacesEndpoint.Read(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse>>
-~Consul.INamespacesEndpoint.Update(Consul.Namespace ns) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
-~Consul.INamespacesEndpoint.Update(Consul.Namespace ns, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
-~Consul.INamespacesEndpoint.Update(Consul.Namespace ns, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
-~Consul.IngressGatewayEntry.Defaults.get -> Consul.GatewayDefaults
-~Consul.IngressGatewayEntry.Defaults.set -> void
-~Consul.IngressGatewayEntry.Kind.get -> string
-~Consul.IngressGatewayEntry.Kind.set -> void
-~Consul.IngressGatewayEntry.Listeners.get -> System.Collections.Generic.List<Consul.GatewayListener>
-~Consul.IngressGatewayEntry.Listeners.set -> void
-~Consul.IngressGatewayEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.IngressGatewayEntry.Meta.set -> void
-~Consul.IngressGatewayEntry.Name.get -> string
-~Consul.IngressGatewayEntry.Name.set -> void
-~Consul.IngressGatewayEntry.Namespace.get -> string
-~Consul.IngressGatewayEntry.Namespace.set -> void
-~Consul.IngressGatewayEntry.Partition.get -> string
-~Consul.IngressGatewayEntry.Partition.set -> void
-~Consul.IngressGatewayEntry.TLS.get -> Consul.TLSConfig
-~Consul.IngressGatewayEntry.TLS.set -> void
-~Consul.InlineCertificateEntry.Certificate.get -> string
-~Consul.InlineCertificateEntry.Certificate.set -> void
-~Consul.InlineCertificateEntry.Kind.get -> string
-~Consul.InlineCertificateEntry.Kind.set -> void
-~Consul.InlineCertificateEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.InlineCertificateEntry.Meta.set -> void
-~Consul.InlineCertificateEntry.Name.get -> string
-~Consul.InlineCertificateEntry.Name.set -> void
-~Consul.InlineCertificateEntry.PrivateKey.get -> string
-~Consul.InlineCertificateEntry.PrivateKey.set -> void
-~Consul.InstanceLevelConfig.Routes.get -> System.Collections.Generic.List<Consul.RouteConfig>
-~Consul.InstanceLevelConfig.Routes.set -> void
-~Consul.IntentionHTTPHeaderPermission.Exact.get -> string
-~Consul.IntentionHTTPHeaderPermission.Exact.set -> void
-~Consul.IntentionHTTPHeaderPermission.Name.get -> string
-~Consul.IntentionHTTPHeaderPermission.Name.set -> void
-~Consul.IntentionHTTPHeaderPermission.Prefix.get -> string
-~Consul.IntentionHTTPHeaderPermission.Prefix.set -> void
-~Consul.IntentionHTTPHeaderPermission.Regex.get -> string
-~Consul.IntentionHTTPHeaderPermission.Regex.set -> void
-~Consul.IntentionHTTPHeaderPermission.Suffix.get -> string
-~Consul.IntentionHTTPHeaderPermission.Suffix.set -> void
-~Consul.IntentionHTTPPermission.Header.get -> System.Collections.Generic.List<Consul.IntentionHTTPHeaderPermission>
-~Consul.IntentionHTTPPermission.Header.set -> void
-~Consul.IntentionHTTPPermission.Methods.get -> System.Collections.Generic.List<string>
-~Consul.IntentionHTTPPermission.Methods.set -> void
-~Consul.IntentionHTTPPermission.PathExact.get -> string
-~Consul.IntentionHTTPPermission.PathExact.set -> void
-~Consul.IntentionHTTPPermission.PathPrefix.get -> string
-~Consul.IntentionHTTPPermission.PathPrefix.set -> void
-~Consul.IntentionHTTPPermission.PathRegex.get -> string
-~Consul.IntentionHTTPPermission.PathRegex.set -> void
-~Consul.IntentionPermission.Action.get -> string
-~Consul.IntentionPermission.Action.set -> void
-~Consul.IntentionPermission.HTTP.get -> Consul.IntentionHTTPPermission
-~Consul.IntentionPermission.HTTP.set -> void
-~Consul.Interfaces.IBindingRuleEndpoint.Create(Consul.ACLBindingRule entry) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
-~Consul.Interfaces.IBindingRuleEndpoint.Create(Consul.ACLBindingRule entry, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
-~Consul.Interfaces.IBindingRuleEndpoint.Create(Consul.ACLBindingRule entry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
-~Consul.Interfaces.IBindingRuleEndpoint.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IBindingRuleEndpoint.Delete(string id, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IBindingRuleEndpoint.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IBindingRuleEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse[]>>
-~Consul.Interfaces.IBindingRuleEndpoint.List(Consul.QueryOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse[]>>
-~Consul.Interfaces.IBindingRuleEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse[]>>
-~Consul.Interfaces.IBindingRuleEndpoint.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse>>
-~Consul.Interfaces.IBindingRuleEndpoint.Read(string id, Consul.QueryOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse>>
-~Consul.Interfaces.IBindingRuleEndpoint.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse>>
-~Consul.Interfaces.IBindingRuleEndpoint.Update(Consul.ACLBindingRule entry) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
-~Consul.Interfaces.IBindingRuleEndpoint.Update(Consul.ACLBindingRule entry, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
-~Consul.Interfaces.IBindingRuleEndpoint.Update(Consul.ACLBindingRule entry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
-~Consul.Interfaces.IClusterPeeringEndpoint.DeletePeering(string name, Consul.WriteOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IClusterPeeringEndpoint.DeletePeering(string name, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IClusterPeeringEndpoint.GenerateToken(Consul.ClusterPeeringTokenEntry tokenEntry) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ClusterPeeringTokenResponse>>
-~Consul.Interfaces.IClusterPeeringEndpoint.GenerateToken(Consul.ClusterPeeringTokenEntry tokenEntry, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ClusterPeeringTokenResponse>>
-~Consul.Interfaces.IClusterPeeringEndpoint.GenerateToken(Consul.ClusterPeeringTokenEntry tokenEntry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ClusterPeeringTokenResponse>>
-~Consul.Interfaces.IClusterPeeringEndpoint.GetPeering(string name, Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus>>
-~Consul.Interfaces.IClusterPeeringEndpoint.GetPeering(string name, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus>>
-~Consul.Interfaces.IClusterPeeringEndpoint.ListPeerings() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus[]>>
-~Consul.Interfaces.IClusterPeeringEndpoint.ListPeerings(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus[]>>
-~Consul.Interfaces.IClusterPeeringEndpoint.ListPeerings(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus[]>>
-~Consul.Interfaces.IConfigurationEndpoint.ApplyConfig<TConfig>(Consul.WriteOptions q, TConfig configurationEntry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IConfigurationEndpoint.ApplyConfig<TConfig>(TConfig configurationEntry) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IConfigurationEndpoint.ApplyConfig<TConfig>(TConfig configurationEntry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IConfigurationEndpoint.DeleteConfig(string kind, string name) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IConfigurationEndpoint.DeleteConfig(string kind, string name, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IConfigurationEndpoint.DeleteConfig(string kind, string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IConfigurationEndpoint.GetConfig<TConfig>(string kind, string name) -> System.Threading.Tasks.Task<Consul.QueryResult<TConfig>>
-~Consul.Interfaces.IConfigurationEndpoint.GetConfig<TConfig>(string kind, string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<TConfig>>
-~Consul.Interfaces.IConfigurationEndpoint.GetConfig<TConfig>(string kind, string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<TConfig>>
-~Consul.Interfaces.IConfigurationEndpoint.ListConfig<TConfig>(string kind) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<TConfig>>>
-~Consul.Interfaces.IConfigurationEndpoint.ListConfig<TConfig>(string kind, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<TConfig>>>
-~Consul.Interfaces.IConfigurationEndpoint.ListConfig<TConfig>(string kind, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<TConfig>>>
-~Consul.Interfaces.IConnectEndpoint.CAGetConfig() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CAConfig>>
-~Consul.Interfaces.IConnectEndpoint.CAGetConfig(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CAConfig>>
-~Consul.Interfaces.IConnectEndpoint.CAGetConfig(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CAConfig>>
-~Consul.Interfaces.IConnectEndpoint.CARoots() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
-~Consul.Interfaces.IConnectEndpoint.CARoots(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
-~Consul.Interfaces.IConnectEndpoint.CARoots(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
-~Consul.Interfaces.IConnectEndpoint.CASetConfig(Consul.CAConfig config) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IConnectEndpoint.CASetConfig(Consul.CAConfig config, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IConnectEndpoint.CASetConfig(Consul.CAConfig config, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IConnectEndpoint.CheckIntentionResult(string source, string destination) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceIntentionResultResponse>>
-~Consul.Interfaces.IConnectEndpoint.CheckIntentionResult(string source, string destination, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceIntentionResultResponse>>
-~Consul.Interfaces.IConnectEndpoint.CheckIntentionResult(string source, string destination, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceIntentionResultResponse>>
-~Consul.Interfaces.IConnectEndpoint.DeleteIntentionByName(string source, string destination) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IConnectEndpoint.DeleteIntentionByName(string source, string destination, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IConnectEndpoint.DeleteIntentionByName(string source, string destination, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Interfaces.IConnectEndpoint.ListIntentions<ServiceIntention>() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<ServiceIntention>>>
-~Consul.Interfaces.IConnectEndpoint.ListIntentions<ServiceIntention>(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<ServiceIntention>>>
-~Consul.Interfaces.IConnectEndpoint.ListIntentions<ServiceIntention>(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<ServiceIntention>>>
-~Consul.Interfaces.IConnectEndpoint.ListMatchingIntentions(string by, string name) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Consul.ServiceIntention>>>>
-~Consul.Interfaces.IConnectEndpoint.ListMatchingIntentions(string by, string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Consul.ServiceIntention>>>>
-~Consul.Interfaces.IConnectEndpoint.ListMatchingIntentions(string by, string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Consul.ServiceIntention>>>>
-~Consul.Interfaces.IConnectEndpoint.ReadSpecificIntentionByName<ServiceIntention>(string source, string destination) -> System.Threading.Tasks.Task<Consul.QueryResult<ServiceIntention>>
-~Consul.Interfaces.IConnectEndpoint.ReadSpecificIntentionByName<ServiceIntention>(string source, string destination, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<ServiceIntention>>
-~Consul.Interfaces.IConnectEndpoint.ReadSpecificIntentionByName<ServiceIntention>(string source, string destination, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<ServiceIntention>>
-~Consul.Interfaces.IConnectEndpoint.UpsertIntentionsByName(Consul.ServiceIntention intention) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Interfaces.IConnectEndpoint.UpsertIntentionsByName(Consul.ServiceIntention intention, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Interfaces.IConnectEndpoint.UpsertIntentionsByName(Consul.ServiceIntention intention, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
-~Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.DiscoveryChainOptions options) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
-~Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.DiscoveryChainOptions options, Consul.WriteOptions q, string compileDataCenter = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
-~Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.DiscoveryChainOptions options, string compileDataCenter) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
-~Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.DiscoveryChainOptions options, string compileDataCenter, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
-~Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.DiscoveryChainOptions options, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
-~Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
-~Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
-~Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
-~Consul.Interfaces.IExportedServicesEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ResolvedExportedService[]>>
-~Consul.Interfaces.IExportedServicesEndpoint.List(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ResolvedExportedService[]>>
-~Consul.Interfaces.IExportedServicesEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ResolvedExportedService[]>>
-~Consul.InvalidKeyPairException.InvalidKeyPairException(string message) -> void
-~Consul.InvalidKeyPairException.InvalidKeyPairException(string message, System.Exception inner) -> void
-~Consul.IOperatorEndpoint.AreaCreate(Consul.AreaRequest area) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IOperatorEndpoint.AreaCreate(Consul.AreaRequest area, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IOperatorEndpoint.AreaCreate(Consul.AreaRequest area, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IOperatorEndpoint.AreaDelete(string areaId) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.AreaDelete(string areaId, Consul.WriteOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.AreaDelete(string areaId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.AreaGet(string areaId) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Area[]>>
-~Consul.IOperatorEndpoint.AreaGet(string areaId, Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Area[]>>
-~Consul.IOperatorEndpoint.AreaGet(string areaId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Area[]>>
-~Consul.IOperatorEndpoint.AreaList() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<Consul.Area>>>
-~Consul.IOperatorEndpoint.AreaList(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<Consul.Area>>>
-~Consul.IOperatorEndpoint.AreaList(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<Consul.Area>>>
-~Consul.IOperatorEndpoint.AreaUpdate(Consul.AreaRequest area, string areaId) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IOperatorEndpoint.AreaUpdate(Consul.AreaRequest area, string areaId, Consul.WriteOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IOperatorEndpoint.AreaUpdate(Consul.AreaRequest area, string areaId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IOperatorEndpoint.AutopilotGetConfiguration() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotConfiguration>>
-~Consul.IOperatorEndpoint.AutopilotGetConfiguration(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotConfiguration>>
-~Consul.IOperatorEndpoint.AutopilotGetConfiguration(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotConfiguration>>
-~Consul.IOperatorEndpoint.AutopilotGetHealth() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotHealth>>
-~Consul.IOperatorEndpoint.AutopilotGetHealth(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotHealth>>
-~Consul.IOperatorEndpoint.AutopilotGetHealth(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotHealth>>
-~Consul.IOperatorEndpoint.AutopilotGetState() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotState>>
-~Consul.IOperatorEndpoint.AutopilotGetState(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotState>>
-~Consul.IOperatorEndpoint.AutopilotGetState(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotState>>
-~Consul.IOperatorEndpoint.AutopilotSetConfiguration(Consul.AutopilotConfiguration configuration) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.AutopilotSetConfiguration(Consul.AutopilotConfiguration configuration, Consul.WriteOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.AutopilotSetConfiguration(Consul.AutopilotConfiguration configuration, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.GetConsulLicense(string datacenter = "", System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ConsulLicense>>
-~Consul.IOperatorEndpoint.KeyringInstall(string key) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.KeyringInstall(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.KeyringInstall(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.KeyringList() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KeyringResponse[]>>
-~Consul.IOperatorEndpoint.KeyringList(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KeyringResponse[]>>
-~Consul.IOperatorEndpoint.KeyringList(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KeyringResponse[]>>
-~Consul.IOperatorEndpoint.KeyringRemove(string key) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.KeyringRemove(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.KeyringRemove(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.KeyringUse(string key) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.KeyringUse(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.KeyringUse(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.OperatorGetUsage() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.OperatorUsageInformation>>
-~Consul.IOperatorEndpoint.OperatorGetUsage(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.OperatorUsageInformation>>
-~Consul.IOperatorEndpoint.OperatorGetUsage(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.OperatorUsageInformation>>
-~Consul.IOperatorEndpoint.RaftGetConfiguration() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RaftConfiguration>>
-~Consul.IOperatorEndpoint.RaftGetConfiguration(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RaftConfiguration>>
-~Consul.IOperatorEndpoint.RaftGetConfiguration(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RaftConfiguration>>
-~Consul.IOperatorEndpoint.RaftRemovePeerByAddress(string address) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.RaftRemovePeerByAddress(string address, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.RaftRemovePeerByAddress(string address, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.RaftTransferLeader() -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.RaftTransferLeader(Consul.WriteOptions q) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.RaftTransferLeader(Consul.WriteOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.RaftTransferLeader(string id) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.RaftTransferLeader(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.RaftTransferLeader(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.RaftTransferLeader(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IOperatorEndpoint.SegmentList() -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.IOperatorEndpoint.SegmentList(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.IOperatorEndpoint.SegmentList(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.IPolicyEndpoint.Create(Consul.PolicyEntry policy) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.Create(Consul.PolicyEntry policy, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.Create(Consul.PolicyEntry policy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IPolicyEndpoint.Delete(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IPolicyEndpoint.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IPolicyEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry[]>>
-~Consul.IPolicyEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry[]>>
-~Consul.IPolicyEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry[]>>
-~Consul.IPolicyEndpoint.ListTemplatedPolicies() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.TemplatedPolicyResponse>>>
-~Consul.IPolicyEndpoint.ListTemplatedPolicies(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.TemplatedPolicyResponse>>>
-~Consul.IPolicyEndpoint.ListTemplatedPolicies(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.TemplatedPolicyResponse>>>
-~Consul.IPolicyEndpoint.PreviewTemplatedPolicy(string name) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.PreviewTemplatedPolicy(string name, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.PreviewTemplatedPolicy(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.Read(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.ReadPolicyByName(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.ReadPolicyByName(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.ReadPolicyByName(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.ReadTemplatedPolicyByName(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TemplatedPolicyResponse>>
-~Consul.IPolicyEndpoint.ReadTemplatedPolicyByName(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TemplatedPolicyResponse>>
-~Consul.IPolicyEndpoint.ReadTemplatedPolicyByName(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TemplatedPolicyResponse>>
-~Consul.IPolicyEndpoint.Update(Consul.PolicyEntry policy) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.Update(Consul.PolicyEntry policy, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.IPolicyEndpoint.Update(Consul.PolicyEntry policy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.IPreparedQueryEndpoint.Create(Consul.PreparedQueryDefinition query) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IPreparedQueryEndpoint.Create(Consul.PreparedQueryDefinition query, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IPreparedQueryEndpoint.Create(Consul.PreparedQueryDefinition query, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.IPreparedQueryEndpoint.Delete(string queryID) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IPreparedQueryEndpoint.Delete(string queryID, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IPreparedQueryEndpoint.Delete(string queryID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IPreparedQueryEndpoint.Execute(string queryIDOrName) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExecuteResponse>>
-~Consul.IPreparedQueryEndpoint.Execute(string queryIDOrName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExecuteResponse>>
-~Consul.IPreparedQueryEndpoint.Execute(string queryIDOrName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExecuteResponse>>
-~Consul.IPreparedQueryEndpoint.Explain(string queryIDOrName) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExplainResponse>>
-~Consul.IPreparedQueryEndpoint.Explain(string queryIDOrName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExplainResponse>>
-~Consul.IPreparedQueryEndpoint.Explain(string queryIDOrName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExplainResponse>>
-~Consul.IPreparedQueryEndpoint.Get(string queryID) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
-~Consul.IPreparedQueryEndpoint.Get(string queryID, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
-~Consul.IPreparedQueryEndpoint.Get(string queryID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
-~Consul.IPreparedQueryEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
-~Consul.IPreparedQueryEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
-~Consul.IPreparedQueryEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
-~Consul.IPreparedQueryEndpoint.Update(Consul.PreparedQueryDefinition query) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IPreparedQueryEndpoint.Update(Consul.PreparedQueryDefinition query, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IPreparedQueryEndpoint.Update(Consul.PreparedQueryDefinition query, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.IRawEndpoint.Query(string endpoint, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<dynamic>>
-~Consul.IRawEndpoint.Write(string endpoint, object obj, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<dynamic>>
-~Consul.IRoleEndpoint.Create(Consul.RoleEntry role) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
-~Consul.IRoleEndpoint.Create(Consul.RoleEntry role, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
-~Consul.IRoleEndpoint.Create(Consul.RoleEntry role, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
-~Consul.IRoleEndpoint.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IRoleEndpoint.Delete(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IRoleEndpoint.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.IRoleEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry[]>>
-~Consul.IRoleEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry[]>>
-~Consul.IRoleEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry[]>>
-~Consul.IRoleEndpoint.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
-~Consul.IRoleEndpoint.Read(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
-~Consul.IRoleEndpoint.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
-~Consul.IRoleEndpoint.ReadByName(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
-~Consul.IRoleEndpoint.ReadByName(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
-~Consul.IRoleEndpoint.ReadByName(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
-~Consul.IRoleEndpoint.Update(Consul.RoleEntry role) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
-~Consul.IRoleEndpoint.Update(Consul.RoleEntry role, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
-~Consul.IRoleEndpoint.Update(Consul.RoleEntry role, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
-~Consul.ISessionEndpoint.Create() -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ISessionEndpoint.Create(Consul.SessionEntry se) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ISessionEndpoint.Create(Consul.SessionEntry se, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ISessionEndpoint.Create(Consul.SessionEntry se, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ISessionEndpoint.Create(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ISessionEndpoint.CreateNoChecks() -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ISessionEndpoint.CreateNoChecks(Consul.SessionEntry se) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ISessionEndpoint.CreateNoChecks(Consul.SessionEntry se, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ISessionEndpoint.CreateNoChecks(Consul.SessionEntry se, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ISessionEndpoint.CreateNoChecks(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.ISessionEndpoint.Destroy(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.ISessionEndpoint.Destroy(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.ISessionEndpoint.Destroy(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.ISessionEndpoint.Info(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry>>
-~Consul.ISessionEndpoint.Info(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry>>
-~Consul.ISessionEndpoint.Info(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry>>
-~Consul.ISessionEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
-~Consul.ISessionEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
-~Consul.ISessionEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
-~Consul.ISessionEndpoint.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
-~Consul.ISessionEndpoint.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
-~Consul.ISessionEndpoint.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
-~Consul.ISessionEndpoint.Renew(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.SessionEntry>>
-~Consul.ISessionEndpoint.Renew(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.SessionEntry>>
-~Consul.ISessionEndpoint.Renew(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.SessionEntry>>
-~Consul.ISessionEndpoint.RenewPeriodic(System.TimeSpan initialTTL, string id, Consul.WriteOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
-~Consul.ISessionEndpoint.RenewPeriodic(System.TimeSpan initialTTL, string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
-~Consul.ISnapshotEndpoint.Restore(System.IO.Stream s) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ISnapshotEndpoint.Restore(System.IO.Stream s, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ISnapshotEndpoint.Restore(System.IO.Stream s, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.ISnapshotEndpoint.Save() -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
-~Consul.ISnapshotEndpoint.Save(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
-~Consul.ISnapshotEndpoint.Save(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
-~Consul.IStatusEndpoint.Leader(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
-~Consul.IStatusEndpoint.Peers(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string[]>
-~Consul.ITokenEndpoint.Bootstrap() -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Bootstrap(Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Bootstrap(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Clone(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Clone(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Clone(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Create(Consul.TokenEntry token) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Create(Consul.TokenEntry token, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Create(Consul.TokenEntry token, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.ITokenEndpoint.Delete(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.ITokenEndpoint.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.ITokenEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry[]>>
-~Consul.ITokenEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry[]>>
-~Consul.ITokenEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry[]>>
-~Consul.ITokenEndpoint.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Read(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.ReadSelfToken(string token) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.ReadSelfToken(string token, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.ReadSelfToken(string token, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Update(Consul.TokenEntry token) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Update(Consul.TokenEntry token, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.ITokenEndpoint.Update(Consul.TokenEntry token, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.JSONWebKeySetConfig.Local.get -> Consul.LocalJSONWebKeySet
-~Consul.JSONWebKeySetConfig.Local.set -> void
-~Consul.JSONWebKeySetConfig.Remote.get -> Consul.RemoteJSONWebKeySet
-~Consul.JSONWebKeySetConfig.Remote.set -> void
-~Consul.JWKSClusterConfig.ConnectTimeout.get -> string
-~Consul.JWKSClusterConfig.ConnectTimeout.set -> void
-~Consul.JWKSClusterConfig.DiscoveryType.get -> string
-~Consul.JWKSClusterConfig.DiscoveryType.set -> void
-~Consul.JWKSClusterConfig.TLSCertificates.get -> Consul.TLSCertificatesConfig
-~Consul.JWKSClusterConfig.TLSCertificates.set -> void
-~Consul.JWTProvider.Name.get -> string
-~Consul.JWTProvider.Name.set -> void
-~Consul.JWTProvider.VerifyClaims.get -> Consul.VerifyClaims
-~Consul.JWTProvider.VerifyClaims.set -> void
-~Consul.JWTProviderEntry.Audiences.get -> System.Collections.Generic.List<string>
-~Consul.JWTProviderEntry.Audiences.set -> void
-~Consul.JWTProviderEntry.CacheConfig.get -> Consul.CacheConfig
-~Consul.JWTProviderEntry.CacheConfig.set -> void
-~Consul.JWTProviderEntry.ClockSkewSeconds.get -> string
-~Consul.JWTProviderEntry.ClockSkewSeconds.set -> void
-~Consul.JWTProviderEntry.Forwarding.get -> Consul.ForwardingConfig
-~Consul.JWTProviderEntry.Forwarding.set -> void
-~Consul.JWTProviderEntry.Issuer.get -> string
-~Consul.JWTProviderEntry.Issuer.set -> void
-~Consul.JWTProviderEntry.JSONWebKeySet.get -> System.Collections.Generic.List<Consul.JSONWebKeySetConfig>
-~Consul.JWTProviderEntry.JSONWebKeySet.set -> void
-~Consul.JWTProviderEntry.Kind.get -> string
-~Consul.JWTProviderEntry.Kind.set -> void
-~Consul.JWTProviderEntry.Locations.get -> System.Collections.Generic.List<Consul.ProviderLocation>
-~Consul.JWTProviderEntry.Locations.set -> void
-~Consul.JWTProviderEntry.Name.get -> string
-~Consul.JWTProviderEntry.Name.set -> void
-~Consul.JWTSettings.Providers.get -> System.Collections.Generic.List<Consul.JWTProvider>
-~Consul.JWTSettings.Providers.set -> void
-~Consul.KeyringResponse.Datacenter.get -> string
-~Consul.KeyringResponse.Datacenter.set -> void
-~Consul.KeyringResponse.Keys.get -> System.Collections.Generic.IDictionary<string, int>
-~Consul.KeyringResponse.Keys.set -> void
-~Consul.KV.Acquire(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.Acquire(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.Acquire(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.CAS(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.CAS(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.CAS(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.Delete(string key) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.Delete(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.Delete(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.DeleteCAS(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.DeleteCAS(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.DeleteCAS(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.DeleteTree(string prefix) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.DeleteTree(string prefix, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.DeleteTree(string prefix, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.Get(string key) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair>>
-~Consul.KV.Get(string key, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair>>
-~Consul.KV.Get(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair>>
-~Consul.KV.Keys(string prefix) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.KV.Keys(string prefix, string separator) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.KV.Keys(string prefix, string separator, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.KV.Keys(string prefix, string separator, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.KV.Keys(string prefix, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.KV.KV(Consul.ConsulClient c) -> void
-~Consul.KV.List(string prefix) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair[]>>
-~Consul.KV.List(string prefix, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair[]>>
-~Consul.KV.List(string prefix, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair[]>>
-~Consul.KV.Put(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.Put(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.Put(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.Release(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.Release(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.Release(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.KV.Txn(System.Collections.Generic.List<Consul.KVTxnOp> txn) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.KVTxnResponse>>
-~Consul.KV.Txn(System.Collections.Generic.List<Consul.KVTxnOp> txn, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.KVTxnResponse>>
-~Consul.KV.Txn(System.Collections.Generic.List<Consul.KVTxnOp> txn, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.KVTxnResponse>>
-~Consul.KVPair.Key.get -> string
-~Consul.KVPair.Key.set -> void
-~Consul.KVPair.KVPair(string key) -> void
-~Consul.KVPair.Session.get -> string
-~Consul.KVPair.Session.set -> void
-~Consul.KVPair.Value.get -> byte[]
-~Consul.KVPair.Value.set -> void
-~Consul.KVTxnOp.Key.get -> string
-~Consul.KVTxnOp.Key.set -> void
-~Consul.KVTxnOp.KVTxnOp(string key, Consul.KVTxnVerb verb) -> void
-~Consul.KVTxnOp.Session.get -> string
-~Consul.KVTxnOp.Session.set -> void
-~Consul.KVTxnOp.Value.get -> byte[]
-~Consul.KVTxnOp.Value.set -> void
-~Consul.KVTxnOp.Verb.get -> Consul.KVTxnVerb
-~Consul.KVTxnOp.Verb.set -> void
-~Consul.KVTxnResponse.Errors.get -> System.Collections.Generic.List<Consul.TxnError>
-~Consul.KVTxnResponse.Results.get -> System.Collections.Generic.List<Consul.KVPair>
-~Consul.KVTxnVerb.Equals(Consul.KVTxnVerb other) -> bool
-~Consul.KVTxnVerb.Operation.get -> string
-~Consul.License.CustomerId.get -> string
-~Consul.License.CustomerId.set -> void
-~Consul.License.ExpirationTime.get -> string
-~Consul.License.ExpirationTime.set -> void
-~Consul.License.Features.get -> string[]
-~Consul.License.Features.set -> void
-~Consul.License.Flags.get -> Consul.Flags
-~Consul.License.Flags.set -> void
-~Consul.License.InstallationId.get -> string
-~Consul.License.InstallationId.set -> void
-~Consul.License.IssueTime.get -> string
-~Consul.License.IssueTime.set -> void
-~Consul.License.LicenseId.get -> string
-~Consul.License.LicenseId.set -> void
-~Consul.License.Product.get -> string
-~Consul.License.Product.set -> void
-~Consul.License.StartTime.get -> string
-~Consul.License.StartTime.set -> void
-~Consul.LinkedService.CAFile.get -> string
-~Consul.LinkedService.CAFile.set -> void
-~Consul.LinkedService.CertFile.get -> string
-~Consul.LinkedService.CertFile.set -> void
-~Consul.LinkedService.KeyFile.get -> string
-~Consul.LinkedService.KeyFile.set -> void
-~Consul.LinkedService.Name.get -> string
-~Consul.LinkedService.Name.set -> void
-~Consul.LinkedService.Namespace.get -> string
-~Consul.LinkedService.Namespace.set -> void
-~Consul.LinkedService.SNI.get -> string
-~Consul.LinkedService.SNI.set -> void
-~Consul.LoadBalancerConfig.CookieConfig.get -> Consul.CookieConfig
-~Consul.LoadBalancerConfig.CookieConfig.set -> void
-~Consul.LoadBalancerConfig.HashPolicies.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.LoadBalancerConfig.HashPolicies.set -> void
-~Consul.LoadBalancerConfig.LeastRequestConfig.get -> Consul.LeastRequestConfig
-~Consul.LoadBalancerConfig.LeastRequestConfig.set -> void
-~Consul.LoadBalancerConfig.Policy.get -> string
-~Consul.LoadBalancerConfig.Policy.set -> void
-~Consul.LoadBalancerConfig.RingHashConfig.get -> Consul.RingHashConfig
-~Consul.LoadBalancerConfig.RingHashConfig.set -> void
-~Consul.LocalJSONWebKeySet.Filename.get -> string
-~Consul.LocalJSONWebKeySet.Filename.set -> void
-~Consul.LocalJSONWebKeySet.JWKS.get -> string
-~Consul.LocalJSONWebKeySet.JWKS.set -> void
-~Consul.LocalServiceHealth.AggregatedStatus.get -> Consul.HealthStatus
-~Consul.LocalServiceHealth.AggregatedStatus.set -> void
-~Consul.LocalServiceHealth.Checks.get -> Consul.AgentCheck[]
-~Consul.LocalServiceHealth.Checks.set -> void
-~Consul.LocalServiceHealth.Service.get -> Consul.AgentService
-~Consul.LocalServiceHealth.Service.set -> void
-~Consul.Lock.Acquire() -> System.Threading.Tasks.Task<System.Threading.CancellationToken>
-~Consul.Lock.Acquire(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Threading.CancellationToken>
-~Consul.Lock.Destroy(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.Lock.Release(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.LockConflictException.LockConflictException(string message) -> void
-~Consul.LockConflictException.LockConflictException(string message, System.Exception inner) -> void
-~Consul.LockHeldException.LockHeldException(string message) -> void
-~Consul.LockHeldException.LockHeldException(string message, System.Exception inner) -> void
-~Consul.LockInUseException.LockInUseException(string message) -> void
-~Consul.LockInUseException.LockInUseException(string message, System.Exception inner) -> void
-~Consul.LockMaxAttemptsReachedException.LockMaxAttemptsReachedException(string message) -> void
-~Consul.LockMaxAttemptsReachedException.LockMaxAttemptsReachedException(string message, System.Exception inner) -> void
-~Consul.LockNotHeldException.LockNotHeldException(string message) -> void
-~Consul.LockNotHeldException.LockNotHeldException(string message, System.Exception inner) -> void
-~Consul.LockOptions.Key.get -> string
-~Consul.LockOptions.Key.set -> void
-~Consul.LockOptions.LockOptions(string key) -> void
-~Consul.LockOptions.Session.get -> string
-~Consul.LockOptions.Session.set -> void
-~Consul.LockOptions.SessionName.get -> string
-~Consul.LockOptions.SessionName.set -> void
-~Consul.LockOptions.Value.get -> byte[]
-~Consul.LockOptions.Value.set -> void
-~Consul.MapConfig.Header.get -> System.Collections.Generic.List<Consul.HeaderConfig>
-~Consul.MapConfig.Header.set -> void
-~Consul.MapConfig.Methods.get -> System.Collections.Generic.List<string>
-~Consul.MapConfig.Methods.set -> void
-~Consul.MapConfig.PathExact.get -> string
-~Consul.MapConfig.PathExact.set -> void
-~Consul.MapConfig.PathPrefix.get -> string
-~Consul.MapConfig.PathPrefix.set -> void
-~Consul.MapConfig.PathRegex.get -> string
-~Consul.MapConfig.PathRegex.set -> void
-~Consul.MapConfig.QueryParam.get -> System.Collections.Generic.List<Consul.QueryParamConfig>
-~Consul.MapConfig.QueryParam.set -> void
-~Consul.MeshEntry.HTTP.get -> Consul.HTTPConfig
-~Consul.MeshEntry.HTTP.set -> void
-~Consul.MeshEntry.Incoming.get -> Consul.TLSDirectionConfig
-~Consul.MeshEntry.Incoming.set -> void
-~Consul.MeshEntry.Kind.get -> string
-~Consul.MeshEntry.Kind.set -> void
-~Consul.MeshEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.MeshEntry.Meta.set -> void
-~Consul.MeshEntry.Namespace.get -> string
-~Consul.MeshEntry.Namespace.set -> void
-~Consul.MeshEntry.Outgoing.get -> Consul.TLSDirectionConfig
-~Consul.MeshEntry.Outgoing.set -> void
-~Consul.MeshEntry.Partition.get -> string
-~Consul.MeshEntry.Partition.set -> void
-~Consul.MeshEntry.Peering.get -> Consul.PeeringMeshConfig
-~Consul.MeshEntry.Peering.set -> void
-~Consul.MeshEntry.TLS.get -> Consul.TLSConfig
-~Consul.MeshEntry.TLS.set -> void
-~Consul.MeshEntry.TransparentProxy.get -> Consul.TransparentProxyConfig
-~Consul.MeshEntry.TransparentProxy.set -> void
-~Consul.MeshGatewayConfig.Mode.get -> string
-~Consul.MeshGatewayConfig.Mode.set -> void
-~Consul.Metrics.Counters.get -> System.Collections.Generic.List<Consul.Counter>
-~Consul.Metrics.Counters.set -> void
-~Consul.Metrics.Gauges.get -> System.Collections.Generic.List<Consul.Gauge>
-~Consul.Metrics.Gauges.set -> void
-~Consul.Metrics.Points.get -> System.Collections.Generic.List<Consul.Point>
-~Consul.Metrics.Points.set -> void
-~Consul.Metrics.Samples.get -> System.Collections.Generic.List<Consul.Sample>
-~Consul.Metrics.Samples.set -> void
-~Consul.Metrics.Timestamp.get -> string
-~Consul.Metrics.Timestamp.set -> void
-~Consul.Namespace.ACLs.get -> Consul.NamespaceACLConfig
-~Consul.Namespace.ACLs.set -> void
-~Consul.Namespace.Description.get -> string
-~Consul.Namespace.Description.set -> void
-~Consul.Namespace.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.Namespace.Meta.set -> void
-~Consul.Namespace.Name.get -> string
-~Consul.Namespace.Name.set -> void
-~Consul.NamespaceACLConfig.PolicyDefaults.get -> System.Collections.Generic.List<Consul.AuthMethodEntry>
-~Consul.NamespaceACLConfig.PolicyDefaults.set -> void
-~Consul.NamespaceACLConfig.RoleDefaults.get -> System.Collections.Generic.List<Consul.AuthMethodEntry>
-~Consul.NamespaceACLConfig.RoleDefaults.set -> void
-~Consul.Namespaces.Create(Consul.Namespace ns) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
-~Consul.Namespaces.Create(Consul.Namespace ns, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
-~Consul.Namespaces.Create(Consul.Namespace ns, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
-~Consul.Namespaces.Delete(string name) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Namespaces.Delete(string name, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Namespaces.Delete(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Namespaces.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse[]>>
-~Consul.Namespaces.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse[]>>
-~Consul.Namespaces.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse[]>>
-~Consul.Namespaces.Read(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse>>
-~Consul.Namespaces.Read(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse>>
-~Consul.Namespaces.Read(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse>>
-~Consul.Namespaces.Update(Consul.Namespace ns) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
-~Consul.Namespaces.Update(Consul.Namespace ns, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
-~Consul.Namespaces.Update(Consul.Namespace ns, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
-~Consul.Node.Address.get -> string
-~Consul.Node.Address.set -> void
-~Consul.Node.Datacenter.get -> string
-~Consul.Node.Datacenter.set -> void
-~Consul.Node.Name.get -> string
-~Consul.Node.Name.set -> void
-~Consul.Node.TaggedAddresses.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.Node.TaggedAddresses.set -> void
-~Consul.NodeIdentity.Datacenter.get -> string
-~Consul.NodeIdentity.Datacenter.set -> void
-~Consul.NodeIdentity.NodeIdentity(string nodeName, string datacenter) -> void
-~Consul.NodeIdentity.NodeName.get -> string
-~Consul.NodeIdentity.NodeName.set -> void
-~Consul.NodeInfo.Address.get -> string
-~Consul.NodeInfo.Address.set -> void
-~Consul.NodeInfo.Datacenter.get -> string
-~Consul.NodeInfo.Datacenter.set -> void
-~Consul.NodeInfo.ID.get -> string
-~Consul.NodeInfo.ID.set -> void
-~Consul.NodeInfo.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.NodeInfo.Meta.set -> void
-~Consul.NodeInfo.Node.get -> string
-~Consul.NodeInfo.Node.set -> void
-~Consul.NodeInfo.TaggedAddresses.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.NodeInfo.TaggedAddresses.set -> void
-~Consul.NodeService.Node.get -> Consul.NodeInfo
-~Consul.NodeService.Node.set -> void
-~Consul.NodeService.Services.get -> System.Collections.Generic.List<Consul.ServiceInfo>
-~Consul.NodeService.Services.set -> void
-~Consul.Operator.AreaCreate(Consul.AreaRequest area) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Operator.AreaCreate(Consul.AreaRequest area, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Operator.AreaCreate(Consul.AreaRequest area, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Operator.AreaDelete(string areaId) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.AreaDelete(string areaId, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.AreaDelete(string areaId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.AreaGet(string areaId) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Area[]>>
-~Consul.Operator.AreaGet(string areaId, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Area[]>>
-~Consul.Operator.AreaGet(string areaId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Area[]>>
-~Consul.Operator.AreaList() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<Consul.Area>>>
-~Consul.Operator.AreaList(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<Consul.Area>>>
-~Consul.Operator.AreaList(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<Consul.Area>>>
-~Consul.Operator.AreaUpdate(Consul.AreaRequest area, string areaId) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Operator.AreaUpdate(Consul.AreaRequest area, string areaId, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Operator.AreaUpdate(Consul.AreaRequest area, string areaId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Operator.AutopilotGetConfiguration() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotConfiguration>>
-~Consul.Operator.AutopilotGetConfiguration(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotConfiguration>>
-~Consul.Operator.AutopilotGetConfiguration(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotConfiguration>>
-~Consul.Operator.AutopilotGetHealth() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotHealth>>
-~Consul.Operator.AutopilotGetHealth(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotHealth>>
-~Consul.Operator.AutopilotGetHealth(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotHealth>>
-~Consul.Operator.AutopilotGetState() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotState>>
-~Consul.Operator.AutopilotGetState(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotState>>
-~Consul.Operator.AutopilotGetState(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotState>>
-~Consul.Operator.AutopilotSetConfiguration(Consul.AutopilotConfiguration configuration) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.AutopilotSetConfiguration(Consul.AutopilotConfiguration configuration, Consul.WriteOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.AutopilotSetConfiguration(Consul.AutopilotConfiguration configuration, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.GetConsulLicense(string datacenter = "", System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ConsulLicense>>
-~Consul.Operator.KeyringInstall(string key) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.KeyringInstall(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.KeyringInstall(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.KeyringList() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KeyringResponse[]>>
-~Consul.Operator.KeyringList(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KeyringResponse[]>>
-~Consul.Operator.KeyringList(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KeyringResponse[]>>
-~Consul.Operator.KeyringRemove(string key) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.KeyringRemove(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.KeyringRemove(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.KeyringUse(string key) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.KeyringUse(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.KeyringUse(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.OperatorGetUsage() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.OperatorUsageInformation>>
-~Consul.Operator.OperatorGetUsage(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.OperatorUsageInformation>>
-~Consul.Operator.OperatorGetUsage(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.OperatorUsageInformation>>
-~Consul.Operator.RaftGetConfiguration() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RaftConfiguration>>
-~Consul.Operator.RaftGetConfiguration(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RaftConfiguration>>
-~Consul.Operator.RaftGetConfiguration(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RaftConfiguration>>
-~Consul.Operator.RaftRemovePeerByAddress(string address) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.RaftRemovePeerByAddress(string address, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.RaftRemovePeerByAddress(string address, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.RaftTransferLeader() -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.RaftTransferLeader(Consul.WriteOptions q) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.RaftTransferLeader(Consul.WriteOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.RaftTransferLeader(string id) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.RaftTransferLeader(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.RaftTransferLeader(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.RaftTransferLeader(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Operator.SegmentList() -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.Operator.SegmentList(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.Operator.SegmentList(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
-~Consul.OperatorUsageInformation.Usage.get -> System.Collections.Generic.Dictionary<string, Consul.DatacenterUsage>
-~Consul.OperatorUsageInformation.Usage.set -> void
-~Consul.OverrideConfig.BalanceOutboundConnections.get -> string
-~Consul.OverrideConfig.BalanceOutboundConnections.set -> void
-~Consul.OverrideConfig.Limits.get -> Consul.LimitsConfig
-~Consul.OverrideConfig.Limits.set -> void
-~Consul.OverrideConfig.MeshGateway.get -> Consul.MeshGatewayConfig
-~Consul.OverrideConfig.MeshGateway.set -> void
-~Consul.OverrideConfig.Name.get -> string
-~Consul.OverrideConfig.Name.set -> void
-~Consul.OverrideConfig.Namespace.get -> string
-~Consul.OverrideConfig.Namespace.set -> void
-~Consul.OverrideConfig.PassiveHealthCheck.get -> Consul.PassiveHealthCheckConfig
-~Consul.OverrideConfig.PassiveHealthCheck.set -> void
-~Consul.OverrideConfig.Peer.get -> string
-~Consul.OverrideConfig.Peer.set -> void
-~Consul.OverrideConfig.Protocol.get -> string
-~Consul.OverrideConfig.Protocol.set -> void
-~Consul.PassiveHealthCheckConfig.BaseEjectionTime.get -> string
-~Consul.PassiveHealthCheckConfig.BaseEjectionTime.set -> void
-~Consul.PassiveHealthCheckConfig.Interval.get -> string
-~Consul.PassiveHealthCheckConfig.Interval.set -> void
-~Consul.PathConfig.Path.get -> string
-~Consul.PathConfig.Path.set -> void
-~Consul.PathConfig.Protocol.get -> string
-~Consul.PathConfig.Protocol.set -> void
-~Consul.PeeringRemoteInfo.Datacenter.get -> string
-~Consul.PeeringRemoteInfo.Datacenter.set -> void
-~Consul.PeeringRemoteInfo.Partition.get -> string
-~Consul.PeeringRemoteInfo.Partition.set -> void
-~Consul.PeeringStreamStatus.ExportedServices.get -> System.Collections.Generic.List<string>
-~Consul.PeeringStreamStatus.ExportedServices.set -> void
-~Consul.PeeringStreamStatus.ImportedServices.get -> System.Collections.Generic.List<string>
-~Consul.PeeringStreamStatus.ImportedServices.set -> void
-~Consul.Point.Labels.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.Point.Labels.set -> void
-~Consul.Point.Name.get -> string
-~Consul.Point.Name.set -> void
-~Consul.Policy.Create(Consul.PolicyEntry policy) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.Policy.Create(Consul.PolicyEntry policy, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.Policy.Create(Consul.PolicyEntry policy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.Policy.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Policy.Delete(string id, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Policy.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Policy.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry[]>>
-~Consul.Policy.List(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry[]>>
-~Consul.Policy.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry[]>>
-~Consul.Policy.ListTemplatedPolicies() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.TemplatedPolicyResponse>>>
-~Consul.Policy.ListTemplatedPolicies(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.TemplatedPolicyResponse>>>
-~Consul.Policy.ListTemplatedPolicies(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.TemplatedPolicyResponse>>>
-~Consul.Policy.PreviewTemplatedPolicy(string name) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.Policy.PreviewTemplatedPolicy(string name, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.Policy.PreviewTemplatedPolicy(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.Policy.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
-~Consul.Policy.Read(string id, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
-~Consul.Policy.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
-~Consul.Policy.ReadPolicyByName(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
-~Consul.Policy.ReadPolicyByName(string name, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
-~Consul.Policy.ReadPolicyByName(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
-~Consul.Policy.ReadTemplatedPolicyByName(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TemplatedPolicyResponse>>
-~Consul.Policy.ReadTemplatedPolicyByName(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TemplatedPolicyResponse>>
-~Consul.Policy.ReadTemplatedPolicyByName(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TemplatedPolicyResponse>>
-~Consul.Policy.Update(Consul.PolicyEntry policy) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.Policy.Update(Consul.PolicyEntry policy, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.Policy.Update(Consul.PolicyEntry policy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
-~Consul.PolicyEntry.Datacenters.get -> string[]
-~Consul.PolicyEntry.Datacenters.set -> void
-~Consul.PolicyEntry.Description.get -> string
-~Consul.PolicyEntry.Description.set -> void
-~Consul.PolicyEntry.ID.get -> string
-~Consul.PolicyEntry.ID.set -> void
-~Consul.PolicyEntry.Name.get -> string
-~Consul.PolicyEntry.Name.set -> void
-~Consul.PolicyEntry.PolicyEntry(string id) -> void
-~Consul.PolicyEntry.PolicyEntry(string id, string name) -> void
-~Consul.PolicyEntry.PolicyEntry(string id, string name, string description, string rules, string[] datacenters) -> void
-~Consul.PolicyEntry.Rules.get -> string
-~Consul.PolicyEntry.Rules.set -> void
-~Consul.PolicyLink.ID.get -> string
-~Consul.PolicyLink.ID.set -> void
-~Consul.PolicyLink.Name.get -> string
-~Consul.PolicyLink.Name.set -> void
-~Consul.PolicyLink.PolicyLink(string id) -> void
-~Consul.PolicyLink.PolicyLink(string id, string name) -> void
-~Consul.PostRequest.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.PostRequest.Options.get -> Consul.WriteOptions
-~Consul.PostRequest.Options.set -> void
-~Consul.PostRequest.PostRequest(Consul.ConsulClient client, string url, string body, Consul.WriteOptions options = null) -> void
-~Consul.PostRequest<TIn, TOut>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<TOut>>
-~Consul.PostRequest<TIn, TOut>.Options.get -> Consul.WriteOptions
-~Consul.PostRequest<TIn, TOut>.Options.set -> void
-~Consul.PostRequest<TIn, TOut>.PostRequest(Consul.ConsulClient client, string url, TIn body, Consul.WriteOptions options = null) -> void
-~Consul.PostRequest<TIn>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.PostRequest<TIn>.Options.get -> Consul.WriteOptions
-~Consul.PostRequest<TIn>.Options.set -> void
-~Consul.PostRequest<TIn>.PostRequest(Consul.ConsulClient client, string url, TIn body, Consul.WriteOptions options = null) -> void
-~Consul.PostReturningRequest<TOut>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<TOut>>
-~Consul.PostReturningRequest<TOut>.Options.get -> Consul.WriteOptions
-~Consul.PostReturningRequest<TOut>.Options.set -> void
-~Consul.PostReturningRequest<TOut>.PostReturningRequest(Consul.ConsulClient client, string url, Consul.WriteOptions options = null) -> void
-~Consul.PreparedQuery.Create(Consul.PreparedQueryDefinition query) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.PreparedQuery.Create(Consul.PreparedQueryDefinition query, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.PreparedQuery.Create(Consul.PreparedQueryDefinition query, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.PreparedQuery.Delete(string queryID) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.PreparedQuery.Delete(string queryID, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.PreparedQuery.Delete(string queryID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.PreparedQuery.Execute(string queryIDOrName) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExecuteResponse>>
-~Consul.PreparedQuery.Execute(string queryIDOrName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExecuteResponse>>
-~Consul.PreparedQuery.Execute(string queryIDOrName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExecuteResponse>>
-~Consul.PreparedQuery.Explain(string queryIDOrName) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExplainResponse>>
-~Consul.PreparedQuery.Explain(string queryIDOrName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExplainResponse>>
-~Consul.PreparedQuery.Explain(string queryIDOrName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExplainResponse>>
-~Consul.PreparedQuery.Get(string queryID) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
-~Consul.PreparedQuery.Get(string queryID, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
-~Consul.PreparedQuery.Get(string queryID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
-~Consul.PreparedQuery.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
-~Consul.PreparedQuery.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
-~Consul.PreparedQuery.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
-~Consul.PreparedQuery.Update(Consul.PreparedQueryDefinition query) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.PreparedQuery.Update(Consul.PreparedQueryDefinition query, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.PreparedQuery.Update(Consul.PreparedQueryDefinition query, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.PreparedQueryDefinition.DNS.get -> Consul.QueryDNSOptions
-~Consul.PreparedQueryDefinition.DNS.set -> void
-~Consul.PreparedQueryDefinition.ID.get -> string
-~Consul.PreparedQueryDefinition.ID.set -> void
-~Consul.PreparedQueryDefinition.Name.get -> string
-~Consul.PreparedQueryDefinition.Name.set -> void
-~Consul.PreparedQueryDefinition.Service.get -> Consul.ServiceQuery
-~Consul.PreparedQueryDefinition.Service.set -> void
-~Consul.PreparedQueryDefinition.Session.get -> string
-~Consul.PreparedQueryDefinition.Session.set -> void
-~Consul.PreparedQueryDefinition.Template.get -> Consul.QueryTemplate
-~Consul.PreparedQueryDefinition.Template.set -> void
-~Consul.PreparedQueryDefinition.Token.get -> string
-~Consul.PreparedQueryDefinition.Token.set -> void
-~Consul.PreparedQueryExecuteResponse.Datacenter.get -> string
-~Consul.PreparedQueryExecuteResponse.Datacenter.set -> void
-~Consul.PreparedQueryExecuteResponse.DNS.get -> Consul.QueryDNSOptions
-~Consul.PreparedQueryExecuteResponse.DNS.set -> void
-~Consul.PreparedQueryExecuteResponse.Nodes.get -> Consul.ServiceEntry[]
-~Consul.PreparedQueryExecuteResponse.Nodes.set -> void
-~Consul.PreparedQueryExecuteResponse.Service.get -> string
-~Consul.PreparedQueryExecuteResponse.Service.set -> void
-~Consul.PreparedQueryExplainResponse.Query.get -> Consul.PreparedQueryDefinition
-~Consul.PreparedQueryExplainResponse.Query.set -> void
-~Consul.Provider.Action.get -> string
-~Consul.Provider.Action.set -> void
-~Consul.Provider.HTTP.get -> System.Collections.Generic.Dictionary<string, object>
-~Consul.Provider.HTTP.set -> void
-~Consul.Provider.Name.get -> string
-~Consul.Provider.Name.set -> void
-~Consul.Provider.Namespace.get -> string
-~Consul.Provider.Namespace.set -> void
-~Consul.Provider.Partition.get -> string
-~Consul.Provider.Partition.set -> void
-~Consul.Provider.Peer.get -> string
-~Consul.Provider.Peer.set -> void
-~Consul.Provider.Permissions.get -> System.Collections.Generic.List<string>
-~Consul.Provider.Permissions.set -> void
-~Consul.Provider.SamenessGroup.get -> string
-~Consul.Provider.SamenessGroup.set -> void
-~Consul.Provider.Sources.get -> System.Collections.Generic.List<string>
-~Consul.Provider.Sources.set -> void
-~Consul.Provider.VerifyClaims.get -> System.Collections.Generic.List<Consul.VerifyClaim>
-~Consul.Provider.VerifyClaims.set -> void
-~Consul.ProviderLocation.Cookie.get -> Consul.CookieLocation
-~Consul.ProviderLocation.Cookie.set -> void
-~Consul.ProviderLocation.Header.get -> Consul.HeaderLocation
-~Consul.ProviderLocation.Header.set -> void
-~Consul.ProviderLocation.QueryParam.get -> Consul.QueryParamLocation
-~Consul.ProviderLocation.QueryParam.set -> void
-~Consul.Proxy.Config.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.Proxy.Config.set -> void
-~Consul.Proxy.DestinationServiceID.get -> string
-~Consul.Proxy.DestinationServiceID.set -> void
-~Consul.Proxy.DestinationServiceName.get -> string
-~Consul.Proxy.DestinationServiceName.set -> void
-~Consul.Proxy.LocalServiceAddress.get -> string
-~Consul.Proxy.LocalServiceAddress.set -> void
-~Consul.Proxy.Mode.get -> string
-~Consul.Proxy.Mode.set -> void
-~Consul.Proxy.TransparentProxy.get -> Consul.TransparentProxy
-~Consul.Proxy.TransparentProxy.set -> void
-~Consul.Proxy.Upstreams.get -> System.Collections.Generic.List<Consul.Upstream>
-~Consul.Proxy.Upstreams.set -> void
-~Consul.ProxyDefaultEntry.AccessLogs.get -> Consul.AccessLogsConfig
-~Consul.ProxyDefaultEntry.AccessLogs.set -> void
-~Consul.ProxyDefaultEntry.Config.get -> System.Collections.Generic.Dictionary<string, object>
-~Consul.ProxyDefaultEntry.Config.set -> void
-~Consul.ProxyDefaultEntry.EnvoyExtensions.get -> System.Collections.Generic.List<Consul.EnvoyExtension>
-~Consul.ProxyDefaultEntry.EnvoyExtensions.set -> void
-~Consul.ProxyDefaultEntry.Expose.get -> Consul.ExposeConfig
-~Consul.ProxyDefaultEntry.Expose.set -> void
-~Consul.ProxyDefaultEntry.Kind.get -> string
-~Consul.ProxyDefaultEntry.Kind.set -> void
-~Consul.ProxyDefaultEntry.MeshGateway.get -> Consul.MeshGatewayConfig
-~Consul.ProxyDefaultEntry.MeshGateway.set -> void
-~Consul.ProxyDefaultEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ProxyDefaultEntry.Meta.set -> void
-~Consul.ProxyDefaultEntry.Mode.get -> string
-~Consul.ProxyDefaultEntry.Mode.set -> void
-~Consul.ProxyDefaultEntry.MutualTLSMode.get -> string
-~Consul.ProxyDefaultEntry.MutualTLSMode.set -> void
-~Consul.ProxyDefaultEntry.Name.get -> string
-~Consul.ProxyDefaultEntry.Name.set -> void
-~Consul.ProxyDefaultEntry.Namespace.get -> string
-~Consul.ProxyDefaultEntry.Namespace.set -> void
-~Consul.ProxyDefaultEntry.TransparentProxy.get -> Consul.TransparentProxyConfig
-~Consul.ProxyDefaultEntry.TransparentProxy.set -> void
-~Consul.PutNothingRequest.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.PutNothingRequest.Options.get -> Consul.WriteOptions
-~Consul.PutNothingRequest.Options.set -> void
-~Consul.PutNothingRequest.PutNothingRequest(Consul.ConsulClient client, string url, Consul.WriteOptions options = null) -> void
-~Consul.PutRequest<TIn, TOut>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<TOut>>
-~Consul.PutRequest<TIn, TOut>.Options.get -> Consul.WriteOptions
-~Consul.PutRequest<TIn, TOut>.Options.set -> void
-~Consul.PutRequest<TIn, TOut>.PutRequest(Consul.ConsulClient client, string url, TIn body, Consul.WriteOptions options = null) -> void
-~Consul.PutRequest<TIn>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.PutRequest<TIn>.Options.get -> Consul.WriteOptions
-~Consul.PutRequest<TIn>.Options.set -> void
-~Consul.PutRequest<TIn>.PutRequest(Consul.ConsulClient client, string url, TIn body, Consul.WriteOptions options = null) -> void
-~Consul.PutReturningRequest<TOut>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<TOut>>
-~Consul.PutReturningRequest<TOut>.Options.get -> Consul.WriteOptions
-~Consul.PutReturningRequest<TOut>.Options.set -> void
-~Consul.PutReturningRequest<TOut>.PutReturningRequest(Consul.ConsulClient client, string url, Consul.WriteOptions options = null) -> void
-~Consul.QueryDatacenterOptions.Datacenters.get -> System.Collections.Generic.List<string>
-~Consul.QueryDatacenterOptions.Datacenters.set -> void
-~Consul.QueryOptions.Datacenter.get -> string
-~Consul.QueryOptions.Datacenter.set -> void
-~Consul.QueryOptions.Namespace.get -> string
-~Consul.QueryOptions.Namespace.set -> void
-~Consul.QueryOptions.Near.get -> string
-~Consul.QueryOptions.Near.set -> void
-~Consul.QueryOptions.Token.get -> string
-~Consul.QueryOptions.Token.set -> void
-~Consul.QueryParamConfig.Exact.get -> string
-~Consul.QueryParamConfig.Exact.set -> void
-~Consul.QueryParamConfig.Name.get -> string
-~Consul.QueryParamConfig.Name.set -> void
-~Consul.QueryParamConfig.Regex.get -> string
-~Consul.QueryParamConfig.Regex.set -> void
-~Consul.QueryParamLocation.Name.get -> string
-~Consul.QueryParamLocation.Name.set -> void
-~Consul.QueryResult.QueryResult(Consul.QueryResult other) -> void
-~Consul.QueryResult<T>.QueryResult(Consul.QueryResult other) -> void
-~Consul.QueryResult<T>.QueryResult(Consul.QueryResult other, T value) -> void
-~Consul.QueryTemplate.Regexp.get -> string
-~Consul.QueryTemplate.Regexp.set -> void
-~Consul.QueryTemplate.Type.get -> string
-~Consul.QueryTemplate.Type.set -> void
-~Consul.RaftConfiguration.Servers.get -> System.Collections.Generic.List<Consul.RaftServer>
-~Consul.RaftConfiguration.Servers.set -> void
-~Consul.RaftServer.Address.get -> string
-~Consul.RaftServer.Address.set -> void
-~Consul.RaftServer.ID.get -> string
-~Consul.RaftServer.ID.set -> void
-~Consul.RaftServer.Node.get -> string
-~Consul.RaftServer.Node.set -> void
-~Consul.RateLimitsConfig.InstanceLevel.get -> Consul.InstanceLevelConfig
-~Consul.RateLimitsConfig.InstanceLevel.set -> void
-~Consul.Raw.Query(string endpoint, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<dynamic>>
-~Consul.Raw.Write(string endpoint, object obj, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<dynamic>>
-~Consul.RemoteJSONWebKeySet.CacheDuration.get -> string
-~Consul.RemoteJSONWebKeySet.CacheDuration.set -> void
-~Consul.RemoteJSONWebKeySet.JWKSCluster.get -> Consul.JWKSClusterConfig
-~Consul.RemoteJSONWebKeySet.JWKSCluster.set -> void
-~Consul.RemoteJSONWebKeySet.RequestTimeoutMs.get -> string
-~Consul.RemoteJSONWebKeySet.RequestTimeoutMs.set -> void
-~Consul.RemoteJSONWebKeySet.RetryPolicy.get -> Consul.RetryPolicyConfig
-~Consul.RemoteJSONWebKeySet.RetryPolicy.set -> void
-~Consul.RemoteJSONWebKeySet.URI.get -> string
-~Consul.RemoteJSONWebKeySet.URI.set -> void
-~Consul.ResolvedConsumers.Partitions.get -> System.Collections.Generic.List<string>
-~Consul.ResolvedConsumers.Partitions.set -> void
-~Consul.ResolvedConsumers.Peers.get -> System.Collections.Generic.List<string>
-~Consul.ResolvedConsumers.Peers.set -> void
-~Consul.ResolvedExportedService.Consumers.get -> Consul.ResolvedConsumers
-~Consul.ResolvedExportedService.Consumers.set -> void
-~Consul.ResolvedExportedService.Namespace.get -> string
-~Consul.ResolvedExportedService.Namespace.set -> void
-~Consul.ResolvedExportedService.Partition.get -> string
-~Consul.ResolvedExportedService.Partition.set -> void
-~Consul.ResolvedExportedService.Service.get -> string
-~Consul.ResolvedExportedService.Service.set -> void
-~Consul.RetryPolicyBackOffConfig.BaseInterval.get -> string
-~Consul.RetryPolicyBackOffConfig.BaseInterval.set -> void
-~Consul.RetryPolicyBackOffConfig.MaxInterval.get -> string
-~Consul.RetryPolicyBackOffConfig.MaxInterval.set -> void
-~Consul.RetryPolicyConfig.NumRetries.get -> string
-~Consul.RetryPolicyConfig.NumRetries.set -> void
-~Consul.RetryPolicyConfig.RetryPolicyBackOff.get -> Consul.RetryPolicyBackOffConfig
-~Consul.RetryPolicyConfig.RetryPolicyBackOff.set -> void
-~Consul.Role.Create(Consul.RoleEntry policy) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
-~Consul.Role.Create(Consul.RoleEntry policy, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
-~Consul.Role.Create(Consul.RoleEntry policy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
-~Consul.Role.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Role.Delete(string id, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Role.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Role.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry[]>>
-~Consul.Role.List(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry[]>>
-~Consul.Role.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry[]>>
-~Consul.Role.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
-~Consul.Role.Read(string id, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
-~Consul.Role.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
-~Consul.Role.ReadByName(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
-~Consul.Role.ReadByName(string name, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
-~Consul.Role.ReadByName(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
-~Consul.Role.Update(Consul.RoleEntry role) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
-~Consul.Role.Update(Consul.RoleEntry role, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
-~Consul.Role.Update(Consul.RoleEntry role, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
-~Consul.RoleEntry.Description.get -> string
-~Consul.RoleEntry.Description.set -> void
-~Consul.RoleEntry.ID.get -> string
-~Consul.RoleEntry.ID.set -> void
-~Consul.RoleEntry.Name.get -> string
-~Consul.RoleEntry.Name.set -> void
-~Consul.RoleEntry.NodeIdentities.get -> Consul.NodeIdentity[]
-~Consul.RoleEntry.NodeIdentities.set -> void
-~Consul.RoleEntry.Policies.get -> Consul.PolicyLink[]
-~Consul.RoleEntry.Policies.set -> void
-~Consul.RoleEntry.RoleEntry(string id, string name, string description) -> void
-~Consul.RoleEntry.RoleEntry(string id, string name, string description, Consul.PolicyLink[] policies) -> void
-~Consul.RoleEntry.RoleEntry(string id, string name, string description, Consul.PolicyLink[] policies, Consul.ServiceIdentity[] serviceIdentities) -> void
-~Consul.RoleEntry.RoleEntry(string id, string name, string description, Consul.ServiceIdentity[] serviceIdentities) -> void
-~Consul.RoleEntry.RoleEntry(string name) -> void
-~Consul.RoleEntry.RoleEntry(string name, string description) -> void
-~Consul.RoleEntry.ServiceIdentities.get -> Consul.ServiceIdentity[]
-~Consul.RoleEntry.ServiceIdentities.set -> void
-~Consul.RoleLink.ID.get -> string
-~Consul.RoleLink.ID.set -> void
-~Consul.RoleLink.Name.get -> string
-~Consul.RoleLink.Name.set -> void
-~Consul.RoleLink.RoleLink(string id) -> void
-~Consul.RoleLink.RoleLink(string id, string name) -> void
-~Consul.Root.ExternalTrustDomain.get -> string
-~Consul.Root.ExternalTrustDomain.set -> void
-~Consul.Root.ID.get -> string
-~Consul.Root.ID.set -> void
-~Consul.Root.IntermediateCerts.get -> System.Collections.Generic.List<string>
-~Consul.Root.IntermediateCerts.set -> void
-~Consul.Root.Name.get -> string
-~Consul.Root.Name.set -> void
-~Consul.Root.NotAfter.get -> string
-~Consul.Root.NotAfter.set -> void
-~Consul.Root.NotBefore.get -> string
-~Consul.Root.NotBefore.set -> void
-~Consul.Root.PrivateKeyType.get -> string
-~Consul.Root.PrivateKeyType.set -> void
-~Consul.Root.RootCert.get -> string
-~Consul.Root.RootCert.set -> void
-~Consul.Root.SigningKeyID.get -> string
-~Consul.Root.SigningKeyID.set -> void
-~Consul.RouteConfig.PathExact.get -> string
-~Consul.RouteConfig.PathExact.set -> void
-~Consul.RouteConfig.PathPrefix.get -> string
-~Consul.RouteConfig.PathPrefix.set -> void
-~Consul.RouteConfig.PathRegex.get -> string
-~Consul.RouteConfig.PathRegex.set -> void
-~Consul.Routes.Destination.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.Routes.Destination.set -> void
-~Consul.Routes.HTTP.get -> Consul.HTTPConfig
-~Consul.Routes.HTTP.set -> void
-~Consul.Routes.Match.get -> Consul.MapConfig
-~Consul.Routes.Match.set -> void
-~Consul.SamenessGroupEntry.Kind.get -> string
-~Consul.SamenessGroupEntry.Kind.set -> void
-~Consul.SamenessGroupEntry.Members.get -> System.Collections.Generic.List<Consul.SamenessGroupMember>
-~Consul.SamenessGroupEntry.Members.set -> void
-~Consul.SamenessGroupEntry.Name.get -> string
-~Consul.SamenessGroupEntry.Name.set -> void
-~Consul.SamenessGroupEntry.Partition.get -> string
-~Consul.SamenessGroupEntry.Partition.set -> void
-~Consul.SamenessGroupMember.Partition.get -> string
-~Consul.SamenessGroupMember.Partition.set -> void
-~Consul.SamenessGroupMember.Peer.get -> string
-~Consul.SamenessGroupMember.Peer.set -> void
-~Consul.Sample.Labels.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.Sample.Labels.set -> void
-~Consul.Sample.Name.get -> string
-~Consul.Sample.Name.set -> void
-~Consul.SDSConfig.CertResource.get -> string
-~Consul.SDSConfig.CertResource.set -> void
-~Consul.SDSConfig.ClusterName.get -> string
-~Consul.SDSConfig.ClusterName.set -> void
-~Consul.Semaphore.Acquire() -> System.Threading.Tasks.Task<System.Threading.CancellationToken>
-~Consul.Semaphore.Acquire(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Threading.CancellationToken>
-~Consul.Semaphore.Destroy(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.Semaphore.Release(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-~Consul.SemaphoreConflictException.SemaphoreConflictException(string message) -> void
-~Consul.SemaphoreConflictException.SemaphoreConflictException(string message, System.Exception inner) -> void
-~Consul.SemaphoreHeldException.SemaphoreHeldException(string message) -> void
-~Consul.SemaphoreHeldException.SemaphoreHeldException(string message, System.Exception inner) -> void
-~Consul.SemaphoreInUseException.SemaphoreInUseException(string message) -> void
-~Consul.SemaphoreInUseException.SemaphoreInUseException(string message, System.Exception inner) -> void
-~Consul.SemaphoreLimitConflictException.SemaphoreLimitConflictException(string message, int remoteLimit, int localLimit) -> void
-~Consul.SemaphoreLimitConflictException.SemaphoreLimitConflictException(string message, int remoteLimit, int localLimit, System.Exception inner) -> void
-~Consul.SemaphoreMaxAttemptsReachedException.SemaphoreMaxAttemptsReachedException(string message) -> void
-~Consul.SemaphoreMaxAttemptsReachedException.SemaphoreMaxAttemptsReachedException(string message, System.Exception inner) -> void
-~Consul.SemaphoreNotHeldException.SemaphoreNotHeldException(string message) -> void
-~Consul.SemaphoreNotHeldException.SemaphoreNotHeldException(string message, System.Exception inner) -> void
-~Consul.SemaphoreOptions.Prefix.get -> string
-~Consul.SemaphoreOptions.Prefix.set -> void
-~Consul.SemaphoreOptions.SemaphoreOptions(string prefix, int limit) -> void
-~Consul.SemaphoreOptions.Session.get -> string
-~Consul.SemaphoreOptions.Session.set -> void
-~Consul.SemaphoreOptions.SessionName.get -> string
-~Consul.SemaphoreOptions.SessionName.set -> void
-~Consul.SemaphoreOptions.Value.get -> byte[]
-~Consul.SemaphoreOptions.Value.set -> void
-~Consul.SerfCoordinate.Vec.get -> System.Collections.Generic.List<double>
-~Consul.SerfCoordinate.Vec.set -> void
-~Consul.ServiceAddress.Address.get -> string
-~Consul.ServiceAddress.Address.set -> void
-~Consul.ServiceConfiguration.Address.get -> string
-~Consul.ServiceConfiguration.Address.set -> void
-~Consul.ServiceConfiguration.ContentHash.get -> string
-~Consul.ServiceConfiguration.ContentHash.set -> void
-~Consul.ServiceConfiguration.Datacenter.get -> string
-~Consul.ServiceConfiguration.Datacenter.set -> void
-~Consul.ServiceConfiguration.ID.get -> string
-~Consul.ServiceConfiguration.ID.set -> void
-~Consul.ServiceConfiguration.Kind.get -> string
-~Consul.ServiceConfiguration.Kind.set -> void
-~Consul.ServiceConfiguration.Meta.get -> object
-~Consul.ServiceConfiguration.Meta.set -> void
-~Consul.ServiceConfiguration.Namespace.get -> string
-~Consul.ServiceConfiguration.Namespace.set -> void
-~Consul.ServiceConfiguration.Proxy.get -> Consul.Proxy
-~Consul.ServiceConfiguration.Proxy.set -> void
-~Consul.ServiceConfiguration.Service.get -> string
-~Consul.ServiceConfiguration.Service.set -> void
-~Consul.ServiceConfiguration.TaggedAddresses.get -> Consul.TaggedAddresses
-~Consul.ServiceConfiguration.TaggedAddresses.set -> void
-~Consul.ServiceConfiguration.Tags.get -> object
-~Consul.ServiceConfiguration.Tags.set -> void
-~Consul.ServiceConfiguration.Weights.get -> Consul.Weights
-~Consul.ServiceConfiguration.Weights.set -> void
-~Consul.ServiceDefaultsEntry.BalanceInboundConnections.get -> string
-~Consul.ServiceDefaultsEntry.BalanceInboundConnections.set -> void
-~Consul.ServiceDefaultsEntry.Defaults.get -> Consul.DefaultsConfig
-~Consul.ServiceDefaultsEntry.Defaults.set -> void
-~Consul.ServiceDefaultsEntry.Destination.get -> Consul.DestinationConfig
-~Consul.ServiceDefaultsEntry.Destination.set -> void
-~Consul.ServiceDefaultsEntry.EnvoyExtensions.get -> System.Collections.Generic.List<Consul.EnvoyExtensionConfig>
-~Consul.ServiceDefaultsEntry.EnvoyExtensions.set -> void
-~Consul.ServiceDefaultsEntry.Expose.get -> Consul.ExposeConfig
-~Consul.ServiceDefaultsEntry.Expose.set -> void
-~Consul.ServiceDefaultsEntry.ExternalSNI.get -> string
-~Consul.ServiceDefaultsEntry.ExternalSNI.set -> void
-~Consul.ServiceDefaultsEntry.Kind.get -> string
-~Consul.ServiceDefaultsEntry.Kind.set -> void
-~Consul.ServiceDefaultsEntry.MeshGateway.get -> Consul.MeshGatewayConfig
-~Consul.ServiceDefaultsEntry.MeshGateway.set -> void
-~Consul.ServiceDefaultsEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ServiceDefaultsEntry.Meta.set -> void
-~Consul.ServiceDefaultsEntry.Mode.get -> string
-~Consul.ServiceDefaultsEntry.Mode.set -> void
-~Consul.ServiceDefaultsEntry.MutualTLSMode.get -> string
-~Consul.ServiceDefaultsEntry.MutualTLSMode.set -> void
-~Consul.ServiceDefaultsEntry.Name.get -> string
-~Consul.ServiceDefaultsEntry.Name.set -> void
-~Consul.ServiceDefaultsEntry.Namespace.get -> string
-~Consul.ServiceDefaultsEntry.Namespace.set -> void
-~Consul.ServiceDefaultsEntry.Partition.get -> string
-~Consul.ServiceDefaultsEntry.Partition.set -> void
-~Consul.ServiceDefaultsEntry.Protocol.get -> string
-~Consul.ServiceDefaultsEntry.Protocol.set -> void
-~Consul.ServiceDefaultsEntry.RateLimits.get -> Consul.RateLimitsConfig
-~Consul.ServiceDefaultsEntry.RateLimits.set -> void
-~Consul.ServiceDefaultsEntry.TransparentProxy.get -> Consul.TransparentProxyConfig
-~Consul.ServiceDefaultsEntry.TransparentProxy.set -> void
-~Consul.ServiceDefaultsEntry.UpstreamConfig.get -> Consul.UpstreamConfig
-~Consul.ServiceDefaultsEntry.UpstreamConfig.set -> void
-~Consul.ServiceDefinition.Consumers.get -> System.Collections.Generic.List<Consul.ConsumerDefinition>
-~Consul.ServiceDefinition.Consumers.set -> void
-~Consul.ServiceDefinition.Name.get -> string
-~Consul.ServiceDefinition.Name.set -> void
-~Consul.ServiceDefinition.Namespace.get -> string
-~Consul.ServiceDefinition.Namespace.set -> void
-~Consul.ServiceEntry.Checks.get -> Consul.HealthCheck[]
-~Consul.ServiceEntry.Checks.set -> void
-~Consul.ServiceEntry.Node.get -> Consul.Node
-~Consul.ServiceEntry.Node.set -> void
-~Consul.ServiceEntry.Service.get -> Consul.AgentService
-~Consul.ServiceEntry.Service.set -> void
-~Consul.ServiceIdentity.Datacenters.get -> string[]
-~Consul.ServiceIdentity.Datacenters.set -> void
-~Consul.ServiceIdentity.ServiceIdentity(string serviceName, string[] datacenters) -> void
-~Consul.ServiceIdentity.ServiceName.get -> string
-~Consul.ServiceIdentity.ServiceName.set -> void
-~Consul.ServiceInfo.ID.get -> string
-~Consul.ServiceInfo.ID.set -> void
-~Consul.ServiceInfo.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ServiceInfo.Meta.set -> void
-~Consul.ServiceInfo.Namespace.get -> string
-~Consul.ServiceInfo.Namespace.set -> void
-~Consul.ServiceInfo.Service.get -> string
-~Consul.ServiceInfo.Service.set -> void
-~Consul.ServiceInfo.TaggedAddresses.get -> System.Collections.Generic.Dictionary<string, Consul.ServiceAddress>
-~Consul.ServiceInfo.TaggedAddresses.set -> void
-~Consul.ServiceInfo.Tags.get -> string[]
-~Consul.ServiceInfo.Tags.set -> void
-~Consul.ServiceIntention.Action.get -> string
-~Consul.ServiceIntention.Action.set -> void
-~Consul.ServiceIntention.Description.get -> string
-~Consul.ServiceIntention.Description.set -> void
-~Consul.ServiceIntention.DestinationName.get -> string
-~Consul.ServiceIntention.DestinationName.set -> void
-~Consul.ServiceIntention.DestinationNS.get -> string
-~Consul.ServiceIntention.DestinationNS.set -> void
-~Consul.ServiceIntention.ID.get -> string
-~Consul.ServiceIntention.ID.set -> void
-~Consul.ServiceIntention.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ServiceIntention.Meta.set -> void
-~Consul.ServiceIntention.SourceName.get -> string
-~Consul.ServiceIntention.SourceName.set -> void
-~Consul.ServiceIntention.SourceNS.get -> string
-~Consul.ServiceIntention.SourceNS.set -> void
-~Consul.ServiceIntention.SourceType.get -> string
-~Consul.ServiceIntention.SourceType.set -> void
-~Consul.ServiceIntentionsEntry.Kind.get -> string
-~Consul.ServiceIntentionsEntry.Kind.set -> void
-~Consul.ServiceIntentionsEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ServiceIntentionsEntry.Meta.set -> void
-~Consul.ServiceIntentionsEntry.Name.get -> string
-~Consul.ServiceIntentionsEntry.Name.set -> void
-~Consul.ServiceIntentionsEntry.Namespace.get -> string
-~Consul.ServiceIntentionsEntry.Namespace.set -> void
-~Consul.ServiceIntentionsEntry.Partition.get -> string
-~Consul.ServiceIntentionsEntry.Partition.set -> void
-~Consul.ServiceIntentionsEntry.Sources.get -> System.Collections.Generic.List<Consul.SourceIntention>
-~Consul.ServiceIntentionsEntry.Sources.set -> void
-~Consul.ServiceKind.Equals(Consul.ServiceKind other) -> bool
-~Consul.ServiceQuery.Failover.get -> Consul.QueryDatacenterOptions
-~Consul.ServiceQuery.Failover.set -> void
-~Consul.ServiceQuery.Near.get -> string
-~Consul.ServiceQuery.Near.set -> void
-~Consul.ServiceQuery.Service.get -> string
-~Consul.ServiceQuery.Service.set -> void
-~Consul.ServiceQuery.Tags.get -> System.Collections.Generic.List<string>
-~Consul.ServiceQuery.Tags.set -> void
-~Consul.ServiceResolverEntry.ConnectTimeout.get -> string
-~Consul.ServiceResolverEntry.ConnectTimeout.set -> void
-~Consul.ServiceResolverEntry.DefaultSubset.get -> string
-~Consul.ServiceResolverEntry.DefaultSubset.set -> void
-~Consul.ServiceResolverEntry.Filter.get -> string
-~Consul.ServiceResolverEntry.Filter.set -> void
-~Consul.ServiceResolverEntry.Kind.get -> string
-~Consul.ServiceResolverEntry.Kind.set -> void
-~Consul.ServiceResolverEntry.LoadBalancer.get -> Consul.LoadBalancerConfig
-~Consul.ServiceResolverEntry.LoadBalancer.set -> void
-~Consul.ServiceResolverEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ServiceResolverEntry.Meta.set -> void
-~Consul.ServiceResolverEntry.Name.get -> string
-~Consul.ServiceResolverEntry.Name.set -> void
-~Consul.ServiceResolverEntry.Namespace.get -> string
-~Consul.ServiceResolverEntry.Namespace.set -> void
-~Consul.ServiceResolverEntry.Partition.get -> string
-~Consul.ServiceResolverEntry.Partition.set -> void
-~Consul.ServiceResolverEntry.Redirect.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ServiceResolverEntry.Redirect.set -> void
-~Consul.ServiceResolverEntry.RequestTimeout.get -> string
-~Consul.ServiceResolverEntry.RequestTimeout.set -> void
-~Consul.ServiceResolverEntry.Subsets.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ServiceResolverEntry.Subsets.set -> void
-~Consul.ServiceRouterEntry.Kind.get -> string
-~Consul.ServiceRouterEntry.Kind.set -> void
-~Consul.ServiceRouterEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ServiceRouterEntry.Meta.set -> void
-~Consul.ServiceRouterEntry.Name.get -> string
-~Consul.ServiceRouterEntry.Name.set -> void
-~Consul.ServiceRouterEntry.Namespace.get -> string
-~Consul.ServiceRouterEntry.Namespace.set -> void
-~Consul.ServiceRouterEntry.Partition.get -> string
-~Consul.ServiceRouterEntry.Partition.set -> void
-~Consul.ServiceRouterEntry.Routes.get -> System.Collections.Generic.List<Consul.Routes>
-~Consul.ServiceRouterEntry.Routes.set -> void
-~Consul.ServiceSplitterEntry.Kind.get -> string
-~Consul.ServiceSplitterEntry.Kind.set -> void
-~Consul.ServiceSplitterEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.ServiceSplitterEntry.Meta.set -> void
-~Consul.ServiceSplitterEntry.Name.get -> string
-~Consul.ServiceSplitterEntry.Name.set -> void
-~Consul.ServiceSplitterEntry.Namespace.get -> string
-~Consul.ServiceSplitterEntry.Namespace.set -> void
-~Consul.ServiceSplitterEntry.Partition.get -> string
-~Consul.ServiceSplitterEntry.Partition.set -> void
-~Consul.ServiceSplitterEntry.Splits.get -> System.Collections.Generic.List<Consul.SplitConfig>
-~Consul.ServiceSplitterEntry.Splits.set -> void
-~Consul.ServiceTaggedAddress.Address.get -> string
-~Consul.ServiceTaggedAddress.Address.set -> void
-~Consul.Session.Create() -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Session.Create(Consul.SessionEntry se) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Session.Create(Consul.SessionEntry se, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Session.Create(Consul.SessionEntry se, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Session.Create(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Session.CreateNoChecks() -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Session.CreateNoChecks(Consul.SessionEntry se) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Session.CreateNoChecks(Consul.SessionEntry se, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Session.CreateNoChecks(Consul.SessionEntry se, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Session.CreateNoChecks(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
-~Consul.Session.Destroy(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Session.Destroy(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Session.Destroy(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Session.Info(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry>>
-~Consul.Session.Info(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry>>
-~Consul.Session.Info(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry>>
-~Consul.Session.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
-~Consul.Session.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
-~Consul.Session.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
-~Consul.Session.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
-~Consul.Session.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
-~Consul.Session.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
-~Consul.Session.Renew(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.SessionEntry>>
-~Consul.Session.Renew(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.SessionEntry>>
-~Consul.Session.Renew(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.SessionEntry>>
-~Consul.Session.RenewPeriodic(System.TimeSpan initialTTL, string id, Consul.WriteOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
-~Consul.Session.RenewPeriodic(System.TimeSpan initialTTL, string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
-~Consul.SessionBehavior.Behavior.get -> string
-~Consul.SessionBehavior.Equals(Consul.SessionBehavior other) -> bool
-~Consul.SessionCreationException.SessionCreationException(string message) -> void
-~Consul.SessionCreationException.SessionCreationException(string message, System.Exception inner) -> void
-~Consul.SessionEntry.Behavior.get -> Consul.SessionBehavior
-~Consul.SessionEntry.Behavior.set -> void
-~Consul.SessionEntry.Checks.get -> System.Collections.Generic.List<string>
-~Consul.SessionEntry.Checks.set -> void
-~Consul.SessionEntry.ID.get -> string
-~Consul.SessionEntry.ID.set -> void
-~Consul.SessionEntry.Name.get -> string
-~Consul.SessionEntry.Name.set -> void
-~Consul.SessionEntry.Node.get -> string
-~Consul.SessionEntry.Node.set -> void
-~Consul.SessionExpiredException.SessionExpiredException(string message) -> void
-~Consul.SessionExpiredException.SessionExpiredException(string message, System.Exception inner) -> void
-~Consul.Snapshot.Restore(System.IO.Stream s) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Snapshot.Restore(System.IO.Stream s, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Snapshot.Restore(System.IO.Stream s, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
-~Consul.Snapshot.Save() -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
-~Consul.Snapshot.Save(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
-~Consul.Snapshot.Save(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
-~Consul.SourceIntention.Action.get -> string
-~Consul.SourceIntention.Action.set -> void
-~Consul.SourceIntention.Description.get -> string
-~Consul.SourceIntention.Description.set -> void
-~Consul.SourceIntention.LegacyID.get -> string
-~Consul.SourceIntention.LegacyID.set -> void
-~Consul.SourceIntention.LegacyMeta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.SourceIntention.LegacyMeta.set -> void
-~Consul.SourceIntention.Name.get -> string
-~Consul.SourceIntention.Name.set -> void
-~Consul.SourceIntention.Namespace.get -> string
-~Consul.SourceIntention.Namespace.set -> void
-~Consul.SourceIntention.Partition.get -> string
-~Consul.SourceIntention.Partition.set -> void
-~Consul.SourceIntention.Peer.get -> string
-~Consul.SourceIntention.Peer.set -> void
-~Consul.SourceIntention.Permissions.get -> System.Collections.Generic.List<Consul.IntentionPermission>
-~Consul.SourceIntention.Permissions.set -> void
-~Consul.SourceIntention.Type.get -> string
-~Consul.SourceIntention.Type.set -> void
-~Consul.SplitConfig.Namespace.get -> string
-~Consul.SplitConfig.Namespace.set -> void
-~Consul.SplitConfig.Partition.get -> string
-~Consul.SplitConfig.Partition.set -> void
-~Consul.SplitConfig.RequestHeaders.get -> System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>>
-~Consul.SplitConfig.RequestHeaders.set -> void
-~Consul.SplitConfig.ResponseHeaders.get -> System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>>
-~Consul.SplitConfig.ResponseHeaders.set -> void
-~Consul.SplitConfig.Service.get -> string
-~Consul.SplitConfig.Service.set -> void
-~Consul.SplitConfig.ServiceSubset.get -> string
-~Consul.SplitConfig.ServiceSubset.set -> void
-~Consul.Status.Leader(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
-~Consul.Status.Peers(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string[]>
-~Consul.TaggedAddresses.Lan.get -> Consul.AddressDetails
-~Consul.TaggedAddresses.Lan.set -> void
-~Consul.TaggedAddresses.Wan.get -> Consul.AddressDetails
-~Consul.TaggedAddresses.Wan.set -> void
-~Consul.TcpRouteEntry.Kind.get -> string
-~Consul.TcpRouteEntry.Kind.set -> void
-~Consul.TcpRouteEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.TcpRouteEntry.Meta.set -> void
-~Consul.TcpRouteEntry.Name.get -> string
-~Consul.TcpRouteEntry.Name.set -> void
-~Consul.TcpRouteEntry.Namespace.get -> string
-~Consul.TcpRouteEntry.Namespace.set -> void
-~Consul.TcpRouteEntry.Parents.get -> System.Collections.Generic.List<Consul.ApiGatewayReference>
-~Consul.TcpRouteEntry.Parents.set -> void
-~Consul.TcpRouteEntry.Partition.get -> string
-~Consul.TcpRouteEntry.Partition.set -> void
-~Consul.TcpRouteEntry.Services.get -> System.Collections.Generic.List<Consul.TcpRouteService>
-~Consul.TcpRouteEntry.Services.set -> void
-~Consul.TcpRouteService.Name.get -> string
-~Consul.TcpRouteService.Name.set -> void
-~Consul.TcpRouteService.Namespace.get -> string
-~Consul.TcpRouteService.Namespace.set -> void
-~Consul.TcpRouteService.Partition.get -> string
-~Consul.TcpRouteService.Partition.set -> void
-~Consul.TemplatedPolicyResponse.Schema.get -> string
-~Consul.TemplatedPolicyResponse.Schema.set -> void
-~Consul.TemplatedPolicyResponse.Template.get -> string
-~Consul.TemplatedPolicyResponse.Template.set -> void
-~Consul.TemplatedPolicyResponse.TemplateName.get -> string
-~Consul.TemplatedPolicyResponse.TemplateName.set -> void
-~Consul.TerminatingGatewayEntry.Kind.get -> string
-~Consul.TerminatingGatewayEntry.Kind.set -> void
-~Consul.TerminatingGatewayEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
-~Consul.TerminatingGatewayEntry.Meta.set -> void
-~Consul.TerminatingGatewayEntry.Name.get -> string
-~Consul.TerminatingGatewayEntry.Name.set -> void
-~Consul.TerminatingGatewayEntry.Namespace.get -> string
-~Consul.TerminatingGatewayEntry.Namespace.set -> void
-~Consul.TerminatingGatewayEntry.Partition.get -> string
-~Consul.TerminatingGatewayEntry.Partition.set -> void
-~Consul.TerminatingGatewayEntry.Services.get -> System.Collections.Generic.List<Consul.LinkedService>
-~Consul.TerminatingGatewayEntry.Services.set -> void
-~Consul.TLSCertificatesConfig.CaCertificateProviderInstance.get -> Consul.CaCertificateProviderInstanceConfig
-~Consul.TLSCertificatesConfig.CaCertificateProviderInstance.set -> void
-~Consul.TLSCertificatesConfig.TrustedCA.get -> Consul.TrustedCAConfig
-~Consul.TLSCertificatesConfig.TrustedCA.set -> void
-~Consul.TLSConfig.CipherSuites.get -> System.Collections.Generic.List<string>
-~Consul.TLSConfig.CipherSuites.set -> void
-~Consul.TLSConfig.SDS.get -> Consul.SDSConfig
-~Consul.TLSConfig.SDS.set -> void
-~Consul.TLSConfig.TLSMaxVersion.get -> string
-~Consul.TLSConfig.TLSMaxVersion.set -> void
-~Consul.TLSConfig.TLSMinVersion.get -> string
-~Consul.TLSConfig.TLSMinVersion.set -> void
-~Consul.TLSDirectionConfig.CipherSuites.get -> System.Collections.Generic.List<string>
-~Consul.TLSDirectionConfig.CipherSuites.set -> void
-~Consul.TLSDirectionConfig.TLSMaxVersion.get -> string
-~Consul.TLSDirectionConfig.TLSMaxVersion.set -> void
-~Consul.TLSDirectionConfig.TLSMinVersion.get -> string
-~Consul.TLSDirectionConfig.TLSMinVersion.set -> void
-~Consul.Token.Bootstrap() -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Bootstrap(Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Bootstrap(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Clone(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Clone(string id, Consul.WriteOptions writeOptions) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Clone(string id, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Clone(string id, string description, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Clone(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Create(Consul.TokenEntry token) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Create(Consul.TokenEntry token, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Create(Consul.TokenEntry token, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Token.Delete(string id, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Token.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
-~Consul.Token.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry[]>>
-~Consul.Token.List(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry[]>>
-~Consul.Token.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry[]>>
-~Consul.Token.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
-~Consul.Token.Read(string id, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
-~Consul.Token.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
-~Consul.Token.ReadSelfToken(string token) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
-~Consul.Token.ReadSelfToken(string token, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
-~Consul.Token.ReadSelfToken(string token, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
-~Consul.Token.Update(Consul.TokenEntry token) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Update(Consul.TokenEntry token, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.Token.Update(Consul.TokenEntry token, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
-~Consul.TokenEntry.AccessorID.get -> string
-~Consul.TokenEntry.AccessorID.set -> void
-~Consul.TokenEntry.AuthMethod.get -> string
-~Consul.TokenEntry.AuthMethod.set -> void
-~Consul.TokenEntry.Description.get -> string
-~Consul.TokenEntry.Description.set -> void
-~Consul.TokenEntry.NodeIdentities.get -> Consul.NodeIdentity[]
-~Consul.TokenEntry.NodeIdentities.set -> void
-~Consul.TokenEntry.Policies.get -> Consul.PolicyLink[]
-~Consul.TokenEntry.Policies.set -> void
-~Consul.TokenEntry.Roles.get -> Consul.RoleLink[]
-~Consul.TokenEntry.Roles.set -> void
-~Consul.TokenEntry.SecretID.get -> string
-~Consul.TokenEntry.SecretID.set -> void
-~Consul.TokenEntry.ServiceIdentities.get -> Consul.ServiceIdentity[]
-~Consul.TokenEntry.ServiceIdentities.set -> void
-~Consul.TokenEntry.TokenEntry(string accessorId, string description) -> void
-~Consul.TokenEntry.TokenEntry(string accessorId, string description, Consul.PolicyLink[] policies, Consul.RoleLink[] roles, Consul.ServiceIdentity[] serviceIdentities) -> void
-~Consul.TokenEntry.TokenEntry(string description, Consul.PolicyLink[] policies) -> void
-~Consul.TokenEntry.TokenEntry(string description, Consul.RoleLink[] roles) -> void
-~Consul.TokenEntry.TokenEntry(string description, Consul.ServiceIdentity[] serviceIdentities) -> void
-~Consul.TrustedCAConfig.EnvironmentVariable.get -> string
-~Consul.TrustedCAConfig.EnvironmentVariable.set -> void
-~Consul.TrustedCAConfig.Filename.get -> string
-~Consul.TrustedCAConfig.Filename.set -> void
-~Consul.TrustedCAConfig.InlineBytes.get -> string
-~Consul.TrustedCAConfig.InlineBytes.set -> void
-~Consul.TrustedCAConfig.InlineString.get -> string
-~Consul.TrustedCAConfig.InlineString.set -> void
-~Consul.TTLStatus.Equals(Consul.TTLStatus other) -> bool
-~Consul.TTLStatus.Status.get -> string
-~Consul.TxnError.What.get -> string
-~Consul.Upstream.DestinationName.get -> string
-~Consul.Upstream.DestinationName.set -> void
-~Consul.Upstream.DestinationType.get -> string
-~Consul.Upstream.DestinationType.set -> void
-~Consul.UpstreamConfig.Overrides.get -> System.Collections.Generic.List<Consul.OverrideConfig>
-~Consul.UpstreamConfig.Overrides.set -> void
-~Consul.UserEvent.ID.get -> string
-~Consul.UserEvent.ID.set -> void
-~Consul.UserEvent.Name.get -> string
-~Consul.UserEvent.Name.set -> void
-~Consul.UserEvent.NodeFilter.get -> string
-~Consul.UserEvent.NodeFilter.set -> void
-~Consul.UserEvent.Payload.get -> byte[]
-~Consul.UserEvent.Payload.set -> void
-~Consul.UserEvent.ServiceFilter.get -> string
-~Consul.UserEvent.ServiceFilter.set -> void
-~Consul.UserEvent.TagFilter.get -> string
-~Consul.UserEvent.TagFilter.set -> void
-~Consul.VerifyClaim.Path.get -> string
-~Consul.VerifyClaim.Path.set -> void
-~Consul.VerifyClaim.Value.get -> string
-~Consul.VerifyClaim.Value.set -> void
-~Consul.VerifyClaims.Path.get -> System.Collections.Generic.List<string>
-~Consul.VerifyClaims.Path.set -> void
-~Consul.VerifyClaims.Value.get -> string
-~Consul.VerifyClaims.Value.set -> void
-~Consul.WriteOptions.Datacenter.get -> string
-~Consul.WriteOptions.Datacenter.set -> void
-~Consul.WriteOptions.Namespace.get -> string
-~Consul.WriteOptions.Namespace.set -> void
-~Consul.WriteOptions.Token.get -> string
-~Consul.WriteOptions.Token.set -> void
-~Consul.WriteResult.WriteResult(Consul.WriteResult other) -> void
-~Consul.WriteResult<T>.WriteResult(Consul.WriteResult other) -> void
-~Consul.WriteResult<T>.WriteResult(Consul.WriteResult other, T value) -> void
-~override Consul.ACLType.Equals(object other) -> bool
-~override Consul.ACLTypeConverter.CanConvert(System.Type objectType) -> bool
-~override Consul.ACLTypeConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override Consul.ACLTypeConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
-~override Consul.DeleteAcceptingRequest<TIn>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.DeleteAcceptingRequest<TIn>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.DeleteRequest.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.DeleteRequest.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.DeleteReturnRequest<TOut>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.DeleteReturnRequest<TOut>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.DurationTimespanConverter.CanConvert(System.Type objectType) -> bool
-~override Consul.DurationTimespanConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override Consul.DurationTimespanConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
-~override Consul.Filtering.MetaSelector.Encode() -> string
-~override Consul.Filtering.NodeSelector.Encode() -> string
-~override Consul.Filtering.ServiceMetaEntrySelector.Encode() -> string
-~override Consul.Filtering.ServiceSelector.Encode() -> string
-~override Consul.Filtering.StringFieldSelector.Encode() -> string
-~override Consul.Filtering.TagsSelector.Encode() -> string
-~override Consul.GetRequest.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.GetRequest.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.GetRequest<TOut>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.GetRequest<TOut>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.HealthStatus.Equals(object other) -> bool
-~override Consul.HealthStatusConverter.CanConvert(System.Type objectType) -> bool
-~override Consul.HealthStatusConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override Consul.HealthStatusConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
-~override Consul.KVPairConverter.CanConvert(System.Type objectType) -> bool
-~override Consul.KVPairConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override Consul.KVPairConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
-~override Consul.KVTxnVerb.Equals(object other) -> bool
-~override Consul.KVTxnVerbTypeConverter.CanConvert(System.Type objectType) -> bool
-~override Consul.KVTxnVerbTypeConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override Consul.KVTxnVerbTypeConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
-~override Consul.NanoSecTimespanConverter.CanConvert(System.Type objectType) -> bool
-~override Consul.NanoSecTimespanConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override Consul.NanoSecTimespanConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
-~override Consul.PostRequest.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PostRequest.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PostRequest<TIn, TOut>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PostRequest<TIn, TOut>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PostRequest<TIn>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PostRequest<TIn>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PostReturningRequest<TOut>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PostReturningRequest<TOut>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PutNothingRequest.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PutNothingRequest.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PutRequest<TIn, TOut>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PutRequest<TIn, TOut>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PutRequest<TIn>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PutRequest<TIn>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PutReturningRequest<TOut>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.PutReturningRequest<TOut>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
-~override Consul.ServiceKind.Equals(object obj) -> bool
-~override Consul.ServiceKind.ToString() -> string
-~override Consul.SessionBehavior.Equals(object other) -> bool
-~override Consul.SessionBehaviorConverter.CanConvert(System.Type objectType) -> bool
-~override Consul.SessionBehaviorConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override Consul.SessionBehaviorConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
-~override Consul.TTLStatus.Equals(object other) -> bool
-~override Consul.TTLStatusConverter.CanConvert(System.Type objectType) -> bool
-~override Consul.TTLStatusConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
-~override Consul.TTLStatusConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
-~static Consul.ACLType.Client.get -> Consul.ACLType
-~static Consul.ACLType.Management.get -> Consul.ACLType
-~static Consul.Filtering.Filter.operator !(Consul.Filtering.Filter filter) -> Consul.Filtering.Filter
-~static Consul.Filtering.Filter.operator &(Consul.Filtering.Filter left, Consul.Filtering.Filter right) -> Consul.Filtering.Filter
-~static Consul.Filtering.Filter.operator |(Consul.Filtering.Filter left, Consul.Filtering.Filter right) -> Consul.Filtering.Filter
-~static Consul.Filtering.Filter.Quote(string s) -> string
-~static Consul.Filtering.Selector.Combine(string prefix, string self) -> string
-~static Consul.Filtering.Selectors.Service.get -> Consul.Filtering.ServiceSelector
-~static Consul.Filtering.Selectors.ServiceName.get -> Consul.Filtering.StringFieldSelector
-~static Consul.Filtering.ServiceMetaEntrySelector.operator !=(Consul.Filtering.ServiceMetaEntrySelector selector, string value) -> Consul.Filtering.Filter
-~static Consul.Filtering.ServiceMetaEntrySelector.operator ==(Consul.Filtering.ServiceMetaEntrySelector selector, string value) -> Consul.Filtering.Filter
-~static Consul.Filtering.ServiceSelector.operator !=(Consul.Filtering.ServiceSelector selector, string value) -> Consul.Filtering.Filter
-~static Consul.Filtering.ServiceSelector.operator ==(Consul.Filtering.ServiceSelector selector, string value) -> Consul.Filtering.Filter
-~static Consul.Filtering.StringFieldSelector.operator !=(Consul.Filtering.StringFieldSelector selector, string value) -> Consul.Filtering.Filter
-~static Consul.Filtering.StringFieldSelector.operator ==(Consul.Filtering.StringFieldSelector selector, string value) -> Consul.Filtering.Filter
-~static Consul.HealthCheckExtension.AggregatedStatus(this System.Collections.Generic.IEnumerable<Consul.HealthCheck> checks) -> Consul.HealthStatus
-~static Consul.HealthStatus.Any.get -> Consul.HealthStatus
-~static Consul.HealthStatus.Critical.get -> Consul.HealthStatus
-~static Consul.HealthStatus.Maintenance.get -> Consul.HealthStatus
-~static Consul.HealthStatus.Parse(string status) -> Consul.HealthStatus
-~static Consul.HealthStatus.Passing.get -> Consul.HealthStatus
-~static Consul.HealthStatus.Warning.get -> Consul.HealthStatus
-~static Consul.KVTxnVerb.CAS.get -> Consul.KVTxnVerb
-~static Consul.KVTxnVerb.CheckIndex.get -> Consul.KVTxnVerb
-~static Consul.KVTxnVerb.CheckSession.get -> Consul.KVTxnVerb
-~static Consul.KVTxnVerb.Delete.get -> Consul.KVTxnVerb
-~static Consul.KVTxnVerb.DeleteCAS.get -> Consul.KVTxnVerb
-~static Consul.KVTxnVerb.DeleteTree.get -> Consul.KVTxnVerb
-~static Consul.KVTxnVerb.Get.get -> Consul.KVTxnVerb
-~static Consul.KVTxnVerb.GetTree.get -> Consul.KVTxnVerb
-~static Consul.KVTxnVerb.Lock.get -> Consul.KVTxnVerb
-~static Consul.KVTxnVerb.Set.get -> Consul.KVTxnVerb
-~static Consul.KVTxnVerb.Unlock.get -> Consul.KVTxnVerb
-~static Consul.PolicyEntry.implicit operator Consul.PolicyLink(Consul.PolicyEntry p) -> Consul.PolicyLink
-~static Consul.RoleEntry.implicit operator Consul.RoleLink(Consul.RoleEntry r) -> Consul.RoleLink
-~static Consul.ServiceKind.ConnectProxy.get -> Consul.ServiceKind
-~static Consul.ServiceKind.IngressGateway.get -> Consul.ServiceKind
-~static Consul.ServiceKind.MeshGateway.get -> Consul.ServiceKind
-~static Consul.ServiceKind.TerminatingGateway.get -> Consul.ServiceKind
-~static Consul.ServiceKind.TryParse(string value, out Consul.ServiceKind result) -> bool
-~static Consul.SessionBehavior.Delete.get -> Consul.SessionBehavior
-~static Consul.SessionBehavior.Release.get -> Consul.SessionBehavior
-~static Consul.TTLStatus.Critical.get -> Consul.TTLStatus
-~static Consul.TTLStatus.Fail.get -> Consul.TTLStatus
-~static Consul.TTLStatus.Pass.get -> Consul.TTLStatus
-~static Consul.TTLStatus.Warn.get -> Consul.TTLStatus
-~static readonly Consul.QueryOptions.Default -> Consul.QueryOptions
-~static readonly Consul.Semaphore.DefaultSemaphoreKey -> string
-~static readonly Consul.WriteOptions.Default -> Consul.WriteOptions
+abstract Consul.Filtering.Filter.Encode() -> string
+abstract Consul.Filtering.Selector.Encode() -> string
+const Consul.DiscoveryChain.DiscoveryGraphNodeTypeResolver = "resolver" -> string
+const Consul.DiscoveryChain.DiscoveryGraphNodeTypeRouter = "router" -> string
+const Consul.DiscoveryChain.DiscoveryGraphNodeTypeSplitter = "splitter" -> string
+const Consul.HealthStatus.NodeMaintenance = "_node_maintenance" -> string
+const Consul.HealthStatus.ServiceMaintenancePrefix = "_service_maintenance:" -> string
+Consul.AccessLogsConfig.JSONFormat.get -> string
+Consul.AccessLogsConfig.JSONFormat.set -> void
+Consul.AccessLogsConfig.Path.get -> string
+Consul.AccessLogsConfig.Path.set -> void
+Consul.AccessLogsConfig.TextFormat.get -> string
+Consul.AccessLogsConfig.TextFormat.set -> void
+Consul.AccessLogsConfig.Type.get -> string
+Consul.AccessLogsConfig.Type.set -> void
+Consul.ACL.Clone(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ACL.Clone(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ACL.Create(Consul.ACLEntry acl, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ACL.Create(Consul.ACLEntry acl, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ACL.Destroy(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.ACL.Destroy(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.ACL.Info(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry>>
+Consul.ACL.Info(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry>>
+Consul.ACL.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry[]>>
+Consul.ACL.List(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry[]>>
+Consul.ACL.TranslateLegacyTokenRules(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
+Consul.ACL.TranslateLegacyTokenRules(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
+Consul.ACL.TranslateRules(string rules, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ACL.TranslateRules(string rules, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ACL.Update(Consul.ACLEntry acl, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ACL.Update(Consul.ACLEntry acl, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ACLBindingRule.AuthMethod.get -> string
+Consul.ACLBindingRule.AuthMethod.set -> void
+Consul.ACLBindingRule.BindName.get -> string
+Consul.ACLBindingRule.BindName.set -> void
+Consul.ACLBindingRule.BindType.get -> string
+Consul.ACLBindingRule.BindType.set -> void
+Consul.ACLBindingRule.BindVars.get -> Consul.ACLTemplatedPolicyVariables
+Consul.ACLBindingRule.BindVars.set -> void
+Consul.ACLBindingRule.Description.get -> string
+Consul.ACLBindingRule.Description.set -> void
+Consul.ACLBindingRule.ID.get -> string
+Consul.ACLBindingRule.ID.set -> void
+Consul.ACLBindingRule.Selector.get -> string
+Consul.ACLBindingRule.Selector.set -> void
+Consul.ACLEntry.ACLEntry(string id, string name, string rules) -> void
+Consul.ACLEntry.ACLEntry(string name, string rules) -> void
+Consul.ACLEntry.ID.get -> string
+Consul.ACLEntry.ID.set -> void
+Consul.ACLEntry.Name.get -> string
+Consul.ACLEntry.Name.set -> void
+Consul.ACLEntry.Rules.get -> string
+Consul.ACLEntry.Rules.set -> void
+Consul.ACLEntry.Type.get -> Consul.ACLType
+Consul.ACLEntry.Type.set -> void
+Consul.ACLReplication.Status() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLReplicationEntry>>
+Consul.ACLReplication.Status(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLReplicationEntry>>
+Consul.ACLReplication.Status(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLReplicationEntry>>
+Consul.ACLReplicationEntry.ACLReplicationEntry(bool enabled, bool running, string sourceDatacenter, string replicationType, ulong replicatedIndex, ulong replicatedRoleIndex, ulong replicatedTokenIndex, System.DateTime lastSuccess, System.DateTime lastError) -> void
+Consul.ACLReplicationEntry.ReplicationType.get -> string
+Consul.ACLReplicationEntry.ReplicationType.set -> void
+Consul.ACLReplicationEntry.SourceDatacenter.get -> string
+Consul.ACLReplicationEntry.SourceDatacenter.set -> void
+Consul.ACLTemplatedPolicyVariables.Name.get -> string
+Consul.ACLTemplatedPolicyVariables.Name.set -> void
+Consul.ACLType.Equals(Consul.ACLType other) -> bool
+Consul.ACLType.Type.get -> string
+Consul.AddressDetails.Address.get -> string
+Consul.AddressDetails.Address.set -> void
+Consul.Agent.CheckDeregister(string checkID, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.CheckRegister(Consul.AgentCheckRegistration check, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.Checks() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentCheck>>>
+Consul.Agent.Checks(Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentCheck>>>
+Consul.Agent.Checks(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentCheck>>>
+Consul.Agent.ConnectAuthorize(Consul.AgentAuthorizeParameters parameters) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AgentAuthorizeResponse>>
+Consul.Agent.ConnectAuthorize(Consul.AgentAuthorizeParameters parameters, Consul.WriteOptions w, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AgentAuthorizeResponse>>
+Consul.Agent.ConnectAuthorize(Consul.AgentAuthorizeParameters parameters, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AgentAuthorizeResponse>>
+Consul.Agent.DisableNodeMaintenance(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.DisableServiceMaintenance(string serviceID, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.EnableNodeMaintenance(string reason, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.EnableServiceMaintenance(string serviceID, string reason, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.FailTTL(string checkID, string note, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.Agent.ForceLeave(string node, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.GetAgentHostInfo(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AgentHostInfo>>
+Consul.Agent.GetAgentMetrics(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Metrics>>
+Consul.Agent.GetAgentVersion(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AgentVersion>>
+Consul.Agent.GetCALeaf(string serviceId) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CALeaf>>
+Consul.Agent.GetCALeaf(string serviceId, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CALeaf>>
+Consul.Agent.GetCALeaf(string serviceId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CALeaf>>
+Consul.Agent.GetCARoots() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
+Consul.Agent.GetCARoots(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
+Consul.Agent.GetCARoots(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
+Consul.Agent.GetLocalServiceHealth(string serviceName) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth[]>>
+Consul.Agent.GetLocalServiceHealth(string serviceName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth[]>>
+Consul.Agent.GetLocalServiceHealth(string serviceName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth[]>>
+Consul.Agent.GetLocalServiceHealthByID(string serviceID) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth>>
+Consul.Agent.GetLocalServiceHealthByID(string serviceID, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth>>
+Consul.Agent.GetLocalServiceHealthByID(string serviceID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth>>
+Consul.Agent.GetNodeName(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
+Consul.Agent.GetServiceConfiguration(string serviceId) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceConfiguration>>
+Consul.Agent.GetServiceConfiguration(string serviceId, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceConfiguration>>
+Consul.Agent.GetServiceConfiguration(string serviceId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceConfiguration>>
+Consul.Agent.GetWorstLocalServiceHealth(string serviceName) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
+Consul.Agent.GetWorstLocalServiceHealth(string serviceName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
+Consul.Agent.GetWorstLocalServiceHealth(string serviceName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
+Consul.Agent.Join(string addr, bool wan, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.Leave(string node, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.LogStream.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Threading.Tasks.Task<string>>
+Consul.Agent.Members(bool wan, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AgentMember[]>>
+Consul.Agent.Monitor(Consul.LogLevel level = Consul.LogLevel.Info, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.Agent.LogStream>
+Consul.Agent.MonitorJSON(Consul.LogLevel level = Consul.LogLevel.Info, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.Agent.LogStream>
+Consul.Agent.NodeName.get -> string
+Consul.Agent.PassTTL(string checkID, string note, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.Agent.Reload() -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.Reload(string node, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.Reload(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.Self(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, dynamic>>>>
+Consul.Agent.ServiceDeregister(string serviceID, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.ServiceRegister(Consul.AgentServiceRegistration service) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.ServiceRegister(Consul.AgentServiceRegistration service, bool replaceExistingChecks, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.ServiceRegister(Consul.AgentServiceRegistration service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.Services() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentService>>>
+Consul.Agent.Services(Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentService>>>
+Consul.Agent.Services(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentService>>>
+Consul.Agent.UpdateTTL(string checkID, string output, Consul.TTLStatus status, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Agent.WarnTTL(string checkID, string note, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.AgentAuthorizeParameters.ClientCertSerial.get -> string
+Consul.AgentAuthorizeParameters.ClientCertSerial.set -> void
+Consul.AgentAuthorizeParameters.ClientCertURI.get -> string
+Consul.AgentAuthorizeParameters.ClientCertURI.set -> void
+Consul.AgentAuthorizeParameters.Target.get -> string
+Consul.AgentAuthorizeParameters.Target.set -> void
+Consul.AgentAuthorizeResponse.Reason.get -> string
+Consul.AgentAuthorizeResponse.Reason.set -> void
+Consul.AgentCheck.CheckID.get -> string
+Consul.AgentCheck.CheckID.set -> void
+Consul.AgentCheck.Name.get -> string
+Consul.AgentCheck.Name.set -> void
+Consul.AgentCheck.Node.get -> string
+Consul.AgentCheck.Node.set -> void
+Consul.AgentCheck.Notes.get -> string
+Consul.AgentCheck.Notes.set -> void
+Consul.AgentCheck.Output.get -> string
+Consul.AgentCheck.Output.set -> void
+Consul.AgentCheck.ServiceID.get -> string
+Consul.AgentCheck.ServiceID.set -> void
+Consul.AgentCheck.ServiceName.get -> string
+Consul.AgentCheck.ServiceName.set -> void
+Consul.AgentCheck.Status.get -> Consul.HealthStatus
+Consul.AgentCheck.Status.set -> void
+Consul.AgentCheck.Type.get -> string
+Consul.AgentCheck.Type.set -> void
+Consul.AgentCheckRegistration.ServiceID.get -> string
+Consul.AgentCheckRegistration.ServiceID.set -> void
+Consul.AgentHostInfo.CPU.get -> System.Collections.Generic.List<Consul.CPUInfo>
+Consul.AgentHostInfo.CPU.set -> void
+Consul.AgentHostInfo.Disk.get -> Consul.DiskInfo
+Consul.AgentHostInfo.Disk.set -> void
+Consul.AgentHostInfo.Host.get -> Consul.HostInfo
+Consul.AgentHostInfo.Host.set -> void
+Consul.AgentHostInfo.Memory.get -> Consul.MemoryInfo
+Consul.AgentHostInfo.Memory.set -> void
+Consul.AgentMember.Addr.get -> string
+Consul.AgentMember.Addr.set -> void
+Consul.AgentMember.Name.get -> string
+Consul.AgentMember.Name.set -> void
+Consul.AgentMember.Tags.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.AgentMember.Tags.set -> void
+Consul.AgentService.Address.get -> string
+Consul.AgentService.Address.set -> void
+Consul.AgentService.ID.get -> string
+Consul.AgentService.ID.set -> void
+Consul.AgentService.Kind.get -> Consul.ServiceKind
+Consul.AgentService.Kind.set -> void
+Consul.AgentService.Meta.get -> System.Collections.Generic.IDictionary<string, string>
+Consul.AgentService.Meta.set -> void
+Consul.AgentService.Proxy.get -> Consul.AgentServiceProxy
+Consul.AgentService.Proxy.set -> void
+Consul.AgentService.Service.get -> string
+Consul.AgentService.Service.set -> void
+Consul.AgentService.TaggedAddresses.get -> System.Collections.Generic.IDictionary<string, Consul.ServiceTaggedAddress>
+Consul.AgentService.TaggedAddresses.set -> void
+Consul.AgentService.Tags.get -> string[]
+Consul.AgentService.Tags.set -> void
+Consul.AgentServiceCheck.AliasNode.get -> string
+Consul.AgentServiceCheck.AliasNode.set -> void
+Consul.AgentServiceCheck.AliasService.get -> string
+Consul.AgentServiceCheck.AliasService.set -> void
+Consul.AgentServiceCheck.Args.get -> string[]
+Consul.AgentServiceCheck.Args.set -> void
+Consul.AgentServiceCheck.Body.get -> string
+Consul.AgentServiceCheck.Body.set -> void
+Consul.AgentServiceCheck.CheckID.get -> string
+Consul.AgentServiceCheck.CheckID.set -> void
+Consul.AgentServiceCheck.DockerContainerID.get -> string
+Consul.AgentServiceCheck.DockerContainerID.set -> void
+Consul.AgentServiceCheck.GRPC.get -> string
+Consul.AgentServiceCheck.GRPC.set -> void
+Consul.AgentServiceCheck.Header.get -> System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>>
+Consul.AgentServiceCheck.Header.set -> void
+Consul.AgentServiceCheck.HTTP.get -> string
+Consul.AgentServiceCheck.HTTP.set -> void
+Consul.AgentServiceCheck.ID.get -> string
+Consul.AgentServiceCheck.ID.set -> void
+Consul.AgentServiceCheck.Method.get -> string
+Consul.AgentServiceCheck.Method.set -> void
+Consul.AgentServiceCheck.Name.get -> string
+Consul.AgentServiceCheck.Name.set -> void
+Consul.AgentServiceCheck.Notes.get -> string
+Consul.AgentServiceCheck.Notes.set -> void
+Consul.AgentServiceCheck.Script.get -> string
+Consul.AgentServiceCheck.Script.set -> void
+Consul.AgentServiceCheck.Shell.get -> string
+Consul.AgentServiceCheck.Shell.set -> void
+Consul.AgentServiceCheck.Status.get -> Consul.HealthStatus
+Consul.AgentServiceCheck.Status.set -> void
+Consul.AgentServiceCheck.TCP.get -> string
+Consul.AgentServiceCheck.TCP.set -> void
+Consul.AgentServiceConnect.SidecarService.get -> Consul.AgentServiceRegistration
+Consul.AgentServiceConnect.SidecarService.set -> void
+Consul.AgentServiceProxy.DestinationServiceID.get -> string
+Consul.AgentServiceProxy.DestinationServiceID.set -> void
+Consul.AgentServiceProxy.DestinationServiceName.get -> string
+Consul.AgentServiceProxy.DestinationServiceName.set -> void
+Consul.AgentServiceProxy.LocalServiceAddress.get -> string
+Consul.AgentServiceProxy.LocalServiceAddress.set -> void
+Consul.AgentServiceProxy.Upstreams.get -> Consul.AgentServiceProxyUpstream[]
+Consul.AgentServiceProxy.Upstreams.set -> void
+Consul.AgentServiceProxyUpstream.DestinationName.get -> string
+Consul.AgentServiceProxyUpstream.DestinationName.set -> void
+Consul.AgentServiceRegistration.Address.get -> string
+Consul.AgentServiceRegistration.Address.set -> void
+Consul.AgentServiceRegistration.Check.get -> Consul.AgentServiceCheck
+Consul.AgentServiceRegistration.Check.set -> void
+Consul.AgentServiceRegistration.Checks.get -> Consul.AgentServiceCheck[]
+Consul.AgentServiceRegistration.Checks.set -> void
+Consul.AgentServiceRegistration.Connect.get -> Consul.AgentServiceConnect
+Consul.AgentServiceRegistration.Connect.set -> void
+Consul.AgentServiceRegistration.ID.get -> string
+Consul.AgentServiceRegistration.ID.set -> void
+Consul.AgentServiceRegistration.Kind.get -> Consul.ServiceKind
+Consul.AgentServiceRegistration.Kind.set -> void
+Consul.AgentServiceRegistration.Meta.get -> System.Collections.Generic.IDictionary<string, string>
+Consul.AgentServiceRegistration.Meta.set -> void
+Consul.AgentServiceRegistration.Name.get -> string
+Consul.AgentServiceRegistration.Name.set -> void
+Consul.AgentServiceRegistration.Proxy.get -> Consul.AgentServiceProxy
+Consul.AgentServiceRegistration.Proxy.set -> void
+Consul.AgentServiceRegistration.TaggedAddresses.get -> System.Collections.Generic.IDictionary<string, Consul.ServiceTaggedAddress>
+Consul.AgentServiceRegistration.TaggedAddresses.set -> void
+Consul.AgentServiceRegistration.Tags.get -> string[]
+Consul.AgentServiceRegistration.Tags.set -> void
+Consul.AgentVersion.FIPS.get -> string
+Consul.AgentVersion.FIPS.set -> void
+Consul.AgentVersion.HumanVersion.get -> string
+Consul.AgentVersion.HumanVersion.set -> void
+Consul.AgentVersion.SHA.get -> string
+Consul.AgentVersion.SHA.set -> void
+Consul.ApiGatewayCertificate.Kind.get -> string
+Consul.ApiGatewayCertificate.Kind.set -> void
+Consul.ApiGatewayCertificate.Name.get -> string
+Consul.ApiGatewayCertificate.Name.set -> void
+Consul.ApiGatewayCertificate.Namespace.get -> string
+Consul.ApiGatewayCertificate.Namespace.set -> void
+Consul.ApiGatewayCertificate.Partition.get -> string
+Consul.ApiGatewayCertificate.Partition.set -> void
+Consul.ApiGatewayEntry.Kind.get -> string
+Consul.ApiGatewayEntry.Kind.set -> void
+Consul.ApiGatewayEntry.Listeners.get -> System.Collections.Generic.List<Consul.ApiGatewayListener>
+Consul.ApiGatewayEntry.Listeners.set -> void
+Consul.ApiGatewayEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ApiGatewayEntry.Meta.set -> void
+Consul.ApiGatewayEntry.Name.get -> string
+Consul.ApiGatewayEntry.Name.set -> void
+Consul.ApiGatewayEntry.Namespace.get -> string
+Consul.ApiGatewayEntry.Namespace.set -> void
+Consul.ApiGatewayEntry.Partition.get -> string
+Consul.ApiGatewayEntry.Partition.set -> void
+Consul.ApiGatewayJWTProvider.Name.get -> string
+Consul.ApiGatewayJWTProvider.Name.set -> void
+Consul.ApiGatewayJWTProvider.VerifyClaims.get -> Consul.ApiGatewayVerifyClaims
+Consul.ApiGatewayJWTProvider.VerifyClaims.set -> void
+Consul.ApiGatewayJWTSettings.Providers.get -> System.Collections.Generic.List<Consul.ApiGatewayJWTProvider>
+Consul.ApiGatewayJWTSettings.Providers.set -> void
+Consul.ApiGatewayListener.Default.get -> Consul.ApiGatewayOverrideSettings
+Consul.ApiGatewayListener.Default.set -> void
+Consul.ApiGatewayListener.Name.get -> string
+Consul.ApiGatewayListener.Name.set -> void
+Consul.ApiGatewayListener.Override.get -> Consul.ApiGatewayOverrideSettings
+Consul.ApiGatewayListener.Override.set -> void
+Consul.ApiGatewayListener.Protocol.get -> string
+Consul.ApiGatewayListener.Protocol.set -> void
+Consul.ApiGatewayListener.TLS.get -> Consul.ApiGatewayTLS
+Consul.ApiGatewayListener.TLS.set -> void
+Consul.ApiGatewayOverrideSettings.JWT.get -> Consul.ApiGatewayJWTSettings
+Consul.ApiGatewayOverrideSettings.JWT.set -> void
+Consul.ApiGatewayReference.Kind.get -> string
+Consul.ApiGatewayReference.Kind.set -> void
+Consul.ApiGatewayReference.Name.get -> string
+Consul.ApiGatewayReference.Name.set -> void
+Consul.ApiGatewayReference.Namespace.get -> string
+Consul.ApiGatewayReference.Namespace.set -> void
+Consul.ApiGatewayReference.Partition.get -> string
+Consul.ApiGatewayReference.Partition.set -> void
+Consul.ApiGatewayReference.SectionName.get -> string
+Consul.ApiGatewayReference.SectionName.set -> void
+Consul.ApiGatewayTLS.Certificates.get -> System.Collections.Generic.List<Consul.ApiGatewayCertificate>
+Consul.ApiGatewayTLS.Certificates.set -> void
+Consul.ApiGatewayTLS.CipherSuites.get -> System.Collections.Generic.List<string>
+Consul.ApiGatewayTLS.CipherSuites.set -> void
+Consul.ApiGatewayTLS.MaxVersion.get -> string
+Consul.ApiGatewayTLS.MaxVersion.set -> void
+Consul.ApiGatewayTLS.MinVersion.get -> string
+Consul.ApiGatewayTLS.MinVersion.set -> void
+Consul.ApiGatewayVerifyClaims.Path.get -> System.Collections.Generic.List<string>
+Consul.ApiGatewayVerifyClaims.Path.set -> void
+Consul.ApiGatewayVerifyClaims.Value.get -> string
+Consul.ApiGatewayVerifyClaims.Value.set -> void
+Consul.Area.ID.get -> string
+Consul.Area.ID.set -> void
+Consul.AreaRequest.PeerDatacenter.get -> string
+Consul.AreaRequest.PeerDatacenter.set -> void
+Consul.AreaRequest.RetryJoin.get -> string[]
+Consul.AreaRequest.RetryJoin.set -> void
+Consul.AuthMethod.Create(Consul.AuthMethodEntry authMethod) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
+Consul.AuthMethod.Create(Consul.AuthMethodEntry authMethod, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
+Consul.AuthMethod.Create(Consul.AuthMethodEntry authMethod, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
+Consul.AuthMethod.Delete(string name) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.AuthMethod.Delete(string name, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.AuthMethod.Delete(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.AuthMethod.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry[]>>
+Consul.AuthMethod.List(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry[]>>
+Consul.AuthMethod.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry[]>>
+Consul.AuthMethod.Login() -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.AuthMethod.Login(Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.AuthMethod.Login(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.AuthMethod.Logout() -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.AuthMethod.Logout(Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.AuthMethod.Logout(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.AuthMethod.Read(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry>>
+Consul.AuthMethod.Read(string name, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry>>
+Consul.AuthMethod.Read(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry>>
+Consul.AuthMethod.Update(Consul.AuthMethodEntry authMethod) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
+Consul.AuthMethod.Update(Consul.AuthMethodEntry authMethod, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
+Consul.AuthMethod.Update(Consul.AuthMethodEntry authMethod, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
+Consul.AuthMethodEntry.AuthMethodEntry(string name, string type, string description, System.Collections.Generic.Dictionary<string, string> config) -> void
+Consul.AuthMethodEntry.AuthMethodEntry(string name, string type, System.Collections.Generic.Dictionary<string, string> config) -> void
+Consul.AuthMethodEntry.Config.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.AuthMethodEntry.Config.set -> void
+Consul.AuthMethodEntry.Description.get -> string
+Consul.AuthMethodEntry.Description.set -> void
+Consul.AuthMethodEntry.Name.get -> string
+Consul.AuthMethodEntry.Name.set -> void
+Consul.AuthMethodEntry.Type.get -> string
+Consul.AuthMethodEntry.Type.set -> void
+Consul.AutopilotConfiguration.LastContactThreshold.get -> string
+Consul.AutopilotConfiguration.LastContactThreshold.set -> void
+Consul.AutopilotConfiguration.RedundancyZoneTag.get -> string
+Consul.AutopilotConfiguration.RedundancyZoneTag.set -> void
+Consul.AutopilotConfiguration.ServerStabilizationTime.get -> string
+Consul.AutopilotConfiguration.ServerStabilizationTime.set -> void
+Consul.AutopilotConfiguration.UpgradeVersionTag.get -> string
+Consul.AutopilotConfiguration.UpgradeVersionTag.set -> void
+Consul.AutopilotHealth.Servers.get -> System.Collections.Generic.List<Consul.AutopilotServerHealth>
+Consul.AutopilotHealth.Servers.set -> void
+Consul.AutopilotServerHealth.Address.get -> string
+Consul.AutopilotServerHealth.Address.set -> void
+Consul.AutopilotServerHealth.ID.get -> string
+Consul.AutopilotServerHealth.ID.set -> void
+Consul.AutopilotServerHealth.LastContact.get -> string
+Consul.AutopilotServerHealth.LastContact.set -> void
+Consul.AutopilotServerHealth.Name.get -> string
+Consul.AutopilotServerHealth.Name.set -> void
+Consul.AutopilotServerHealth.SerfStatus.get -> string
+Consul.AutopilotServerHealth.SerfStatus.set -> void
+Consul.AutopilotServerHealth.Version.get -> string
+Consul.AutopilotServerHealth.Version.set -> void
+Consul.AutopilotServerState.Address.get -> string
+Consul.AutopilotServerState.Address.set -> void
+Consul.AutopilotServerState.ID.get -> string
+Consul.AutopilotServerState.ID.set -> void
+Consul.AutopilotServerState.LastContact.get -> string
+Consul.AutopilotServerState.LastContact.set -> void
+Consul.AutopilotServerState.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.AutopilotServerState.Meta.set -> void
+Consul.AutopilotServerState.Name.get -> string
+Consul.AutopilotServerState.Name.set -> void
+Consul.AutopilotServerState.NodeStatus.get -> string
+Consul.AutopilotServerState.NodeStatus.set -> void
+Consul.AutopilotServerState.NodeType.get -> string
+Consul.AutopilotServerState.NodeType.set -> void
+Consul.AutopilotServerState.RedundancyZone.get -> string
+Consul.AutopilotServerState.RedundancyZone.set -> void
+Consul.AutopilotServerState.Status.get -> string
+Consul.AutopilotServerState.Status.set -> void
+Consul.AutopilotServerState.UpgradeVersion.get -> string
+Consul.AutopilotServerState.UpgradeVersion.set -> void
+Consul.AutopilotServerState.Version.get -> string
+Consul.AutopilotServerState.Version.set -> void
+Consul.AutopilotState.Leader.get -> string
+Consul.AutopilotState.Leader.set -> void
+Consul.AutopilotState.ReadReplicas.get -> System.Collections.Generic.List<string>
+Consul.AutopilotState.ReadReplicas.set -> void
+Consul.AutopilotState.RedundancyZones.get -> System.Collections.Generic.Dictionary<string, object>
+Consul.AutopilotState.RedundancyZones.set -> void
+Consul.AutopilotState.Servers.get -> System.Collections.Generic.Dictionary<string, Consul.AutopilotServerState>
+Consul.AutopilotState.Servers.set -> void
+Consul.AutopilotState.Upgrade.get -> object
+Consul.AutopilotState.Upgrade.set -> void
+Consul.AutopilotState.Voters.get -> System.Collections.Generic.List<string>
+Consul.AutopilotState.Voters.set -> void
+Consul.BindingRule.Create(Consul.ACLBindingRule entry) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
+Consul.BindingRule.Create(Consul.ACLBindingRule entry, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
+Consul.BindingRule.Create(Consul.ACLBindingRule entry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
+Consul.BindingRule.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.BindingRule.Delete(string id, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.BindingRule.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.BindingRule.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse[]>>
+Consul.BindingRule.List(Consul.QueryOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse[]>>
+Consul.BindingRule.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse[]>>
+Consul.BindingRule.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse>>
+Consul.BindingRule.Read(string id, Consul.QueryOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse>>
+Consul.BindingRule.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse>>
+Consul.BindingRule.Update(Consul.ACLBindingRule entry) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
+Consul.BindingRule.Update(Consul.ACLBindingRule entry, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
+Consul.BindingRule.Update(Consul.ACLBindingRule entry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
+Consul.CaCertificateProviderInstanceConfig.CertificateName.get -> string
+Consul.CaCertificateProviderInstanceConfig.CertificateName.set -> void
+Consul.CaCertificateProviderInstanceConfig.InstanceName.get -> string
+Consul.CaCertificateProviderInstanceConfig.InstanceName.set -> void
+Consul.CacheConfig.Size.get -> string
+Consul.CacheConfig.Size.set -> void
+Consul.CAConfig.Config.get -> System.Collections.Generic.Dictionary<string, object>
+Consul.CAConfig.Config.set -> void
+Consul.CAConfig.Provider.get -> string
+Consul.CAConfig.Provider.set -> void
+Consul.CAConfig.State.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.CAConfig.State.set -> void
+Consul.CALeaf.CertPEM.get -> string
+Consul.CALeaf.CertPEM.set -> void
+Consul.CALeaf.PrivateKeyPEM.get -> string
+Consul.CALeaf.PrivateKeyPEM.set -> void
+Consul.CALeaf.SerialNumber.get -> string
+Consul.CALeaf.SerialNumber.set -> void
+Consul.CALeaf.Service.get -> string
+Consul.CALeaf.Service.set -> void
+Consul.CALeaf.ServiceURI.get -> string
+Consul.CALeaf.ServiceURI.set -> void
+Consul.CARoots.ActiveRootID.get -> string
+Consul.CARoots.ActiveRootID.set -> void
+Consul.CARoots.Roots.get -> System.Collections.Generic.List<Consul.Root>
+Consul.CARoots.Roots.set -> void
+Consul.CARoots.TrustDomain.get -> string
+Consul.CARoots.TrustDomain.set -> void
+Consul.Catalog.Datacenters() -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.Catalog.Datacenters(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.Catalog.Datacenters(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.Catalog.Deregister(Consul.CatalogDeregistration reg) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Catalog.Deregister(Consul.CatalogDeregistration reg, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Catalog.Deregister(Consul.CatalogDeregistration reg, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Catalog.GatewayService(string gateway) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.GatewayService[]>>
+Consul.Catalog.GatewayService(string gateway, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.GatewayService[]>>
+Consul.Catalog.GatewayService(string gateway, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.GatewayService[]>>
+Consul.Catalog.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogNode>>
+Consul.Catalog.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogNode>>
+Consul.Catalog.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogNode>>
+Consul.Catalog.Nodes() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Node[]>>
+Consul.Catalog.Nodes(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Node[]>>
+Consul.Catalog.Nodes(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Node[]>>
+Consul.Catalog.NodesForMeshCapableService(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.Catalog.NodesForMeshCapableService(string service, Consul.Filtering.Filter filter) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.Catalog.NodesForMeshCapableService(string service, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.Catalog.NodesForMeshCapableService(string service, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.Catalog.NodesForMeshCapableService(string service, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.Catalog.NodesForMeshCapableService(string service, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.Catalog.NodesForMeshCapableService(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.Catalog.Register(Consul.CatalogRegistration reg) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Catalog.Register(Consul.CatalogRegistration reg, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Catalog.Register(Consul.CatalogRegistration reg, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Catalog.Service(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.Catalog.Service(string service, string tag) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.Catalog.Service(string service, string tag, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.Catalog.Service(string service, string tag, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.Catalog.Service(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.Catalog.Services() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.Catalog.Services(Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.Catalog.Services(Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.Catalog.Services(string dc, Consul.Filtering.Filter filter) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.Catalog.Services(string dc, Consul.Filtering.Filter filter, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.Catalog.Services(string dc, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.Catalog.Services(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.Catalog.ServicesForNode(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NodeService>>
+Consul.Catalog.ServicesForNode(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NodeService>>
+Consul.Catalog.ServicesForNode(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NodeService>>
+Consul.CatalogDeregistration.Address.get -> string
+Consul.CatalogDeregistration.Address.set -> void
+Consul.CatalogDeregistration.CheckID.get -> string
+Consul.CatalogDeregistration.CheckID.set -> void
+Consul.CatalogDeregistration.Datacenter.get -> string
+Consul.CatalogDeregistration.Datacenter.set -> void
+Consul.CatalogDeregistration.Node.get -> string
+Consul.CatalogDeregistration.Node.set -> void
+Consul.CatalogDeregistration.ServiceID.get -> string
+Consul.CatalogDeregistration.ServiceID.set -> void
+Consul.CatalogNode.Node.get -> Consul.Node
+Consul.CatalogNode.Node.set -> void
+Consul.CatalogNode.Services.get -> System.Collections.Generic.Dictionary<string, Consul.AgentService>
+Consul.CatalogNode.Services.set -> void
+Consul.CatalogRegistration.Address.get -> string
+Consul.CatalogRegistration.Address.set -> void
+Consul.CatalogRegistration.Check.get -> Consul.AgentCheck
+Consul.CatalogRegistration.Check.set -> void
+Consul.CatalogRegistration.Datacenter.get -> string
+Consul.CatalogRegistration.Datacenter.set -> void
+Consul.CatalogRegistration.Node.get -> string
+Consul.CatalogRegistration.Node.set -> void
+Consul.CatalogRegistration.Service.get -> Consul.AgentService
+Consul.CatalogRegistration.Service.set -> void
+Consul.CatalogService.Address.get -> string
+Consul.CatalogService.Address.set -> void
+Consul.CatalogService.Node.get -> string
+Consul.CatalogService.Node.set -> void
+Consul.CatalogService.ServiceAddress.get -> string
+Consul.CatalogService.ServiceAddress.set -> void
+Consul.CatalogService.ServiceID.get -> string
+Consul.CatalogService.ServiceID.set -> void
+Consul.CatalogService.ServiceMeta.get -> System.Collections.Generic.IDictionary<string, string>
+Consul.CatalogService.ServiceMeta.set -> void
+Consul.CatalogService.ServiceName.get -> string
+Consul.CatalogService.ServiceName.set -> void
+Consul.CatalogService.ServiceTaggedAddresses.get -> System.Collections.Generic.Dictionary<string, Consul.ServiceTaggedAddress>
+Consul.CatalogService.ServiceTaggedAddresses.set -> void
+Consul.CatalogService.ServiceTags.get -> string[]
+Consul.CatalogService.ServiceTags.set -> void
+Consul.ClusterPeering.DeletePeering(string name, Consul.WriteOptions options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ClusterPeering.DeletePeering(string name, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ClusterPeering.GenerateToken(Consul.ClusterPeeringTokenEntry tokenEntry) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ClusterPeeringTokenResponse>>
+Consul.ClusterPeering.GenerateToken(Consul.ClusterPeeringTokenEntry tokenEntry, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ClusterPeeringTokenResponse>>
+Consul.ClusterPeering.GenerateToken(Consul.ClusterPeeringTokenEntry tokenEntry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ClusterPeeringTokenResponse>>
+Consul.ClusterPeering.GetPeering(string name, Consul.QueryOptions options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus>>
+Consul.ClusterPeering.GetPeering(string name, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus>>
+Consul.ClusterPeering.ListPeerings() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus[]>>
+Consul.ClusterPeering.ListPeerings(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus[]>>
+Consul.ClusterPeering.ListPeerings(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus[]>>
+Consul.ClusterPeeringStatus.ID.get -> string
+Consul.ClusterPeeringStatus.ID.set -> void
+Consul.ClusterPeeringStatus.Name.get -> string
+Consul.ClusterPeeringStatus.Name.set -> void
+Consul.ClusterPeeringStatus.PeerID.get -> string
+Consul.ClusterPeeringStatus.PeerID.set -> void
+Consul.ClusterPeeringStatus.PeerServerAddresses.get -> string[]
+Consul.ClusterPeeringStatus.PeerServerAddresses.set -> void
+Consul.ClusterPeeringStatus.PeerServerName.get -> string
+Consul.ClusterPeeringStatus.PeerServerName.set -> void
+Consul.ClusterPeeringStatus.Remote.get -> Consul.PeeringRemoteInfo
+Consul.ClusterPeeringStatus.Remote.set -> void
+Consul.ClusterPeeringStatus.State.get -> string
+Consul.ClusterPeeringStatus.State.set -> void
+Consul.ClusterPeeringStatus.StreamStatus.get -> Consul.PeeringStreamStatus
+Consul.ClusterPeeringStatus.StreamStatus.set -> void
+Consul.ClusterPeeringTokenEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ClusterPeeringTokenEntry.Meta.set -> void
+Consul.ClusterPeeringTokenEntry.PeerName.get -> string
+Consul.ClusterPeeringTokenEntry.PeerName.set -> void
+Consul.ClusterPeeringTokenResponse.PeeringToken.get -> string
+Consul.ClusterPeeringTokenResponse.PeeringToken.set -> void
+Consul.CompiledDiscoveryChain.CustomizationHash.get -> string
+Consul.CompiledDiscoveryChain.CustomizationHash.set -> void
+Consul.CompiledDiscoveryChain.Datacenter.get -> string
+Consul.CompiledDiscoveryChain.Datacenter.set -> void
+Consul.CompiledDiscoveryChain.Namespace.get -> string
+Consul.CompiledDiscoveryChain.Namespace.set -> void
+Consul.CompiledDiscoveryChain.Nodes.get -> System.Collections.Generic.Dictionary<string, Consul.DiscoveryGraphNode>
+Consul.CompiledDiscoveryChain.Nodes.set -> void
+Consul.CompiledDiscoveryChain.Protocol.get -> string
+Consul.CompiledDiscoveryChain.Protocol.set -> void
+Consul.CompiledDiscoveryChain.ServiceName.get -> string
+Consul.CompiledDiscoveryChain.ServiceName.set -> void
+Consul.CompiledDiscoveryChain.StartNode.get -> string
+Consul.CompiledDiscoveryChain.StartNode.set -> void
+Consul.CompiledDiscoveryChain.Targets.get -> System.Collections.Generic.Dictionary<string, Consul.DiscoveryTarget>
+Consul.CompiledDiscoveryChain.Targets.set -> void
+Consul.CompoundServiceName.Name.get -> string
+Consul.CompoundServiceName.Name.set -> void
+Consul.CompoundServiceName.Namespace.get -> string
+Consul.CompoundServiceName.Namespace.set -> void
+Consul.CompoundServiceName.Partition.get -> string
+Consul.CompoundServiceName.Partition.set -> void
+Consul.Configuration.ApplyConfig<TConfig>(Consul.WriteOptions q, TConfig configurationEntry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Configuration.ApplyConfig<TConfig>(TConfig configurationEntry) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Configuration.ApplyConfig<TConfig>(TConfig configurationEntry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Configuration.DeleteConfig(string kind, string name) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Configuration.DeleteConfig(string kind, string name, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Configuration.DeleteConfig(string kind, string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Configuration.GetConfig<TConfig>(string kind, string name) -> System.Threading.Tasks.Task<Consul.QueryResult<TConfig>>
+Consul.Configuration.GetConfig<TConfig>(string kind, string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<TConfig>>
+Consul.Configuration.GetConfig<TConfig>(string kind, string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<TConfig>>
+Consul.Configuration.ListConfig<TConfig>(string kind) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<TConfig>>>
+Consul.Configuration.ListConfig<TConfig>(string kind, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<TConfig>>>
+Consul.Configuration.ListConfig<TConfig>(string kind, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<TConfig>>>
+Consul.Connect.CAGetConfig() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CAConfig>>
+Consul.Connect.CAGetConfig(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CAConfig>>
+Consul.Connect.CAGetConfig(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CAConfig>>
+Consul.Connect.CARoots() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
+Consul.Connect.CARoots(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
+Consul.Connect.CARoots(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
+Consul.Connect.CASetConfig(Consul.CAConfig config) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Connect.CASetConfig(Consul.CAConfig config, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Connect.CASetConfig(Consul.CAConfig config, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Connect.CheckIntentionResult(string source, string destination) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceIntentionResultResponse>>
+Consul.Connect.CheckIntentionResult(string source, string destination, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceIntentionResultResponse>>
+Consul.Connect.CheckIntentionResult(string source, string destination, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceIntentionResultResponse>>
+Consul.Connect.DeleteIntentionByName(string source, string destination) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Connect.DeleteIntentionByName(string source, string destination, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Connect.DeleteIntentionByName(string source, string destination, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Connect.ListIntentions<ServiceIntention>() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<ServiceIntention>>>
+Consul.Connect.ListIntentions<ServiceIntention>(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<ServiceIntention>>>
+Consul.Connect.ListIntentions<ServiceIntention>(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<ServiceIntention>>>
+Consul.Connect.ListMatchingIntentions(string by, string name) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Consul.ServiceIntention>>>>
+Consul.Connect.ListMatchingIntentions(string by, string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Consul.ServiceIntention>>>>
+Consul.Connect.ListMatchingIntentions(string by, string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Consul.ServiceIntention>>>>
+Consul.Connect.ReadSpecificIntentionByName<ServiceIntention>(string source, string destination) -> System.Threading.Tasks.Task<Consul.QueryResult<ServiceIntention>>
+Consul.Connect.ReadSpecificIntentionByName<ServiceIntention>(string source, string destination, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<ServiceIntention>>
+Consul.Connect.ReadSpecificIntentionByName<ServiceIntention>(string source, string destination, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<ServiceIntention>>
+Consul.Connect.UpsertIntentionsByName(Consul.ServiceIntention intention) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Connect.UpsertIntentionsByName(Consul.ServiceIntention intention, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Connect.UpsertIntentionsByName(Consul.ServiceIntention intention, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.ConsulClient.ACL.get -> Consul.IACLEndpoint
+Consul.ConsulClient.ACLReplication.get -> Consul.IACLReplicationEndpoint
+Consul.ConsulClient.AcquireLock(Consul.LockOptions opts) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
+Consul.ConsulClient.AcquireLock(Consul.LockOptions opts, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
+Consul.ConsulClient.AcquireLock(string key) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
+Consul.ConsulClient.AcquireLock(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
+Consul.ConsulClient.AcquireSemaphore(Consul.SemaphoreOptions opts) -> System.Threading.Tasks.Task<Consul.IDistributedSemaphore>
+Consul.ConsulClient.AcquireSemaphore(Consul.SemaphoreOptions opts, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.IDistributedSemaphore>
+Consul.ConsulClient.AcquireSemaphore(string prefix, int limit, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.IDistributedSemaphore>
+Consul.ConsulClient.Agent.get -> Consul.IAgentEndpoint
+Consul.ConsulClient.AuthMethod.get -> Consul.IAuthMethodEndpoint
+Consul.ConsulClient.BindingRule.get -> Consul.Interfaces.IBindingRuleEndpoint
+Consul.ConsulClient.Catalog.get -> Consul.ICatalogEndpoint
+Consul.ConsulClient.ClusterPeering.get -> Consul.Interfaces.IClusterPeeringEndpoint
+Consul.ConsulClient.Config.get -> Consul.ConsulClientConfiguration
+Consul.ConsulClient.Configuration.get -> Consul.Interfaces.IConfigurationEndpoint
+Consul.ConsulClient.Connect.get -> Consul.Interfaces.IConnectEndpoint
+Consul.ConsulClient.ConsulClient(Consul.ConsulClientConfiguration config) -> void
+Consul.ConsulClient.ConsulClient(Consul.ConsulClientConfiguration config, System.Net.Http.HttpClient client) -> void
+Consul.ConsulClient.ConsulClient(System.Action<Consul.ConsulClientConfiguration> configOverride) -> void
+Consul.ConsulClient.ConsulClient(System.Action<Consul.ConsulClientConfiguration> configOverride, System.Action<System.Net.Http.HttpClient> clientOverride) -> void
+Consul.ConsulClient.Coordinate.get -> Consul.ICoordinateEndpoint
+Consul.ConsulClient.CreateLock(Consul.LockOptions opts) -> Consul.IDistributedLock
+Consul.ConsulClient.CreateLock(string key) -> Consul.IDistributedLock
+Consul.ConsulClient.DiscoveryChain.get -> Consul.Interfaces.IDiscoveryChainEndpoint
+Consul.ConsulClient.Event.get -> Consul.IEventEndpoint
+Consul.ConsulClient.ExecuteInSemaphore(Consul.SemaphoreOptions opts, System.Action a) -> System.Threading.Tasks.Task
+Consul.ConsulClient.ExecuteInSemaphore(Consul.SemaphoreOptions opts, System.Action a, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
+Consul.ConsulClient.ExecuteInSemaphore(string prefix, int limit, System.Action a, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.ConsulClient.ExecuteLocked(Consul.LockOptions opts, System.Action action) -> System.Threading.Tasks.Task
+Consul.ConsulClient.ExecuteLocked(Consul.LockOptions opts, System.Action action, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
+Consul.ConsulClient.ExecuteLocked(Consul.LockOptions opts, System.Threading.CancellationToken ct, System.Action action) -> System.Threading.Tasks.Task
+Consul.ConsulClient.ExecuteLocked(string key, System.Action action) -> System.Threading.Tasks.Task
+Consul.ConsulClient.ExecuteLocked(string key, System.Action action, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
+Consul.ConsulClient.ExecuteLocked(string key, System.Threading.CancellationToken ct, System.Action action) -> System.Threading.Tasks.Task
+Consul.ConsulClient.ExportedServices.get -> Consul.Interfaces.IExportedServicesEndpoint
+Consul.ConsulClient.Health.get -> Consul.IHealthEndpoint
+Consul.ConsulClient.KV.get -> Consul.IKVEndpoint
+Consul.ConsulClient.Namespaces.get -> Consul.INamespacesEndpoint
+Consul.ConsulClient.Operator.get -> Consul.IOperatorEndpoint
+Consul.ConsulClient.Policy.get -> Consul.IPolicyEndpoint
+Consul.ConsulClient.PreparedQuery.get -> Consul.IPreparedQueryEndpoint
+Consul.ConsulClient.Raw.get -> Consul.IRawEndpoint
+Consul.ConsulClient.Role.get -> Consul.IRoleEndpoint
+Consul.ConsulClient.Semaphore(Consul.SemaphoreOptions opts) -> Consul.IDistributedSemaphore
+Consul.ConsulClient.Semaphore(string prefix, int limit) -> Consul.IDistributedSemaphore
+Consul.ConsulClient.Session.get -> Consul.ISessionEndpoint
+Consul.ConsulClient.Snapshot.get -> Consul.ISnapshotEndpoint
+Consul.ConsulClient.Status.get -> Consul.IStatusEndpoint
+Consul.ConsulClient.Token.get -> Consul.ITokenEndpoint
+Consul.ConsulClientConfiguration.Address.get -> System.Uri
+Consul.ConsulClientConfiguration.Address.set -> void
+Consul.ConsulClientConfiguration.ClientCertificate.set -> void
+Consul.ConsulClientConfiguration.Datacenter.get -> string
+Consul.ConsulClientConfiguration.Datacenter.set -> void
+Consul.ConsulClientConfiguration.HttpAuth.set -> void
+Consul.ConsulClientConfiguration.Namespace.get -> string
+Consul.ConsulClientConfiguration.Namespace.set -> void
+Consul.ConsulClientConfiguration.Token.get -> string
+Consul.ConsulClientConfiguration.Token.set -> void
+Consul.ConsulConfigurationException.ConsulConfigurationException(string message) -> void
+Consul.ConsulConfigurationException.ConsulConfigurationException(string message, System.Exception inner) -> void
+Consul.ConsulLicense.License.get -> Consul.License
+Consul.ConsulLicense.License.set -> void
+Consul.ConsulLicense.Warnings.get -> string[]
+Consul.ConsulLicense.Warnings.set -> void
+Consul.ConsulRequestException.ConsulRequestException(string message, System.Net.HttpStatusCode statusCode) -> void
+Consul.ConsulRequestException.ConsulRequestException(string message, System.Net.HttpStatusCode statusCode, System.Exception inner) -> void
+Consul.ConsulResult.ConsulResult(Consul.ConsulResult other) -> void
+Consul.ConsumerDefinition.Partition.get -> string
+Consul.ConsumerDefinition.Partition.set -> void
+Consul.ConsumerDefinition.Peer.get -> string
+Consul.ConsumerDefinition.Peer.set -> void
+Consul.ConsumerDefinition.SamenessGroup.get -> string
+Consul.ConsumerDefinition.SamenessGroup.set -> void
+Consul.ControlPlaneRequestLimitEntry.ACL.get -> Consul.ACLRateLimit
+Consul.ControlPlaneRequestLimitEntry.ACL.set -> void
+Consul.ControlPlaneRequestLimitEntry.Catalog.get -> Consul.CatalogRateLimit
+Consul.ControlPlaneRequestLimitEntry.Catalog.set -> void
+Consul.ControlPlaneRequestLimitEntry.Kind.get -> string
+Consul.ControlPlaneRequestLimitEntry.Kind.set -> void
+Consul.ControlPlaneRequestLimitEntry.KV.get -> Consul.KVRateLimit
+Consul.ControlPlaneRequestLimitEntry.KV.set -> void
+Consul.ControlPlaneRequestLimitEntry.Mode.get -> string
+Consul.ControlPlaneRequestLimitEntry.Mode.set -> void
+Consul.ControlPlaneRequestLimitEntry.Name.get -> string
+Consul.ControlPlaneRequestLimitEntry.Name.set -> void
+Consul.CookieConfig.Path.get -> string
+Consul.CookieConfig.Path.set -> void
+Consul.CookieConfig.TTL.get -> string
+Consul.CookieConfig.TTL.set -> void
+Consul.CookieLocation.Name.get -> string
+Consul.CookieLocation.Name.set -> void
+Consul.Coordinate.Datacenters(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateDatacenterMap[]>>
+Consul.Coordinate.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
+Consul.Coordinate.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
+Consul.Coordinate.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
+Consul.Coordinate.Nodes() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
+Consul.Coordinate.Nodes(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
+Consul.Coordinate.Nodes(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
+Consul.Coordinate.Update(Consul.CoordinateEntry entry) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Coordinate.Update(Consul.CoordinateEntry entry, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Coordinate.Update(Consul.CoordinateEntry entry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.CoordinateDatacenterMap.Coordinates.get -> System.Collections.Generic.List<Consul.CoordinateEntry>
+Consul.CoordinateDatacenterMap.Coordinates.set -> void
+Consul.CoordinateDatacenterMap.Datacenter.get -> string
+Consul.CoordinateDatacenterMap.Datacenter.set -> void
+Consul.CoordinateEntry.Coord.get -> Consul.SerfCoordinate
+Consul.CoordinateEntry.Coord.set -> void
+Consul.CoordinateEntry.Node.get -> string
+Consul.CoordinateEntry.Node.set -> void
+Consul.CoordinateEntry.Segment.get -> string
+Consul.CoordinateEntry.Segment.set -> void
+Consul.Counter.Labels.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.Counter.Labels.set -> void
+Consul.Counter.Name.get -> string
+Consul.Counter.Name.set -> void
+Consul.CPUInfo.CoreId.get -> string
+Consul.CPUInfo.CoreId.set -> void
+Consul.CPUInfo.Family.get -> string
+Consul.CPUInfo.Family.set -> void
+Consul.CPUInfo.Flags.get -> System.Collections.Generic.List<string>
+Consul.CPUInfo.Flags.set -> void
+Consul.CPUInfo.Microcode.get -> string
+Consul.CPUInfo.Microcode.set -> void
+Consul.CPUInfo.Model.get -> string
+Consul.CPUInfo.Model.set -> void
+Consul.CPUInfo.ModelName.get -> string
+Consul.CPUInfo.ModelName.set -> void
+Consul.CPUInfo.PhysicalId.get -> string
+Consul.CPUInfo.PhysicalId.set -> void
+Consul.CPUInfo.VendorId.get -> string
+Consul.CPUInfo.VendorId.set -> void
+Consul.DatacenterUsage.ConnectServiceInstances.get -> Consul.ConnectServiceInstances
+Consul.DatacenterUsage.ConnectServiceInstances.set -> void
+Consul.DefaultsConfig.BalanceOutboundConnections.get -> string
+Consul.DefaultsConfig.BalanceOutboundConnections.set -> void
+Consul.DefaultsConfig.Limits.get -> Consul.LimitsConfig
+Consul.DefaultsConfig.Limits.set -> void
+Consul.DefaultsConfig.MeshGateway.get -> Consul.MeshGatewayConfig
+Consul.DefaultsConfig.MeshGateway.set -> void
+Consul.DefaultsConfig.PassiveHealthCheck.get -> Consul.PassiveHealthCheckConfig
+Consul.DefaultsConfig.PassiveHealthCheck.set -> void
+Consul.DefaultsConfig.Protocol.get -> string
+Consul.DefaultsConfig.Protocol.set -> void
+Consul.DeleteAcceptingRequest<TIn>.DeleteAcceptingRequest(Consul.ConsulClient client, string url, TIn body, Consul.WriteOptions options = null) -> void
+Consul.DeleteAcceptingRequest<TIn>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.DeleteAcceptingRequest<TIn>.Options.get -> Consul.WriteOptions
+Consul.DeleteAcceptingRequest<TIn>.Options.set -> void
+Consul.DeleteRequest.DeleteRequest(Consul.ConsulClient client, string url, Consul.WriteOptions options = null) -> void
+Consul.DeleteRequest.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.DeleteRequest.Options.get -> Consul.WriteOptions
+Consul.DeleteRequest.Options.set -> void
+Consul.DeleteReturnRequest<TOut>.DeleteReturnRequest(Consul.ConsulClient client, string url, Consul.WriteOptions options = null) -> void
+Consul.DeleteReturnRequest<TOut>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<TOut>>
+Consul.DeleteReturnRequest<TOut>.Options.get -> Consul.WriteOptions
+Consul.DeleteReturnRequest<TOut>.Options.set -> void
+Consul.DestinationConfig.Addresses.get -> System.Collections.Generic.List<string>
+Consul.DestinationConfig.Addresses.set -> void
+Consul.DiscoveryChain.Get(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
+Consul.DiscoveryChain.Get(string name, Consul.DiscoveryChainOptions options) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
+Consul.DiscoveryChain.Get(string name, Consul.DiscoveryChainOptions options, Consul.WriteOptions q, string compileDataCenter = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
+Consul.DiscoveryChain.Get(string name, Consul.DiscoveryChainOptions options, string compileDataCenter) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
+Consul.DiscoveryChain.Get(string name, Consul.DiscoveryChainOptions options, string compileDataCenter, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
+Consul.DiscoveryChain.Get(string name, Consul.DiscoveryChainOptions options, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
+Consul.DiscoveryChain.Get(string name, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
+Consul.DiscoveryChain.Get(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
+Consul.DiscoveryChain.Get(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
+Consul.DiscoveryChainOptions.OverrideMeshGateway.get -> Consul.MeshGatewayConfig
+Consul.DiscoveryChainOptions.OverrideMeshGateway.set -> void
+Consul.DiscoveryChainOptions.OverrideProtocol.get -> string
+Consul.DiscoveryChainOptions.OverrideProtocol.set -> void
+Consul.DiscoveryChainResponse.Chain.get -> Consul.CompiledDiscoveryChain
+Consul.DiscoveryChainResponse.Chain.set -> void
+Consul.DiscoveryFailover.Targets.get -> System.Collections.Generic.List<string>
+Consul.DiscoveryFailover.Targets.set -> void
+Consul.DiscoveryGraphNode.LoadBalancer.get -> Consul.LoadBalancerConfig
+Consul.DiscoveryGraphNode.LoadBalancer.set -> void
+Consul.DiscoveryGraphNode.Name.get -> string
+Consul.DiscoveryGraphNode.Name.set -> void
+Consul.DiscoveryGraphNode.Resolver.get -> Consul.DiscoveryResolver
+Consul.DiscoveryGraphNode.Resolver.set -> void
+Consul.DiscoveryGraphNode.Routes.get -> System.Collections.Generic.List<Consul.DiscoveryRoute>
+Consul.DiscoveryGraphNode.Routes.set -> void
+Consul.DiscoveryGraphNode.Splits.get -> System.Collections.Generic.List<Consul.DiscoverySplit>
+Consul.DiscoveryGraphNode.Splits.set -> void
+Consul.DiscoveryGraphNode.Type.get -> string
+Consul.DiscoveryGraphNode.Type.set -> void
+Consul.DiscoveryResolver.Failover.get -> Consul.DiscoveryFailover
+Consul.DiscoveryResolver.Failover.set -> void
+Consul.DiscoveryResolver.Target.get -> string
+Consul.DiscoveryResolver.Target.set -> void
+Consul.DiscoveryRoute.Definition.get -> Consul.Routes
+Consul.DiscoveryRoute.Definition.set -> void
+Consul.DiscoveryRoute.NextNode.get -> string
+Consul.DiscoveryRoute.NextNode.set -> void
+Consul.DiscoverySplit.NextNode.get -> string
+Consul.DiscoverySplit.NextNode.set -> void
+Consul.DiscoveryTarget.Datacenter.get -> string
+Consul.DiscoveryTarget.Datacenter.set -> void
+Consul.DiscoveryTarget.ID.get -> string
+Consul.DiscoveryTarget.ID.set -> void
+Consul.DiscoveryTarget.MeshGateway.get -> Consul.MeshGatewayConfig
+Consul.DiscoveryTarget.MeshGateway.set -> void
+Consul.DiscoveryTarget.Name.get -> string
+Consul.DiscoveryTarget.Name.set -> void
+Consul.DiscoveryTarget.Namespace.get -> string
+Consul.DiscoveryTarget.Namespace.set -> void
+Consul.DiscoveryTarget.Service.get -> string
+Consul.DiscoveryTarget.Service.set -> void
+Consul.DiscoveryTarget.ServiceSubset.get -> string
+Consul.DiscoveryTarget.ServiceSubset.set -> void
+Consul.DiscoveryTarget.SNI.get -> string
+Consul.DiscoveryTarget.SNI.set -> void
+Consul.DiscoveryTarget.Subset.get -> Consul.ServiceResolverEntry
+Consul.DiscoveryTarget.Subset.set -> void
+Consul.DiskInfo.Fstype.get -> string
+Consul.DiskInfo.Fstype.set -> void
+Consul.DiskInfo.Path.get -> string
+Consul.DiskInfo.Path.set -> void
+Consul.EnvoyExtension.Arguments.get -> string
+Consul.EnvoyExtension.Arguments.set -> void
+Consul.EnvoyExtension.ConsulVersion.get -> string
+Consul.EnvoyExtension.ConsulVersion.set -> void
+Consul.EnvoyExtension.EnvoyVersion.get -> string
+Consul.EnvoyExtension.EnvoyVersion.set -> void
+Consul.EnvoyExtension.Name.get -> string
+Consul.EnvoyExtension.Name.set -> void
+Consul.EnvoyExtension.Required.get -> string
+Consul.EnvoyExtension.Required.set -> void
+Consul.EnvoyExtensionConfig.Arguments.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.EnvoyExtensionConfig.Arguments.set -> void
+Consul.EnvoyExtensionConfig.ConsulVersion.get -> string
+Consul.EnvoyExtensionConfig.ConsulVersion.set -> void
+Consul.EnvoyExtensionConfig.EnvoyVersion.get -> string
+Consul.EnvoyExtensionConfig.EnvoyVersion.set -> void
+Consul.EnvoyExtensionConfig.Name.get -> string
+Consul.EnvoyExtensionConfig.Name.set -> void
+Consul.Event.Fire(Consul.UserEvent ue) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Event.Fire(Consul.UserEvent ue, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Event.Fire(Consul.UserEvent ue, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Event.IDToIndex(string uuid) -> ulong
+Consul.Event.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
+Consul.Event.List(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
+Consul.Event.List(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
+Consul.Event.List(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
+Consul.Event.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
+Consul.ExportedServiceEntry.Kind.get -> string
+Consul.ExportedServiceEntry.Kind.set -> void
+Consul.ExportedServiceEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ExportedServiceEntry.Meta.set -> void
+Consul.ExportedServiceEntry.Name.get -> string
+Consul.ExportedServiceEntry.Name.set -> void
+Consul.ExportedServiceEntry.Partition.get -> string
+Consul.ExportedServiceEntry.Partition.set -> void
+Consul.ExportedServiceEntry.Services.get -> System.Collections.Generic.List<Consul.ServiceDefinition>
+Consul.ExportedServiceEntry.Services.set -> void
+Consul.ExportedServices.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ResolvedExportedService[]>>
+Consul.ExportedServices.List(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ResolvedExportedService[]>>
+Consul.ExportedServices.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ResolvedExportedService[]>>
+Consul.ExposeConfig.Paths.get -> System.Collections.Generic.List<Consul.PathConfig>
+Consul.ExposeConfig.Paths.set -> void
+Consul.ExternalService.Defaults.get -> Consul.GatewayDefaults
+Consul.ExternalService.Defaults.set -> void
+Consul.ExternalService.Hosts.get -> System.Collections.Generic.List<string>
+Consul.ExternalService.Hosts.set -> void
+Consul.ExternalService.Name.get -> string
+Consul.ExternalService.Name.set -> void
+Consul.ExternalService.Namespace.get -> string
+Consul.ExternalService.Namespace.set -> void
+Consul.ExternalService.Partition.get -> string
+Consul.ExternalService.Partition.set -> void
+Consul.ExternalService.RequestHeaders.get -> Consul.HeaderModification
+Consul.ExternalService.RequestHeaders.set -> void
+Consul.ExternalService.ResponseHeaders.get -> Consul.HeaderModification
+Consul.ExternalService.ResponseHeaders.set -> void
+Consul.ExternalService.TLS.get -> Consul.TLSConfig
+Consul.ExternalService.TLS.set -> void
+Consul.Filtering.IEncodable.Encode() -> string
+Consul.Filtering.MetaSelector.IsEmpty() -> Consul.Filtering.Filter
+Consul.Filtering.MetaSelector.MetaSelector(string prefix) -> void
+Consul.Filtering.MetaSelector.Prefix.get -> string
+Consul.Filtering.MetaSelector.this[string name].get -> Consul.Filtering.ServiceMetaEntrySelector
+Consul.Filtering.NodeSelector.Id.get -> Consul.Filtering.StringFieldSelector
+Consul.Filtering.NodeSelector.Meta.get -> Consul.Filtering.MetaSelector
+Consul.Filtering.NodeSelector.Node.get -> Consul.Filtering.StringFieldSelector
+Consul.Filtering.ServiceMetaEntrySelector.Contains(string value) -> Consul.Filtering.Filter
+Consul.Filtering.ServiceMetaEntrySelector.Name.get -> string
+Consul.Filtering.ServiceMetaEntrySelector.Prefix.get -> string
+Consul.Filtering.ServiceMetaEntrySelector.ServiceMetaEntrySelector(string prefix, string name) -> void
+Consul.Filtering.ServiceSelector.Id.get -> Consul.Filtering.StringFieldSelector
+Consul.Filtering.ServiceSelector.Meta.get -> Consul.Filtering.MetaSelector
+Consul.Filtering.ServiceSelector.Tags.get -> Consul.Filtering.TagsSelector
+Consul.Filtering.StringFieldSelector.Contains(string value) -> Consul.Filtering.Filter
+Consul.Filtering.StringFieldSelector.IsEmpty() -> Consul.Filtering.Filter
+Consul.Filtering.StringFieldSelector.Name.get -> string
+Consul.Filtering.StringFieldSelector.Prefix.get -> string
+Consul.Filtering.StringFieldSelector.StringFieldSelector(string name) -> void
+Consul.Filtering.StringFieldSelector.StringFieldSelector(string prefix, string name) -> void
+Consul.Filtering.TagsSelector.Contains(string value) -> Consul.Filtering.Filter
+Consul.Filtering.TagsSelector.IsEmpty() -> Consul.Filtering.Filter
+Consul.Filtering.TagsSelector.Prefix.get -> string
+Consul.Filtering.TagsSelector.TagsSelector(string prefix) -> void
+Consul.Flags.Package.get -> string
+Consul.Flags.Package.set -> void
+Consul.ForwardingConfig.HeaderName.get -> string
+Consul.ForwardingConfig.HeaderName.set -> void
+Consul.GatewayDefaults.PassiveHealthCheck.get -> Consul.PassiveHealthCheckConfig
+Consul.GatewayDefaults.PassiveHealthCheck.set -> void
+Consul.GatewayListener.Protocol.get -> string
+Consul.GatewayListener.Protocol.set -> void
+Consul.GatewayListener.Services.get -> System.Collections.Generic.List<Consul.ExternalService>
+Consul.GatewayListener.Services.set -> void
+Consul.GatewayListener.TLS.get -> Consul.TLSConfig
+Consul.GatewayListener.TLS.set -> void
+Consul.GatewayService.CAFile.get -> string
+Consul.GatewayService.CAFile.set -> void
+Consul.GatewayService.CertFile.get -> string
+Consul.GatewayService.CertFile.set -> void
+Consul.GatewayService.Gateway.get -> Consul.CompoundServiceName
+Consul.GatewayService.Gateway.set -> void
+Consul.GatewayService.GatewayKind.get -> Consul.ServiceKind
+Consul.GatewayService.GatewayKind.set -> void
+Consul.GatewayService.Hosts.get -> System.Collections.Generic.List<string>
+Consul.GatewayService.Hosts.set -> void
+Consul.GatewayService.KeyFile.get -> string
+Consul.GatewayService.KeyFile.set -> void
+Consul.GatewayService.Protocol.get -> string
+Consul.GatewayService.Protocol.set -> void
+Consul.GatewayService.Service.get -> Consul.CompoundServiceName
+Consul.GatewayService.Service.set -> void
+Consul.GatewayService.SNI.get -> string
+Consul.GatewayService.SNI.set -> void
+Consul.Gauge.Labels.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.Gauge.Labels.set -> void
+Consul.Gauge.Name.get -> string
+Consul.Gauge.Name.set -> void
+Consul.GetRequest.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
+Consul.GetRequest.GetRequest(Consul.ConsulClient client, string url, Consul.QueryOptions options = null) -> void
+Consul.GetRequest.Options.get -> Consul.QueryOptions
+Consul.GetRequest.Options.set -> void
+Consul.GetRequest<TOut>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<TOut>>
+Consul.GetRequest<TOut>.ExecuteStreaming(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
+Consul.GetRequest<TOut>.Filter.get -> Consul.Filtering.IEncodable
+Consul.GetRequest<TOut>.GetRequest(Consul.ConsulClient client, string url) -> void
+Consul.GetRequest<TOut>.GetRequest(Consul.ConsulClient client, string url, Consul.QueryOptions options) -> void
+Consul.GetRequest<TOut>.GetRequest(Consul.ConsulClient client, string url, Consul.QueryOptions options, Consul.Filtering.IEncodable filter) -> void
+Consul.GetRequest<TOut>.Options.get -> Consul.QueryOptions
+Consul.GetRequest<TOut>.Options.set -> void
+Consul.GetRequest<TOut>.ParseQueryHeaders(System.Net.Http.HttpResponseMessage res, Consul.QueryResult<TOut> meta) -> void
+Consul.Header.Description.get -> string
+Consul.Header.Description.set -> void
+Consul.Header.Exact.get -> string
+Consul.Header.Exact.set -> void
+Consul.Header.LegacyCreateTime.get -> string
+Consul.Header.LegacyCreateTime.set -> void
+Consul.Header.LegacyID.get -> string
+Consul.Header.LegacyID.set -> void
+Consul.Header.LegacyMeta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.Header.LegacyMeta.set -> void
+Consul.Header.LegacyUpdateTime.get -> string
+Consul.Header.LegacyUpdateTime.set -> void
+Consul.Header.Name.get -> string
+Consul.Header.Name.set -> void
+Consul.Header.Prefix.get -> string
+Consul.Header.Prefix.set -> void
+Consul.Header.Regex.get -> string
+Consul.Header.Regex.set -> void
+Consul.Header.Suffix.get -> string
+Consul.Header.Suffix.set -> void
+Consul.Header.Type.get -> string
+Consul.Header.Type.set -> void
+Consul.HeaderConfig.Exact.get -> string
+Consul.HeaderConfig.Exact.set -> void
+Consul.HeaderConfig.Name.get -> string
+Consul.HeaderConfig.Name.set -> void
+Consul.HeaderConfig.Prefix.get -> string
+Consul.HeaderConfig.Prefix.set -> void
+Consul.HeaderConfig.Regex.get -> string
+Consul.HeaderConfig.Regex.set -> void
+Consul.HeaderConfig.Suffix.get -> string
+Consul.HeaderConfig.Suffix.set -> void
+Consul.HeaderKeyValuePair.Key.get -> string
+Consul.HeaderKeyValuePair.Key.set -> void
+Consul.HeaderKeyValuePair.Value.get -> string
+Consul.HeaderKeyValuePair.Value.set -> void
+Consul.HeaderLocation.Name.get -> string
+Consul.HeaderLocation.Name.set -> void
+Consul.HeaderLocation.ValuePrefix.get -> string
+Consul.HeaderLocation.ValuePrefix.set -> void
+Consul.HeaderModification.Add.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.HeaderModification.Add.set -> void
+Consul.HeaderModification.Remove.get -> System.Collections.Generic.List<string>
+Consul.HeaderModification.Remove.set -> void
+Consul.HeaderModification.Set.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.HeaderModification.Set.set -> void
+Consul.Health.Checks(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.Health.Checks(string service, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.Health.Checks(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.Health.Connect(string service, string tag, bool passingOnly, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Connect(string service, string tag, bool passingOnly, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Connect(string service, string tag, bool passingOnly, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Ingress(string service, string tag, bool passingOnly) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Ingress(string service, string tag, bool passingOnly, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Ingress(string service, string tag, bool passingOnly, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Ingress(string service, string tag, bool passingOnly, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Ingress(string service, string tag, bool passingOnly, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.Health.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.Health.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.Health.Service(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Service(string service, string tag) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Service(string service, string tag, bool passingOnly) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Service(string service, string tag, bool passingOnly, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Service(string service, string tag, bool passingOnly, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Service(string service, string tag, bool passingOnly, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Service(string service, string tag, bool passingOnly, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Service(string service, string tag, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.Service(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.Health.State(Consul.HealthStatus status) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.Health.State(Consul.HealthStatus status, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.Health.State(Consul.HealthStatus status, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.HealthCheck.CheckID.get -> string
+Consul.HealthCheck.CheckID.set -> void
+Consul.HealthCheck.Name.get -> string
+Consul.HealthCheck.Name.set -> void
+Consul.HealthCheck.Node.get -> string
+Consul.HealthCheck.Node.set -> void
+Consul.HealthCheck.Notes.get -> string
+Consul.HealthCheck.Notes.set -> void
+Consul.HealthCheck.Output.get -> string
+Consul.HealthCheck.Output.set -> void
+Consul.HealthCheck.ServiceID.get -> string
+Consul.HealthCheck.ServiceID.set -> void
+Consul.HealthCheck.ServiceName.get -> string
+Consul.HealthCheck.ServiceName.set -> void
+Consul.HealthCheck.ServiceTags.get -> string[]
+Consul.HealthCheck.ServiceTags.set -> void
+Consul.HealthCheck.Status.get -> Consul.HealthStatus
+Consul.HealthCheck.Status.set -> void
+Consul.HealthCheck.Type.get -> string
+Consul.HealthCheck.Type.set -> void
+Consul.HealthStatus.Equals(Consul.HealthStatus other) -> bool
+Consul.HealthStatus.Status.get -> string
+Consul.HostInfo.HostId.get -> string
+Consul.HostInfo.HostId.set -> void
+Consul.HostInfo.Hostname.get -> string
+Consul.HostInfo.Hostname.set -> void
+Consul.HostInfo.KernelArch.get -> string
+Consul.HostInfo.KernelArch.set -> void
+Consul.HostInfo.KernelVersion.get -> string
+Consul.HostInfo.KernelVersion.set -> void
+Consul.HostInfo.Os.get -> string
+Consul.HostInfo.Os.set -> void
+Consul.HostInfo.Platform.get -> string
+Consul.HostInfo.Platform.set -> void
+Consul.HostInfo.PlatformFamily.get -> string
+Consul.HostInfo.PlatformFamily.set -> void
+Consul.HostInfo.PlatformVersion.get -> string
+Consul.HostInfo.PlatformVersion.set -> void
+Consul.HostInfo.VirtualizationRole.get -> string
+Consul.HostInfo.VirtualizationRole.set -> void
+Consul.HostInfo.VirtualizationSystem.get -> string
+Consul.HostInfo.VirtualizationSystem.set -> void
+Consul.HTTPConfig.PrefixRewrite.get -> string
+Consul.HTTPConfig.PrefixRewrite.set -> void
+Consul.HTTPConfig.RequestHeaders.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.HTTPConfig.RequestHeaders.set -> void
+Consul.HTTPConfig.ResponseHeaders.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.HTTPConfig.ResponseHeaders.set -> void
+Consul.HTTPConfig.RetryOn.get -> System.Collections.Generic.List<string>
+Consul.HTTPConfig.RetryOn.set -> void
+Consul.HTTPConfig.RetryOnStatusCodes.get -> System.Collections.Generic.List<int?>
+Consul.HTTPConfig.RetryOnStatusCodes.set -> void
+Consul.HttpHeaderMatch.Match.get -> string
+Consul.HttpHeaderMatch.Match.set -> void
+Consul.HttpHeaderMatch.Name.get -> string
+Consul.HttpHeaderMatch.Name.set -> void
+Consul.HttpHeaderMatch.Value.get -> string
+Consul.HttpHeaderMatch.Value.set -> void
+Consul.HttpHeaderOperation.Add.get -> System.Collections.Generic.List<Consul.HeaderKeyValuePair>
+Consul.HttpHeaderOperation.Add.set -> void
+Consul.HttpHeaderOperation.Remove.get -> System.Collections.Generic.List<string>
+Consul.HttpHeaderOperation.Remove.set -> void
+Consul.HttpHeaderOperation.Set.get -> System.Collections.Generic.List<Consul.HeaderKeyValuePair>
+Consul.HttpHeaderOperation.Set.set -> void
+Consul.HttpPathMatch.Match.get -> string
+Consul.HttpPathMatch.Match.set -> void
+Consul.HttpPathMatch.Value.get -> string
+Consul.HttpPathMatch.Value.set -> void
+Consul.HttpQueryMatch.Match.get -> string
+Consul.HttpQueryMatch.Match.set -> void
+Consul.HttpQueryMatch.Name.get -> string
+Consul.HttpQueryMatch.Name.set -> void
+Consul.HttpQueryMatch.Value.get -> string
+Consul.HttpQueryMatch.Value.set -> void
+Consul.HttpRouteEntry.Hostnames.get -> System.Collections.Generic.List<string>
+Consul.HttpRouteEntry.Hostnames.set -> void
+Consul.HttpRouteEntry.Kind.get -> string
+Consul.HttpRouteEntry.Kind.set -> void
+Consul.HttpRouteEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.HttpRouteEntry.Meta.set -> void
+Consul.HttpRouteEntry.Name.get -> string
+Consul.HttpRouteEntry.Name.set -> void
+Consul.HttpRouteEntry.Namespace.get -> string
+Consul.HttpRouteEntry.Namespace.set -> void
+Consul.HttpRouteEntry.Parents.get -> System.Collections.Generic.List<Consul.ApiGatewayReference>
+Consul.HttpRouteEntry.Parents.set -> void
+Consul.HttpRouteEntry.Partition.get -> string
+Consul.HttpRouteEntry.Partition.set -> void
+Consul.HttpRouteEntry.Rules.get -> System.Collections.Generic.List<Consul.HttpRouteRule>
+Consul.HttpRouteEntry.Rules.set -> void
+Consul.HttpRouteFilter.Headers.get -> System.Collections.Generic.List<Consul.HttpHeaderOperation>
+Consul.HttpRouteFilter.Headers.set -> void
+Consul.HttpRouteFilter.JWT.get -> Consul.JWTSettings
+Consul.HttpRouteFilter.JWT.set -> void
+Consul.HttpRouteFilter.URLRewrite.get -> System.Collections.Generic.List<Consul.HttpURLRewriteOperation>
+Consul.HttpRouteFilter.URLRewrite.set -> void
+Consul.HttpRouteMatch.Headers.get -> System.Collections.Generic.List<Consul.HttpHeaderMatch>
+Consul.HttpRouteMatch.Headers.set -> void
+Consul.HttpRouteMatch.Method.get -> string
+Consul.HttpRouteMatch.Method.set -> void
+Consul.HttpRouteMatch.Path.get -> System.Collections.Generic.List<Consul.HttpPathMatch>
+Consul.HttpRouteMatch.Path.set -> void
+Consul.HttpRouteMatch.Query.get -> System.Collections.Generic.List<Consul.HttpQueryMatch>
+Consul.HttpRouteMatch.Query.set -> void
+Consul.HttpRouteRule.Filters.get -> System.Collections.Generic.List<Consul.HttpRouteFilter>
+Consul.HttpRouteRule.Filters.set -> void
+Consul.HttpRouteRule.Matches.get -> System.Collections.Generic.List<Consul.HttpRouteMatch>
+Consul.HttpRouteRule.Matches.set -> void
+Consul.HttpRouteRule.Services.get -> System.Collections.Generic.List<Consul.HttpRouteService>
+Consul.HttpRouteRule.Services.set -> void
+Consul.HttpRouteService.Filters.get -> System.Collections.Generic.List<Consul.HttpRouteFilter>
+Consul.HttpRouteService.Filters.set -> void
+Consul.HttpRouteService.Name.get -> string
+Consul.HttpRouteService.Name.set -> void
+Consul.HttpRouteService.Namespace.get -> string
+Consul.HttpRouteService.Namespace.set -> void
+Consul.HttpRouteService.Partition.get -> string
+Consul.HttpRouteService.Partition.set -> void
+Consul.HttpRouteService.ResponseFilters.get -> System.Collections.Generic.List<Consul.HttpRouteFilter>
+Consul.HttpRouteService.ResponseFilters.set -> void
+Consul.HttpURLRewriteOperation.Path.get -> string
+Consul.HttpURLRewriteOperation.Path.set -> void
+Consul.IACLEndpoint.Clone(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IACLEndpoint.Clone(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IACLEndpoint.Create(Consul.ACLEntry acl, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IACLEndpoint.Create(Consul.ACLEntry acl, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IACLEndpoint.Destroy(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IACLEndpoint.Destroy(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IACLEndpoint.Info(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry>>
+Consul.IACLEndpoint.Info(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry>>
+Consul.IACLEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry[]>>
+Consul.IACLEndpoint.List(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLEntry[]>>
+Consul.IACLEndpoint.TranslateLegacyTokenRules(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
+Consul.IACLEndpoint.TranslateLegacyTokenRules(string id, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
+Consul.IACLEndpoint.TranslateRules(string rules, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IACLEndpoint.TranslateRules(string rules, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IACLEndpoint.Update(Consul.ACLEntry acl, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IACLEndpoint.Update(Consul.ACLEntry acl, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IACLReplicationEndpoint.Status() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLReplicationEntry>>
+Consul.IACLReplicationEndpoint.Status(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLReplicationEntry>>
+Consul.IACLReplicationEndpoint.Status(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLReplicationEntry>>
+Consul.IAgentEndpoint.CheckDeregister(string checkID, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.CheckRegister(Consul.AgentCheckRegistration check, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.Checks() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentCheck>>>
+Consul.IAgentEndpoint.Checks(Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentCheck>>>
+Consul.IAgentEndpoint.Checks(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentCheck>>>
+Consul.IAgentEndpoint.ConnectAuthorize(Consul.AgentAuthorizeParameters parameters) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AgentAuthorizeResponse>>
+Consul.IAgentEndpoint.ConnectAuthorize(Consul.AgentAuthorizeParameters parameters, Consul.WriteOptions w, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AgentAuthorizeResponse>>
+Consul.IAgentEndpoint.ConnectAuthorize(Consul.AgentAuthorizeParameters parameters, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AgentAuthorizeResponse>>
+Consul.IAgentEndpoint.DisableNodeMaintenance(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.DisableServiceMaintenance(string serviceID, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.EnableNodeMaintenance(string reason, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.EnableServiceMaintenance(string serviceID, string reason, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.FailTTL(string checkID, string note, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.IAgentEndpoint.ForceLeave(string node, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.GetAgentHostInfo(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AgentHostInfo>>
+Consul.IAgentEndpoint.GetAgentMetrics(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Metrics>>
+Consul.IAgentEndpoint.GetAgentVersion(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AgentVersion>>
+Consul.IAgentEndpoint.GetCALeaf(string serviceId) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CALeaf>>
+Consul.IAgentEndpoint.GetCALeaf(string serviceId, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CALeaf>>
+Consul.IAgentEndpoint.GetCALeaf(string serviceId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CALeaf>>
+Consul.IAgentEndpoint.GetCARoots() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
+Consul.IAgentEndpoint.GetCARoots(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
+Consul.IAgentEndpoint.GetCARoots(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
+Consul.IAgentEndpoint.GetLocalServiceHealth(string serviceName) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth[]>>
+Consul.IAgentEndpoint.GetLocalServiceHealth(string serviceName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth[]>>
+Consul.IAgentEndpoint.GetLocalServiceHealth(string serviceName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth[]>>
+Consul.IAgentEndpoint.GetLocalServiceHealthByID(string serviceID) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth>>
+Consul.IAgentEndpoint.GetLocalServiceHealthByID(string serviceID, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth>>
+Consul.IAgentEndpoint.GetLocalServiceHealthByID(string serviceID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.LocalServiceHealth>>
+Consul.IAgentEndpoint.GetNodeName(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
+Consul.IAgentEndpoint.GetServiceConfiguration(string serviceID) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceConfiguration>>
+Consul.IAgentEndpoint.GetServiceConfiguration(string serviceID, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceConfiguration>>
+Consul.IAgentEndpoint.GetServiceConfiguration(string serviceID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceConfiguration>>
+Consul.IAgentEndpoint.GetWorstLocalServiceHealth(string serviceName) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
+Consul.IAgentEndpoint.GetWorstLocalServiceHealth(string serviceName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
+Consul.IAgentEndpoint.GetWorstLocalServiceHealth(string serviceName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string>>
+Consul.IAgentEndpoint.Join(string addr, bool wan, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.Leave(string node, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.Members(bool wan, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AgentMember[]>>
+Consul.IAgentEndpoint.Monitor(Consul.LogLevel level = Consul.LogLevel.Info, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.Agent.LogStream>
+Consul.IAgentEndpoint.MonitorJSON(Consul.LogLevel level = Consul.LogLevel.Info, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.Agent.LogStream>
+Consul.IAgentEndpoint.NodeName.get -> string
+Consul.IAgentEndpoint.PassTTL(string checkID, string note, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.IAgentEndpoint.Reload() -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.Reload(string node, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.Reload(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.Self(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, dynamic>>>>
+Consul.IAgentEndpoint.ServiceDeregister(string serviceID, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.ServiceRegister(Consul.AgentServiceRegistration service) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.ServiceRegister(Consul.AgentServiceRegistration service, bool replaceExistingChecks, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.ServiceRegister(Consul.AgentServiceRegistration service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.Services() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentService>>>
+Consul.IAgentEndpoint.Services(Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentService>>>
+Consul.IAgentEndpoint.Services(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.AgentService>>>
+Consul.IAgentEndpoint.UpdateTTL(string checkID, string output, Consul.TTLStatus status, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAgentEndpoint.WarnTTL(string checkID, string note, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.IAuthMethodEndpoint.Create(Consul.AuthMethodEntry authMethod) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
+Consul.IAuthMethodEndpoint.Create(Consul.AuthMethodEntry authMethod, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
+Consul.IAuthMethodEndpoint.Create(Consul.AuthMethodEntry authMethod, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
+Consul.IAuthMethodEndpoint.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IAuthMethodEndpoint.Delete(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IAuthMethodEndpoint.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IAuthMethodEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry[]>>
+Consul.IAuthMethodEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry[]>>
+Consul.IAuthMethodEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry[]>>
+Consul.IAuthMethodEndpoint.Login() -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.IAuthMethodEndpoint.Login(Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.IAuthMethodEndpoint.Login(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.IAuthMethodEndpoint.Logout() -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAuthMethodEndpoint.Logout(Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAuthMethodEndpoint.Logout(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IAuthMethodEndpoint.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry>>
+Consul.IAuthMethodEndpoint.Read(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry>>
+Consul.IAuthMethodEndpoint.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AuthMethodEntry>>
+Consul.IAuthMethodEndpoint.Update(Consul.AuthMethodEntry authMethod) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
+Consul.IAuthMethodEndpoint.Update(Consul.AuthMethodEntry authMethod, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
+Consul.IAuthMethodEndpoint.Update(Consul.AuthMethodEntry authMethod, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.AuthMethodEntry>>
+Consul.ICatalogEndpoint.Datacenters() -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.ICatalogEndpoint.Datacenters(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.ICatalogEndpoint.Datacenters(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.ICatalogEndpoint.Deregister(Consul.CatalogDeregistration reg) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ICatalogEndpoint.Deregister(Consul.CatalogDeregistration reg, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ICatalogEndpoint.Deregister(Consul.CatalogDeregistration reg, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ICatalogEndpoint.GatewayService(string gateway) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.GatewayService[]>>
+Consul.ICatalogEndpoint.GatewayService(string gateway, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.GatewayService[]>>
+Consul.ICatalogEndpoint.GatewayService(string gateway, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.GatewayService[]>>
+Consul.ICatalogEndpoint.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogNode>>
+Consul.ICatalogEndpoint.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogNode>>
+Consul.ICatalogEndpoint.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogNode>>
+Consul.ICatalogEndpoint.Nodes() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Node[]>>
+Consul.ICatalogEndpoint.Nodes(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Node[]>>
+Consul.ICatalogEndpoint.Nodes(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Node[]>>
+Consul.ICatalogEndpoint.NodesForMeshCapableService(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.ICatalogEndpoint.NodesForMeshCapableService(string service, Consul.Filtering.Filter filter) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.ICatalogEndpoint.NodesForMeshCapableService(string service, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.ICatalogEndpoint.NodesForMeshCapableService(string service, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.ICatalogEndpoint.NodesForMeshCapableService(string service, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.ICatalogEndpoint.NodesForMeshCapableService(string service, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.ICatalogEndpoint.NodesForMeshCapableService(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.ICatalogEndpoint.Register(Consul.CatalogRegistration reg) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ICatalogEndpoint.Register(Consul.CatalogRegistration reg, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ICatalogEndpoint.Register(Consul.CatalogRegistration reg, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ICatalogEndpoint.Service(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.ICatalogEndpoint.Service(string service, string tag) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.ICatalogEndpoint.Service(string service, string tag, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.ICatalogEndpoint.Service(string service, string tag, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.ICatalogEndpoint.Service(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CatalogService[]>>
+Consul.ICatalogEndpoint.Services() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.ICatalogEndpoint.Services(Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.ICatalogEndpoint.Services(Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.ICatalogEndpoint.Services(string dc, Consul.Filtering.Filter filter) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.ICatalogEndpoint.Services(string dc, Consul.Filtering.Filter filter, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.ICatalogEndpoint.Services(string dc, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.ICatalogEndpoint.Services(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, string[]>>>
+Consul.ICatalogEndpoint.ServicesForNode(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NodeService>>
+Consul.ICatalogEndpoint.ServicesForNode(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NodeService>>
+Consul.ICatalogEndpoint.ServicesForNode(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NodeService>>
+Consul.IConfigurationEntry.Kind.get -> string
+Consul.IConfigurationEntry.Kind.set -> void
+Consul.IConsulClient.ACL.get -> Consul.IACLEndpoint
+Consul.IConsulClient.AcquireLock(Consul.LockOptions opts) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
+Consul.IConsulClient.AcquireLock(Consul.LockOptions opts, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
+Consul.IConsulClient.AcquireLock(string key) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
+Consul.IConsulClient.AcquireLock(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.IDistributedLock>
+Consul.IConsulClient.AcquireSemaphore(Consul.SemaphoreOptions opts) -> System.Threading.Tasks.Task<Consul.IDistributedSemaphore>
+Consul.IConsulClient.AcquireSemaphore(Consul.SemaphoreOptions opts, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.IDistributedSemaphore>
+Consul.IConsulClient.AcquireSemaphore(string prefix, int limit, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.IDistributedSemaphore>
+Consul.IConsulClient.Agent.get -> Consul.IAgentEndpoint
+Consul.IConsulClient.Catalog.get -> Consul.ICatalogEndpoint
+Consul.IConsulClient.Configuration.get -> Consul.Interfaces.IConfigurationEndpoint
+Consul.IConsulClient.Coordinate.get -> Consul.ICoordinateEndpoint
+Consul.IConsulClient.CreateLock(Consul.LockOptions opts) -> Consul.IDistributedLock
+Consul.IConsulClient.CreateLock(string key) -> Consul.IDistributedLock
+Consul.IConsulClient.DiscoveryChain.get -> Consul.Interfaces.IDiscoveryChainEndpoint
+Consul.IConsulClient.Event.get -> Consul.IEventEndpoint
+Consul.IConsulClient.ExecuteInSemaphore(Consul.SemaphoreOptions opts, System.Action a) -> System.Threading.Tasks.Task
+Consul.IConsulClient.ExecuteInSemaphore(Consul.SemaphoreOptions opts, System.Action a, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
+Consul.IConsulClient.ExecuteInSemaphore(string prefix, int limit, System.Action a, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.IConsulClient.ExecuteLocked(Consul.LockOptions opts, System.Action action) -> System.Threading.Tasks.Task
+Consul.IConsulClient.ExecuteLocked(Consul.LockOptions opts, System.Action action, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
+Consul.IConsulClient.ExecuteLocked(Consul.LockOptions opts, System.Threading.CancellationToken ct, System.Action action) -> System.Threading.Tasks.Task
+Consul.IConsulClient.ExecuteLocked(string key, System.Action action) -> System.Threading.Tasks.Task
+Consul.IConsulClient.ExecuteLocked(string key, System.Action action, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
+Consul.IConsulClient.ExecuteLocked(string key, System.Threading.CancellationToken ct, System.Action action) -> System.Threading.Tasks.Task
+Consul.IConsulClient.ExportedServices.get -> Consul.Interfaces.IExportedServicesEndpoint
+Consul.IConsulClient.Health.get -> Consul.IHealthEndpoint
+Consul.IConsulClient.KV.get -> Consul.IKVEndpoint
+Consul.IConsulClient.Operator.get -> Consul.IOperatorEndpoint
+Consul.IConsulClient.Policy.get -> Consul.IPolicyEndpoint
+Consul.IConsulClient.PreparedQuery.get -> Consul.IPreparedQueryEndpoint
+Consul.IConsulClient.Raw.get -> Consul.IRawEndpoint
+Consul.IConsulClient.Role.get -> Consul.IRoleEndpoint
+Consul.IConsulClient.Semaphore(Consul.SemaphoreOptions opts) -> Consul.IDistributedSemaphore
+Consul.IConsulClient.Semaphore(string prefix, int limit) -> Consul.IDistributedSemaphore
+Consul.IConsulClient.Session.get -> Consul.ISessionEndpoint
+Consul.IConsulClient.Snapshot.get -> Consul.ISnapshotEndpoint
+Consul.IConsulClient.Status.get -> Consul.IStatusEndpoint
+Consul.IConsulClient.Token.get -> Consul.ITokenEndpoint
+Consul.ICoordinateEndpoint.Datacenters(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateDatacenterMap[]>>
+Consul.ICoordinateEndpoint.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
+Consul.ICoordinateEndpoint.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
+Consul.ICoordinateEndpoint.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
+Consul.ICoordinateEndpoint.Nodes() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
+Consul.ICoordinateEndpoint.Nodes(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
+Consul.ICoordinateEndpoint.Nodes(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CoordinateEntry[]>>
+Consul.ICoordinateEndpoint.Update(Consul.CoordinateEntry entry) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ICoordinateEndpoint.Update(Consul.CoordinateEntry entry, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ICoordinateEndpoint.Update(Consul.CoordinateEntry entry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IDistributedLock.Acquire(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Threading.CancellationToken>
+Consul.IDistributedLock.Destroy(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.IDistributedLock.Release(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.IDistributedSemaphore.Acquire(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Threading.CancellationToken>
+Consul.IDistributedSemaphore.Destroy(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.IDistributedSemaphore.Release(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.IEventEndpoint.Fire(Consul.UserEvent ue) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IEventEndpoint.Fire(Consul.UserEvent ue, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IEventEndpoint.Fire(Consul.UserEvent ue, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IEventEndpoint.IDToIndex(string uuid) -> ulong
+Consul.IEventEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
+Consul.IEventEndpoint.List(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
+Consul.IEventEndpoint.List(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
+Consul.IEventEndpoint.List(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
+Consul.IEventEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.UserEvent[]>>
+Consul.IHealthEndpoint.Checks(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.IHealthEndpoint.Checks(string service, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.IHealthEndpoint.Checks(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.IHealthEndpoint.Connect(string service, string tag, bool passingOnly, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Connect(string service, string tag, bool passingOnly, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Connect(string service, string tag, bool passingOnly, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Ingress(string service, string tag, bool passingOnly) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Ingress(string service, string tag, bool passingOnly, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Ingress(string service, string tag, bool passingOnly, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Ingress(string service, string tag, bool passingOnly, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Ingress(string service, string tag, bool passingOnly, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.IHealthEndpoint.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.IHealthEndpoint.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.IHealthEndpoint.Service(string service) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Service(string service, string tag) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Service(string service, string tag, bool passingOnly) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Service(string service, string tag, bool passingOnly, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Service(string service, string tag, bool passingOnly, Consul.QueryOptions q, Consul.Filtering.Filter filter, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Service(string service, string tag, bool passingOnly, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Service(string service, string tag, bool passingOnly, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Service(string service, string tag, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.Service(string service, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceEntry[]>>
+Consul.IHealthEndpoint.State(Consul.HealthStatus status) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.IHealthEndpoint.State(Consul.HealthStatus status, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.IHealthEndpoint.State(Consul.HealthStatus status, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.HealthCheck[]>>
+Consul.IKVEndpoint.Acquire(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.Acquire(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.Acquire(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.CAS(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.CAS(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.CAS(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.Delete(string key) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.Delete(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.Delete(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.DeleteCAS(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.DeleteCAS(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.DeleteCAS(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.DeleteTree(string prefix) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.DeleteTree(string prefix, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.DeleteTree(string prefix, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.Get(string key) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair>>
+Consul.IKVEndpoint.Get(string key, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair>>
+Consul.IKVEndpoint.Get(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair>>
+Consul.IKVEndpoint.Keys(string prefix) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.IKVEndpoint.Keys(string prefix, string separator) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.IKVEndpoint.Keys(string prefix, string separator, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.IKVEndpoint.Keys(string prefix, string separator, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.IKVEndpoint.Keys(string prefix, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.IKVEndpoint.List(string prefix) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair[]>>
+Consul.IKVEndpoint.List(string prefix, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair[]>>
+Consul.IKVEndpoint.List(string prefix, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair[]>>
+Consul.IKVEndpoint.Put(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.Put(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.Put(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.Release(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.Release(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.Release(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IKVEndpoint.Txn(System.Collections.Generic.List<Consul.KVTxnOp> txn) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.KVTxnResponse>>
+Consul.IKVEndpoint.Txn(System.Collections.Generic.List<Consul.KVTxnOp> txn, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.KVTxnResponse>>
+Consul.IKVEndpoint.Txn(System.Collections.Generic.List<Consul.KVTxnOp> txn, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.KVTxnResponse>>
+Consul.INamespacesEndpoint.Create(Consul.Namespace ns) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
+Consul.INamespacesEndpoint.Create(Consul.Namespace ns, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
+Consul.INamespacesEndpoint.Create(Consul.Namespace ns, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
+Consul.INamespacesEndpoint.Delete(string name) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.INamespacesEndpoint.Delete(string name, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.INamespacesEndpoint.Delete(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.INamespacesEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse[]>>
+Consul.INamespacesEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse[]>>
+Consul.INamespacesEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse[]>>
+Consul.INamespacesEndpoint.Read(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse>>
+Consul.INamespacesEndpoint.Read(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse>>
+Consul.INamespacesEndpoint.Read(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse>>
+Consul.INamespacesEndpoint.Update(Consul.Namespace ns) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
+Consul.INamespacesEndpoint.Update(Consul.Namespace ns, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
+Consul.INamespacesEndpoint.Update(Consul.Namespace ns, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
+Consul.IngressGatewayEntry.Defaults.get -> Consul.GatewayDefaults
+Consul.IngressGatewayEntry.Defaults.set -> void
+Consul.IngressGatewayEntry.Kind.get -> string
+Consul.IngressGatewayEntry.Kind.set -> void
+Consul.IngressGatewayEntry.Listeners.get -> System.Collections.Generic.List<Consul.GatewayListener>
+Consul.IngressGatewayEntry.Listeners.set -> void
+Consul.IngressGatewayEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.IngressGatewayEntry.Meta.set -> void
+Consul.IngressGatewayEntry.Name.get -> string
+Consul.IngressGatewayEntry.Name.set -> void
+Consul.IngressGatewayEntry.Namespace.get -> string
+Consul.IngressGatewayEntry.Namespace.set -> void
+Consul.IngressGatewayEntry.Partition.get -> string
+Consul.IngressGatewayEntry.Partition.set -> void
+Consul.IngressGatewayEntry.TLS.get -> Consul.TLSConfig
+Consul.IngressGatewayEntry.TLS.set -> void
+Consul.InlineCertificateEntry.Certificate.get -> string
+Consul.InlineCertificateEntry.Certificate.set -> void
+Consul.InlineCertificateEntry.Kind.get -> string
+Consul.InlineCertificateEntry.Kind.set -> void
+Consul.InlineCertificateEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.InlineCertificateEntry.Meta.set -> void
+Consul.InlineCertificateEntry.Name.get -> string
+Consul.InlineCertificateEntry.Name.set -> void
+Consul.InlineCertificateEntry.PrivateKey.get -> string
+Consul.InlineCertificateEntry.PrivateKey.set -> void
+Consul.InstanceLevelConfig.Routes.get -> System.Collections.Generic.List<Consul.RouteConfig>
+Consul.InstanceLevelConfig.Routes.set -> void
+Consul.IntentionHTTPHeaderPermission.Exact.get -> string
+Consul.IntentionHTTPHeaderPermission.Exact.set -> void
+Consul.IntentionHTTPHeaderPermission.Name.get -> string
+Consul.IntentionHTTPHeaderPermission.Name.set -> void
+Consul.IntentionHTTPHeaderPermission.Prefix.get -> string
+Consul.IntentionHTTPHeaderPermission.Prefix.set -> void
+Consul.IntentionHTTPHeaderPermission.Regex.get -> string
+Consul.IntentionHTTPHeaderPermission.Regex.set -> void
+Consul.IntentionHTTPHeaderPermission.Suffix.get -> string
+Consul.IntentionHTTPHeaderPermission.Suffix.set -> void
+Consul.IntentionHTTPPermission.Header.get -> System.Collections.Generic.List<Consul.IntentionHTTPHeaderPermission>
+Consul.IntentionHTTPPermission.Header.set -> void
+Consul.IntentionHTTPPermission.Methods.get -> System.Collections.Generic.List<string>
+Consul.IntentionHTTPPermission.Methods.set -> void
+Consul.IntentionHTTPPermission.PathExact.get -> string
+Consul.IntentionHTTPPermission.PathExact.set -> void
+Consul.IntentionHTTPPermission.PathPrefix.get -> string
+Consul.IntentionHTTPPermission.PathPrefix.set -> void
+Consul.IntentionHTTPPermission.PathRegex.get -> string
+Consul.IntentionHTTPPermission.PathRegex.set -> void
+Consul.IntentionPermission.Action.get -> string
+Consul.IntentionPermission.Action.set -> void
+Consul.IntentionPermission.HTTP.get -> Consul.IntentionHTTPPermission
+Consul.IntentionPermission.HTTP.set -> void
+Consul.Interfaces.IBindingRuleEndpoint.Create(Consul.ACLBindingRule entry) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
+Consul.Interfaces.IBindingRuleEndpoint.Create(Consul.ACLBindingRule entry, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
+Consul.Interfaces.IBindingRuleEndpoint.Create(Consul.ACLBindingRule entry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
+Consul.Interfaces.IBindingRuleEndpoint.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IBindingRuleEndpoint.Delete(string id, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IBindingRuleEndpoint.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IBindingRuleEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse[]>>
+Consul.Interfaces.IBindingRuleEndpoint.List(Consul.QueryOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse[]>>
+Consul.Interfaces.IBindingRuleEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse[]>>
+Consul.Interfaces.IBindingRuleEndpoint.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse>>
+Consul.Interfaces.IBindingRuleEndpoint.Read(string id, Consul.QueryOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse>>
+Consul.Interfaces.IBindingRuleEndpoint.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ACLBindingRuleResponse>>
+Consul.Interfaces.IBindingRuleEndpoint.Update(Consul.ACLBindingRule entry) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
+Consul.Interfaces.IBindingRuleEndpoint.Update(Consul.ACLBindingRule entry, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
+Consul.Interfaces.IBindingRuleEndpoint.Update(Consul.ACLBindingRule entry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ACLBindingRuleResponse>>
+Consul.Interfaces.IClusterPeeringEndpoint.DeletePeering(string name, Consul.WriteOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IClusterPeeringEndpoint.DeletePeering(string name, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IClusterPeeringEndpoint.GenerateToken(Consul.ClusterPeeringTokenEntry tokenEntry) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ClusterPeeringTokenResponse>>
+Consul.Interfaces.IClusterPeeringEndpoint.GenerateToken(Consul.ClusterPeeringTokenEntry tokenEntry, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ClusterPeeringTokenResponse>>
+Consul.Interfaces.IClusterPeeringEndpoint.GenerateToken(Consul.ClusterPeeringTokenEntry tokenEntry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.ClusterPeeringTokenResponse>>
+Consul.Interfaces.IClusterPeeringEndpoint.GetPeering(string name, Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus>>
+Consul.Interfaces.IClusterPeeringEndpoint.GetPeering(string name, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus>>
+Consul.Interfaces.IClusterPeeringEndpoint.ListPeerings() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus[]>>
+Consul.Interfaces.IClusterPeeringEndpoint.ListPeerings(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus[]>>
+Consul.Interfaces.IClusterPeeringEndpoint.ListPeerings(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ClusterPeeringStatus[]>>
+Consul.Interfaces.IConfigurationEndpoint.ApplyConfig<TConfig>(Consul.WriteOptions q, TConfig configurationEntry, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IConfigurationEndpoint.ApplyConfig<TConfig>(TConfig configurationEntry) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IConfigurationEndpoint.ApplyConfig<TConfig>(TConfig configurationEntry, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IConfigurationEndpoint.DeleteConfig(string kind, string name) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IConfigurationEndpoint.DeleteConfig(string kind, string name, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IConfigurationEndpoint.DeleteConfig(string kind, string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IConfigurationEndpoint.GetConfig<TConfig>(string kind, string name) -> System.Threading.Tasks.Task<Consul.QueryResult<TConfig>>
+Consul.Interfaces.IConfigurationEndpoint.GetConfig<TConfig>(string kind, string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<TConfig>>
+Consul.Interfaces.IConfigurationEndpoint.GetConfig<TConfig>(string kind, string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<TConfig>>
+Consul.Interfaces.IConfigurationEndpoint.ListConfig<TConfig>(string kind) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<TConfig>>>
+Consul.Interfaces.IConfigurationEndpoint.ListConfig<TConfig>(string kind, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<TConfig>>>
+Consul.Interfaces.IConfigurationEndpoint.ListConfig<TConfig>(string kind, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<TConfig>>>
+Consul.Interfaces.IConnectEndpoint.CAGetConfig() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CAConfig>>
+Consul.Interfaces.IConnectEndpoint.CAGetConfig(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CAConfig>>
+Consul.Interfaces.IConnectEndpoint.CAGetConfig(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CAConfig>>
+Consul.Interfaces.IConnectEndpoint.CARoots() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
+Consul.Interfaces.IConnectEndpoint.CARoots(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
+Consul.Interfaces.IConnectEndpoint.CARoots(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.CARoots>>
+Consul.Interfaces.IConnectEndpoint.CASetConfig(Consul.CAConfig config) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IConnectEndpoint.CASetConfig(Consul.CAConfig config, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IConnectEndpoint.CASetConfig(Consul.CAConfig config, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IConnectEndpoint.CheckIntentionResult(string source, string destination) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceIntentionResultResponse>>
+Consul.Interfaces.IConnectEndpoint.CheckIntentionResult(string source, string destination, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceIntentionResultResponse>>
+Consul.Interfaces.IConnectEndpoint.CheckIntentionResult(string source, string destination, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ServiceIntentionResultResponse>>
+Consul.Interfaces.IConnectEndpoint.DeleteIntentionByName(string source, string destination) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IConnectEndpoint.DeleteIntentionByName(string source, string destination, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IConnectEndpoint.DeleteIntentionByName(string source, string destination, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Interfaces.IConnectEndpoint.ListIntentions<ServiceIntention>() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<ServiceIntention>>>
+Consul.Interfaces.IConnectEndpoint.ListIntentions<ServiceIntention>(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<ServiceIntention>>>
+Consul.Interfaces.IConnectEndpoint.ListIntentions<ServiceIntention>(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<ServiceIntention>>>
+Consul.Interfaces.IConnectEndpoint.ListMatchingIntentions(string by, string name) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Consul.ServiceIntention>>>>
+Consul.Interfaces.IConnectEndpoint.ListMatchingIntentions(string by, string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Consul.ServiceIntention>>>>
+Consul.Interfaces.IConnectEndpoint.ListMatchingIntentions(string by, string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Consul.ServiceIntention>>>>
+Consul.Interfaces.IConnectEndpoint.ReadSpecificIntentionByName<ServiceIntention>(string source, string destination) -> System.Threading.Tasks.Task<Consul.QueryResult<ServiceIntention>>
+Consul.Interfaces.IConnectEndpoint.ReadSpecificIntentionByName<ServiceIntention>(string source, string destination, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<ServiceIntention>>
+Consul.Interfaces.IConnectEndpoint.ReadSpecificIntentionByName<ServiceIntention>(string source, string destination, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<ServiceIntention>>
+Consul.Interfaces.IConnectEndpoint.UpsertIntentionsByName(Consul.ServiceIntention intention) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Interfaces.IConnectEndpoint.UpsertIntentionsByName(Consul.ServiceIntention intention, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Interfaces.IConnectEndpoint.UpsertIntentionsByName(Consul.ServiceIntention intention, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
+Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.DiscoveryChainOptions options) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
+Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.DiscoveryChainOptions options, Consul.WriteOptions q, string compileDataCenter = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
+Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.DiscoveryChainOptions options, string compileDataCenter) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
+Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.DiscoveryChainOptions options, string compileDataCenter, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
+Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.DiscoveryChainOptions options, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.DiscoveryChainResponse>>
+Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.QueryOptions q) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
+Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
+Consul.Interfaces.IDiscoveryChainEndpoint.Get(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.DiscoveryChainResponse>>
+Consul.Interfaces.IExportedServicesEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ResolvedExportedService[]>>
+Consul.Interfaces.IExportedServicesEndpoint.List(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ResolvedExportedService[]>>
+Consul.Interfaces.IExportedServicesEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ResolvedExportedService[]>>
+Consul.InvalidKeyPairException.InvalidKeyPairException(string message) -> void
+Consul.InvalidKeyPairException.InvalidKeyPairException(string message, System.Exception inner) -> void
+Consul.IOperatorEndpoint.AreaCreate(Consul.AreaRequest area) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IOperatorEndpoint.AreaCreate(Consul.AreaRequest area, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IOperatorEndpoint.AreaCreate(Consul.AreaRequest area, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IOperatorEndpoint.AreaDelete(string areaId) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.AreaDelete(string areaId, Consul.WriteOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.AreaDelete(string areaId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.AreaGet(string areaId) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Area[]>>
+Consul.IOperatorEndpoint.AreaGet(string areaId, Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Area[]>>
+Consul.IOperatorEndpoint.AreaGet(string areaId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Area[]>>
+Consul.IOperatorEndpoint.AreaList() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<Consul.Area>>>
+Consul.IOperatorEndpoint.AreaList(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<Consul.Area>>>
+Consul.IOperatorEndpoint.AreaList(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<Consul.Area>>>
+Consul.IOperatorEndpoint.AreaUpdate(Consul.AreaRequest area, string areaId) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IOperatorEndpoint.AreaUpdate(Consul.AreaRequest area, string areaId, Consul.WriteOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IOperatorEndpoint.AreaUpdate(Consul.AreaRequest area, string areaId, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IOperatorEndpoint.AutopilotGetConfiguration() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotConfiguration>>
+Consul.IOperatorEndpoint.AutopilotGetConfiguration(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotConfiguration>>
+Consul.IOperatorEndpoint.AutopilotGetConfiguration(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotConfiguration>>
+Consul.IOperatorEndpoint.AutopilotGetHealth() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotHealth>>
+Consul.IOperatorEndpoint.AutopilotGetHealth(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotHealth>>
+Consul.IOperatorEndpoint.AutopilotGetHealth(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotHealth>>
+Consul.IOperatorEndpoint.AutopilotGetState() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotState>>
+Consul.IOperatorEndpoint.AutopilotGetState(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotState>>
+Consul.IOperatorEndpoint.AutopilotGetState(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotState>>
+Consul.IOperatorEndpoint.AutopilotSetConfiguration(Consul.AutopilotConfiguration configuration) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.AutopilotSetConfiguration(Consul.AutopilotConfiguration configuration, Consul.WriteOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.AutopilotSetConfiguration(Consul.AutopilotConfiguration configuration, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.GetConsulLicense(string datacenter = "", System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ConsulLicense>>
+Consul.IOperatorEndpoint.KeyringInstall(string key) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.KeyringInstall(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.KeyringInstall(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.KeyringList() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KeyringResponse[]>>
+Consul.IOperatorEndpoint.KeyringList(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KeyringResponse[]>>
+Consul.IOperatorEndpoint.KeyringList(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KeyringResponse[]>>
+Consul.IOperatorEndpoint.KeyringRemove(string key) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.KeyringRemove(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.KeyringRemove(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.KeyringUse(string key) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.KeyringUse(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.KeyringUse(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.OperatorGetUsage() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.OperatorUsageInformation>>
+Consul.IOperatorEndpoint.OperatorGetUsage(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.OperatorUsageInformation>>
+Consul.IOperatorEndpoint.OperatorGetUsage(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.OperatorUsageInformation>>
+Consul.IOperatorEndpoint.RaftGetConfiguration() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RaftConfiguration>>
+Consul.IOperatorEndpoint.RaftGetConfiguration(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RaftConfiguration>>
+Consul.IOperatorEndpoint.RaftGetConfiguration(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RaftConfiguration>>
+Consul.IOperatorEndpoint.RaftRemovePeerByAddress(string address) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.RaftRemovePeerByAddress(string address, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.RaftRemovePeerByAddress(string address, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.RaftTransferLeader() -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.RaftTransferLeader(Consul.WriteOptions q) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.RaftTransferLeader(Consul.WriteOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.RaftTransferLeader(string id) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.RaftTransferLeader(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.RaftTransferLeader(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.RaftTransferLeader(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IOperatorEndpoint.SegmentList() -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.IOperatorEndpoint.SegmentList(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.IOperatorEndpoint.SegmentList(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.IPolicyEndpoint.Create(Consul.PolicyEntry policy) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.Create(Consul.PolicyEntry policy, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.Create(Consul.PolicyEntry policy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IPolicyEndpoint.Delete(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IPolicyEndpoint.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IPolicyEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry[]>>
+Consul.IPolicyEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry[]>>
+Consul.IPolicyEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry[]>>
+Consul.IPolicyEndpoint.ListTemplatedPolicies() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.TemplatedPolicyResponse>>>
+Consul.IPolicyEndpoint.ListTemplatedPolicies(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.TemplatedPolicyResponse>>>
+Consul.IPolicyEndpoint.ListTemplatedPolicies(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.TemplatedPolicyResponse>>>
+Consul.IPolicyEndpoint.PreviewTemplatedPolicy(string name) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.PreviewTemplatedPolicy(string name, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.PreviewTemplatedPolicy(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.Read(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.ReadPolicyByName(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.ReadPolicyByName(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.ReadPolicyByName(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.ReadTemplatedPolicyByName(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TemplatedPolicyResponse>>
+Consul.IPolicyEndpoint.ReadTemplatedPolicyByName(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TemplatedPolicyResponse>>
+Consul.IPolicyEndpoint.ReadTemplatedPolicyByName(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TemplatedPolicyResponse>>
+Consul.IPolicyEndpoint.Update(Consul.PolicyEntry policy) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.Update(Consul.PolicyEntry policy, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.IPolicyEndpoint.Update(Consul.PolicyEntry policy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.IPreparedQueryEndpoint.Create(Consul.PreparedQueryDefinition query) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IPreparedQueryEndpoint.Create(Consul.PreparedQueryDefinition query, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IPreparedQueryEndpoint.Create(Consul.PreparedQueryDefinition query, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.IPreparedQueryEndpoint.Delete(string queryID) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IPreparedQueryEndpoint.Delete(string queryID, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IPreparedQueryEndpoint.Delete(string queryID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IPreparedQueryEndpoint.Execute(string queryIDOrName) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExecuteResponse>>
+Consul.IPreparedQueryEndpoint.Execute(string queryIDOrName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExecuteResponse>>
+Consul.IPreparedQueryEndpoint.Execute(string queryIDOrName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExecuteResponse>>
+Consul.IPreparedQueryEndpoint.Explain(string queryIDOrName) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExplainResponse>>
+Consul.IPreparedQueryEndpoint.Explain(string queryIDOrName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExplainResponse>>
+Consul.IPreparedQueryEndpoint.Explain(string queryIDOrName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExplainResponse>>
+Consul.IPreparedQueryEndpoint.Get(string queryID) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
+Consul.IPreparedQueryEndpoint.Get(string queryID, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
+Consul.IPreparedQueryEndpoint.Get(string queryID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
+Consul.IPreparedQueryEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
+Consul.IPreparedQueryEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
+Consul.IPreparedQueryEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
+Consul.IPreparedQueryEndpoint.Update(Consul.PreparedQueryDefinition query) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IPreparedQueryEndpoint.Update(Consul.PreparedQueryDefinition query, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IPreparedQueryEndpoint.Update(Consul.PreparedQueryDefinition query, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.IRawEndpoint.Query(string endpoint, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<dynamic>>
+Consul.IRawEndpoint.Write(string endpoint, object obj, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<dynamic>>
+Consul.IRoleEndpoint.Create(Consul.RoleEntry role) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
+Consul.IRoleEndpoint.Create(Consul.RoleEntry role, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
+Consul.IRoleEndpoint.Create(Consul.RoleEntry role, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
+Consul.IRoleEndpoint.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IRoleEndpoint.Delete(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IRoleEndpoint.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.IRoleEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry[]>>
+Consul.IRoleEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry[]>>
+Consul.IRoleEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry[]>>
+Consul.IRoleEndpoint.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
+Consul.IRoleEndpoint.Read(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
+Consul.IRoleEndpoint.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
+Consul.IRoleEndpoint.ReadByName(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
+Consul.IRoleEndpoint.ReadByName(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
+Consul.IRoleEndpoint.ReadByName(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
+Consul.IRoleEndpoint.Update(Consul.RoleEntry role) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
+Consul.IRoleEndpoint.Update(Consul.RoleEntry role, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
+Consul.IRoleEndpoint.Update(Consul.RoleEntry role, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
+Consul.ISessionEndpoint.Create() -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ISessionEndpoint.Create(Consul.SessionEntry se) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ISessionEndpoint.Create(Consul.SessionEntry se, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ISessionEndpoint.Create(Consul.SessionEntry se, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ISessionEndpoint.Create(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ISessionEndpoint.CreateNoChecks() -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ISessionEndpoint.CreateNoChecks(Consul.SessionEntry se) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ISessionEndpoint.CreateNoChecks(Consul.SessionEntry se, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ISessionEndpoint.CreateNoChecks(Consul.SessionEntry se, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ISessionEndpoint.CreateNoChecks(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.ISessionEndpoint.Destroy(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.ISessionEndpoint.Destroy(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.ISessionEndpoint.Destroy(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.ISessionEndpoint.Info(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry>>
+Consul.ISessionEndpoint.Info(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry>>
+Consul.ISessionEndpoint.Info(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry>>
+Consul.ISessionEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
+Consul.ISessionEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
+Consul.ISessionEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
+Consul.ISessionEndpoint.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
+Consul.ISessionEndpoint.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
+Consul.ISessionEndpoint.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
+Consul.ISessionEndpoint.Renew(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.SessionEntry>>
+Consul.ISessionEndpoint.Renew(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.SessionEntry>>
+Consul.ISessionEndpoint.Renew(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.SessionEntry>>
+Consul.ISessionEndpoint.RenewPeriodic(System.TimeSpan initialTTL, string id, Consul.WriteOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
+Consul.ISessionEndpoint.RenewPeriodic(System.TimeSpan initialTTL, string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
+Consul.ISnapshotEndpoint.Restore(System.IO.Stream s) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ISnapshotEndpoint.Restore(System.IO.Stream s, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ISnapshotEndpoint.Restore(System.IO.Stream s, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.ISnapshotEndpoint.Save() -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
+Consul.ISnapshotEndpoint.Save(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
+Consul.ISnapshotEndpoint.Save(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
+Consul.IStatusEndpoint.Leader(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
+Consul.IStatusEndpoint.Peers(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string[]>
+Consul.ITokenEndpoint.Bootstrap() -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Bootstrap(Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Bootstrap(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Clone(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Clone(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Clone(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Create(Consul.TokenEntry token) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Create(Consul.TokenEntry token, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Create(Consul.TokenEntry token, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.ITokenEndpoint.Delete(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.ITokenEndpoint.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.ITokenEndpoint.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry[]>>
+Consul.ITokenEndpoint.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry[]>>
+Consul.ITokenEndpoint.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry[]>>
+Consul.ITokenEndpoint.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Read(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.ReadSelfToken(string token) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.ReadSelfToken(string token, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.ReadSelfToken(string token, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Update(Consul.TokenEntry token) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Update(Consul.TokenEntry token, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.ITokenEndpoint.Update(Consul.TokenEntry token, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.JSONWebKeySetConfig.Local.get -> Consul.LocalJSONWebKeySet
+Consul.JSONWebKeySetConfig.Local.set -> void
+Consul.JSONWebKeySetConfig.Remote.get -> Consul.RemoteJSONWebKeySet
+Consul.JSONWebKeySetConfig.Remote.set -> void
+Consul.JWKSClusterConfig.ConnectTimeout.get -> string
+Consul.JWKSClusterConfig.ConnectTimeout.set -> void
+Consul.JWKSClusterConfig.DiscoveryType.get -> string
+Consul.JWKSClusterConfig.DiscoveryType.set -> void
+Consul.JWKSClusterConfig.TLSCertificates.get -> Consul.TLSCertificatesConfig
+Consul.JWKSClusterConfig.TLSCertificates.set -> void
+Consul.JWTProvider.Name.get -> string
+Consul.JWTProvider.Name.set -> void
+Consul.JWTProvider.VerifyClaims.get -> Consul.VerifyClaims
+Consul.JWTProvider.VerifyClaims.set -> void
+Consul.JWTProviderEntry.Audiences.get -> System.Collections.Generic.List<string>
+Consul.JWTProviderEntry.Audiences.set -> void
+Consul.JWTProviderEntry.CacheConfig.get -> Consul.CacheConfig
+Consul.JWTProviderEntry.CacheConfig.set -> void
+Consul.JWTProviderEntry.ClockSkewSeconds.get -> string
+Consul.JWTProviderEntry.ClockSkewSeconds.set -> void
+Consul.JWTProviderEntry.Forwarding.get -> Consul.ForwardingConfig
+Consul.JWTProviderEntry.Forwarding.set -> void
+Consul.JWTProviderEntry.Issuer.get -> string
+Consul.JWTProviderEntry.Issuer.set -> void
+Consul.JWTProviderEntry.JSONWebKeySet.get -> System.Collections.Generic.List<Consul.JSONWebKeySetConfig>
+Consul.JWTProviderEntry.JSONWebKeySet.set -> void
+Consul.JWTProviderEntry.Kind.get -> string
+Consul.JWTProviderEntry.Kind.set -> void
+Consul.JWTProviderEntry.Locations.get -> System.Collections.Generic.List<Consul.ProviderLocation>
+Consul.JWTProviderEntry.Locations.set -> void
+Consul.JWTProviderEntry.Name.get -> string
+Consul.JWTProviderEntry.Name.set -> void
+Consul.JWTSettings.Providers.get -> System.Collections.Generic.List<Consul.JWTProvider>
+Consul.JWTSettings.Providers.set -> void
+Consul.KeyringResponse.Datacenter.get -> string
+Consul.KeyringResponse.Datacenter.set -> void
+Consul.KeyringResponse.Keys.get -> System.Collections.Generic.IDictionary<string, int>
+Consul.KeyringResponse.Keys.set -> void
+Consul.KV.Acquire(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.Acquire(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.Acquire(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.CAS(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.CAS(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.CAS(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.Delete(string key) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.Delete(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.Delete(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.DeleteCAS(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.DeleteCAS(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.DeleteCAS(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.DeleteTree(string prefix) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.DeleteTree(string prefix, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.DeleteTree(string prefix, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.Get(string key) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair>>
+Consul.KV.Get(string key, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair>>
+Consul.KV.Get(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair>>
+Consul.KV.Keys(string prefix) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.KV.Keys(string prefix, string separator) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.KV.Keys(string prefix, string separator, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.KV.Keys(string prefix, string separator, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.KV.Keys(string prefix, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.KV.KV(Consul.ConsulClient c) -> void
+Consul.KV.List(string prefix) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair[]>>
+Consul.KV.List(string prefix, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair[]>>
+Consul.KV.List(string prefix, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KVPair[]>>
+Consul.KV.Put(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.Put(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.Put(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.Release(Consul.KVPair p) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.Release(Consul.KVPair p, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.Release(Consul.KVPair p, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.KV.Txn(System.Collections.Generic.List<Consul.KVTxnOp> txn) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.KVTxnResponse>>
+Consul.KV.Txn(System.Collections.Generic.List<Consul.KVTxnOp> txn, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.KVTxnResponse>>
+Consul.KV.Txn(System.Collections.Generic.List<Consul.KVTxnOp> txn, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.KVTxnResponse>>
+Consul.KVPair.Key.get -> string
+Consul.KVPair.Key.set -> void
+Consul.KVPair.KVPair(string key) -> void
+Consul.KVPair.Session.get -> string
+Consul.KVPair.Session.set -> void
+Consul.KVPair.Value.get -> byte[]
+Consul.KVPair.Value.set -> void
+Consul.KVTxnOp.Key.get -> string
+Consul.KVTxnOp.Key.set -> void
+Consul.KVTxnOp.KVTxnOp(string key, Consul.KVTxnVerb verb) -> void
+Consul.KVTxnOp.Session.get -> string
+Consul.KVTxnOp.Session.set -> void
+Consul.KVTxnOp.Value.get -> byte[]
+Consul.KVTxnOp.Value.set -> void
+Consul.KVTxnOp.Verb.get -> Consul.KVTxnVerb
+Consul.KVTxnOp.Verb.set -> void
+Consul.KVTxnResponse.Errors.get -> System.Collections.Generic.List<Consul.TxnError>
+Consul.KVTxnResponse.Results.get -> System.Collections.Generic.List<Consul.KVPair>
+Consul.KVTxnVerb.Equals(Consul.KVTxnVerb other) -> bool
+Consul.KVTxnVerb.Operation.get -> string
+Consul.License.CustomerId.get -> string
+Consul.License.CustomerId.set -> void
+Consul.License.ExpirationTime.get -> string
+Consul.License.ExpirationTime.set -> void
+Consul.License.Features.get -> string[]
+Consul.License.Features.set -> void
+Consul.License.Flags.get -> Consul.Flags
+Consul.License.Flags.set -> void
+Consul.License.InstallationId.get -> string
+Consul.License.InstallationId.set -> void
+Consul.License.IssueTime.get -> string
+Consul.License.IssueTime.set -> void
+Consul.License.LicenseId.get -> string
+Consul.License.LicenseId.set -> void
+Consul.License.Product.get -> string
+Consul.License.Product.set -> void
+Consul.License.StartTime.get -> string
+Consul.License.StartTime.set -> void
+Consul.LinkedService.CAFile.get -> string
+Consul.LinkedService.CAFile.set -> void
+Consul.LinkedService.CertFile.get -> string
+Consul.LinkedService.CertFile.set -> void
+Consul.LinkedService.KeyFile.get -> string
+Consul.LinkedService.KeyFile.set -> void
+Consul.LinkedService.Name.get -> string
+Consul.LinkedService.Name.set -> void
+Consul.LinkedService.Namespace.get -> string
+Consul.LinkedService.Namespace.set -> void
+Consul.LinkedService.SNI.get -> string
+Consul.LinkedService.SNI.set -> void
+Consul.LoadBalancerConfig.CookieConfig.get -> Consul.CookieConfig
+Consul.LoadBalancerConfig.CookieConfig.set -> void
+Consul.LoadBalancerConfig.HashPolicies.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.LoadBalancerConfig.HashPolicies.set -> void
+Consul.LoadBalancerConfig.LeastRequestConfig.get -> Consul.LeastRequestConfig
+Consul.LoadBalancerConfig.LeastRequestConfig.set -> void
+Consul.LoadBalancerConfig.Policy.get -> string
+Consul.LoadBalancerConfig.Policy.set -> void
+Consul.LoadBalancerConfig.RingHashConfig.get -> Consul.RingHashConfig
+Consul.LoadBalancerConfig.RingHashConfig.set -> void
+Consul.LocalJSONWebKeySet.Filename.get -> string
+Consul.LocalJSONWebKeySet.Filename.set -> void
+Consul.LocalJSONWebKeySet.JWKS.get -> string
+Consul.LocalJSONWebKeySet.JWKS.set -> void
+Consul.LocalServiceHealth.AggregatedStatus.get -> Consul.HealthStatus
+Consul.LocalServiceHealth.AggregatedStatus.set -> void
+Consul.LocalServiceHealth.Checks.get -> Consul.AgentCheck[]
+Consul.LocalServiceHealth.Checks.set -> void
+Consul.LocalServiceHealth.Service.get -> Consul.AgentService
+Consul.LocalServiceHealth.Service.set -> void
+Consul.Lock.Acquire() -> System.Threading.Tasks.Task<System.Threading.CancellationToken>
+Consul.Lock.Acquire(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Threading.CancellationToken>
+Consul.Lock.Destroy(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.Lock.Release(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.LockConflictException.LockConflictException(string message) -> void
+Consul.LockConflictException.LockConflictException(string message, System.Exception inner) -> void
+Consul.LockHeldException.LockHeldException(string message) -> void
+Consul.LockHeldException.LockHeldException(string message, System.Exception inner) -> void
+Consul.LockInUseException.LockInUseException(string message) -> void
+Consul.LockInUseException.LockInUseException(string message, System.Exception inner) -> void
+Consul.LockMaxAttemptsReachedException.LockMaxAttemptsReachedException(string message) -> void
+Consul.LockMaxAttemptsReachedException.LockMaxAttemptsReachedException(string message, System.Exception inner) -> void
+Consul.LockNotHeldException.LockNotHeldException(string message) -> void
+Consul.LockNotHeldException.LockNotHeldException(string message, System.Exception inner) -> void
+Consul.LockOptions.Key.get -> string
+Consul.LockOptions.Key.set -> void
+Consul.LockOptions.LockOptions(string key) -> void
+Consul.LockOptions.Session.get -> string
+Consul.LockOptions.Session.set -> void
+Consul.LockOptions.SessionName.get -> string
+Consul.LockOptions.SessionName.set -> void
+Consul.LockOptions.Value.get -> byte[]
+Consul.LockOptions.Value.set -> void
+Consul.MapConfig.Header.get -> System.Collections.Generic.List<Consul.HeaderConfig>
+Consul.MapConfig.Header.set -> void
+Consul.MapConfig.Methods.get -> System.Collections.Generic.List<string>
+Consul.MapConfig.Methods.set -> void
+Consul.MapConfig.PathExact.get -> string
+Consul.MapConfig.PathExact.set -> void
+Consul.MapConfig.PathPrefix.get -> string
+Consul.MapConfig.PathPrefix.set -> void
+Consul.MapConfig.PathRegex.get -> string
+Consul.MapConfig.PathRegex.set -> void
+Consul.MapConfig.QueryParam.get -> System.Collections.Generic.List<Consul.QueryParamConfig>
+Consul.MapConfig.QueryParam.set -> void
+Consul.MeshEntry.HTTP.get -> Consul.HTTPConfig
+Consul.MeshEntry.HTTP.set -> void
+Consul.MeshEntry.Incoming.get -> Consul.TLSDirectionConfig
+Consul.MeshEntry.Incoming.set -> void
+Consul.MeshEntry.Kind.get -> string
+Consul.MeshEntry.Kind.set -> void
+Consul.MeshEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.MeshEntry.Meta.set -> void
+Consul.MeshEntry.Namespace.get -> string
+Consul.MeshEntry.Namespace.set -> void
+Consul.MeshEntry.Outgoing.get -> Consul.TLSDirectionConfig
+Consul.MeshEntry.Outgoing.set -> void
+Consul.MeshEntry.Partition.get -> string
+Consul.MeshEntry.Partition.set -> void
+Consul.MeshEntry.Peering.get -> Consul.PeeringMeshConfig
+Consul.MeshEntry.Peering.set -> void
+Consul.MeshEntry.TLS.get -> Consul.TLSConfig
+Consul.MeshEntry.TLS.set -> void
+Consul.MeshEntry.TransparentProxy.get -> Consul.TransparentProxyConfig
+Consul.MeshEntry.TransparentProxy.set -> void
+Consul.MeshGatewayConfig.Mode.get -> string
+Consul.MeshGatewayConfig.Mode.set -> void
+Consul.Metrics.Counters.get -> System.Collections.Generic.List<Consul.Counter>
+Consul.Metrics.Counters.set -> void
+Consul.Metrics.Gauges.get -> System.Collections.Generic.List<Consul.Gauge>
+Consul.Metrics.Gauges.set -> void
+Consul.Metrics.Points.get -> System.Collections.Generic.List<Consul.Point>
+Consul.Metrics.Points.set -> void
+Consul.Metrics.Samples.get -> System.Collections.Generic.List<Consul.Sample>
+Consul.Metrics.Samples.set -> void
+Consul.Metrics.Timestamp.get -> string
+Consul.Metrics.Timestamp.set -> void
+Consul.Namespace.ACLs.get -> Consul.NamespaceACLConfig
+Consul.Namespace.ACLs.set -> void
+Consul.Namespace.Description.get -> string
+Consul.Namespace.Description.set -> void
+Consul.Namespace.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.Namespace.Meta.set -> void
+Consul.Namespace.Name.get -> string
+Consul.Namespace.Name.set -> void
+Consul.NamespaceACLConfig.PolicyDefaults.get -> System.Collections.Generic.List<Consul.AuthMethodEntry>
+Consul.NamespaceACLConfig.PolicyDefaults.set -> void
+Consul.NamespaceACLConfig.RoleDefaults.get -> System.Collections.Generic.List<Consul.AuthMethodEntry>
+Consul.NamespaceACLConfig.RoleDefaults.set -> void
+Consul.Namespaces.Create(Consul.Namespace ns) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
+Consul.Namespaces.Create(Consul.Namespace ns, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
+Consul.Namespaces.Create(Consul.Namespace ns, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
+Consul.Namespaces.Delete(string name) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Namespaces.Delete(string name, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Namespaces.Delete(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Namespaces.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse[]>>
+Consul.Namespaces.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse[]>>
+Consul.Namespaces.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse[]>>
+Consul.Namespaces.Read(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse>>
+Consul.Namespaces.Read(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse>>
+Consul.Namespaces.Read(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.NamespaceResponse>>
+Consul.Namespaces.Update(Consul.Namespace ns) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
+Consul.Namespaces.Update(Consul.Namespace ns, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
+Consul.Namespaces.Update(Consul.Namespace ns, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.NamespaceResponse>>
+Consul.Node.Address.get -> string
+Consul.Node.Address.set -> void
+Consul.Node.Datacenter.get -> string
+Consul.Node.Datacenter.set -> void
+Consul.Node.Name.get -> string
+Consul.Node.Name.set -> void
+Consul.Node.TaggedAddresses.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.Node.TaggedAddresses.set -> void
+Consul.NodeIdentity.Datacenter.get -> string
+Consul.NodeIdentity.Datacenter.set -> void
+Consul.NodeIdentity.NodeIdentity(string nodeName, string datacenter) -> void
+Consul.NodeIdentity.NodeName.get -> string
+Consul.NodeIdentity.NodeName.set -> void
+Consul.NodeInfo.Address.get -> string
+Consul.NodeInfo.Address.set -> void
+Consul.NodeInfo.Datacenter.get -> string
+Consul.NodeInfo.Datacenter.set -> void
+Consul.NodeInfo.ID.get -> string
+Consul.NodeInfo.ID.set -> void
+Consul.NodeInfo.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.NodeInfo.Meta.set -> void
+Consul.NodeInfo.Node.get -> string
+Consul.NodeInfo.Node.set -> void
+Consul.NodeInfo.TaggedAddresses.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.NodeInfo.TaggedAddresses.set -> void
+Consul.NodeService.Node.get -> Consul.NodeInfo
+Consul.NodeService.Node.set -> void
+Consul.NodeService.Services.get -> System.Collections.Generic.List<Consul.ServiceInfo>
+Consul.NodeService.Services.set -> void
+Consul.Operator.AreaCreate(Consul.AreaRequest area) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Operator.AreaCreate(Consul.AreaRequest area, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Operator.AreaCreate(Consul.AreaRequest area, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Operator.AreaDelete(string areaId) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.AreaDelete(string areaId, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.AreaDelete(string areaId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.AreaGet(string areaId) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Area[]>>
+Consul.Operator.AreaGet(string areaId, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Area[]>>
+Consul.Operator.AreaGet(string areaId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.Area[]>>
+Consul.Operator.AreaList() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<Consul.Area>>>
+Consul.Operator.AreaList(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<Consul.Area>>>
+Consul.Operator.AreaList(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.List<Consul.Area>>>
+Consul.Operator.AreaUpdate(Consul.AreaRequest area, string areaId) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Operator.AreaUpdate(Consul.AreaRequest area, string areaId, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Operator.AreaUpdate(Consul.AreaRequest area, string areaId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Operator.AutopilotGetConfiguration() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotConfiguration>>
+Consul.Operator.AutopilotGetConfiguration(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotConfiguration>>
+Consul.Operator.AutopilotGetConfiguration(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotConfiguration>>
+Consul.Operator.AutopilotGetHealth() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotHealth>>
+Consul.Operator.AutopilotGetHealth(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotHealth>>
+Consul.Operator.AutopilotGetHealth(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotHealth>>
+Consul.Operator.AutopilotGetState() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotState>>
+Consul.Operator.AutopilotGetState(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotState>>
+Consul.Operator.AutopilotGetState(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.AutopilotState>>
+Consul.Operator.AutopilotSetConfiguration(Consul.AutopilotConfiguration configuration) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.AutopilotSetConfiguration(Consul.AutopilotConfiguration configuration, Consul.WriteOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.AutopilotSetConfiguration(Consul.AutopilotConfiguration configuration, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.GetConsulLicense(string datacenter = "", System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.ConsulLicense>>
+Consul.Operator.KeyringInstall(string key) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.KeyringInstall(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.KeyringInstall(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.KeyringList() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KeyringResponse[]>>
+Consul.Operator.KeyringList(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KeyringResponse[]>>
+Consul.Operator.KeyringList(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.KeyringResponse[]>>
+Consul.Operator.KeyringRemove(string key) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.KeyringRemove(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.KeyringRemove(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.KeyringUse(string key) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.KeyringUse(string key, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.KeyringUse(string key, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.OperatorGetUsage() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.OperatorUsageInformation>>
+Consul.Operator.OperatorGetUsage(Consul.QueryOptions q, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.OperatorUsageInformation>>
+Consul.Operator.OperatorGetUsage(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.OperatorUsageInformation>>
+Consul.Operator.RaftGetConfiguration() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RaftConfiguration>>
+Consul.Operator.RaftGetConfiguration(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RaftConfiguration>>
+Consul.Operator.RaftGetConfiguration(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RaftConfiguration>>
+Consul.Operator.RaftRemovePeerByAddress(string address) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.RaftRemovePeerByAddress(string address, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.RaftRemovePeerByAddress(string address, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.RaftTransferLeader() -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.RaftTransferLeader(Consul.WriteOptions q) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.RaftTransferLeader(Consul.WriteOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.RaftTransferLeader(string id) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.RaftTransferLeader(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.RaftTransferLeader(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.RaftTransferLeader(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Operator.SegmentList() -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.Operator.SegmentList(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.Operator.SegmentList(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<string[]>>
+Consul.OperatorUsageInformation.Usage.get -> System.Collections.Generic.Dictionary<string, Consul.DatacenterUsage>
+Consul.OperatorUsageInformation.Usage.set -> void
+Consul.OverrideConfig.BalanceOutboundConnections.get -> string
+Consul.OverrideConfig.BalanceOutboundConnections.set -> void
+Consul.OverrideConfig.Limits.get -> Consul.LimitsConfig
+Consul.OverrideConfig.Limits.set -> void
+Consul.OverrideConfig.MeshGateway.get -> Consul.MeshGatewayConfig
+Consul.OverrideConfig.MeshGateway.set -> void
+Consul.OverrideConfig.Name.get -> string
+Consul.OverrideConfig.Name.set -> void
+Consul.OverrideConfig.Namespace.get -> string
+Consul.OverrideConfig.Namespace.set -> void
+Consul.OverrideConfig.PassiveHealthCheck.get -> Consul.PassiveHealthCheckConfig
+Consul.OverrideConfig.PassiveHealthCheck.set -> void
+Consul.OverrideConfig.Peer.get -> string
+Consul.OverrideConfig.Peer.set -> void
+Consul.OverrideConfig.Protocol.get -> string
+Consul.OverrideConfig.Protocol.set -> void
+Consul.PassiveHealthCheckConfig.BaseEjectionTime.get -> string
+Consul.PassiveHealthCheckConfig.BaseEjectionTime.set -> void
+Consul.PassiveHealthCheckConfig.Interval.get -> string
+Consul.PassiveHealthCheckConfig.Interval.set -> void
+Consul.PathConfig.Path.get -> string
+Consul.PathConfig.Path.set -> void
+Consul.PathConfig.Protocol.get -> string
+Consul.PathConfig.Protocol.set -> void
+Consul.PeeringRemoteInfo.Datacenter.get -> string
+Consul.PeeringRemoteInfo.Datacenter.set -> void
+Consul.PeeringRemoteInfo.Partition.get -> string
+Consul.PeeringRemoteInfo.Partition.set -> void
+Consul.PeeringStreamStatus.ExportedServices.get -> System.Collections.Generic.List<string>
+Consul.PeeringStreamStatus.ExportedServices.set -> void
+Consul.PeeringStreamStatus.ImportedServices.get -> System.Collections.Generic.List<string>
+Consul.PeeringStreamStatus.ImportedServices.set -> void
+Consul.Point.Labels.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.Point.Labels.set -> void
+Consul.Point.Name.get -> string
+Consul.Point.Name.set -> void
+Consul.Policy.Create(Consul.PolicyEntry policy) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.Policy.Create(Consul.PolicyEntry policy, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.Policy.Create(Consul.PolicyEntry policy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.Policy.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Policy.Delete(string id, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Policy.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Policy.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry[]>>
+Consul.Policy.List(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry[]>>
+Consul.Policy.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry[]>>
+Consul.Policy.ListTemplatedPolicies() -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.TemplatedPolicyResponse>>>
+Consul.Policy.ListTemplatedPolicies(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.TemplatedPolicyResponse>>>
+Consul.Policy.ListTemplatedPolicies(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.Collections.Generic.Dictionary<string, Consul.TemplatedPolicyResponse>>>
+Consul.Policy.PreviewTemplatedPolicy(string name) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.Policy.PreviewTemplatedPolicy(string name, Consul.WriteOptions options, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.Policy.PreviewTemplatedPolicy(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.Policy.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
+Consul.Policy.Read(string id, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
+Consul.Policy.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
+Consul.Policy.ReadPolicyByName(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
+Consul.Policy.ReadPolicyByName(string name, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
+Consul.Policy.ReadPolicyByName(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PolicyEntry>>
+Consul.Policy.ReadTemplatedPolicyByName(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TemplatedPolicyResponse>>
+Consul.Policy.ReadTemplatedPolicyByName(string name, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TemplatedPolicyResponse>>
+Consul.Policy.ReadTemplatedPolicyByName(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TemplatedPolicyResponse>>
+Consul.Policy.Update(Consul.PolicyEntry policy) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.Policy.Update(Consul.PolicyEntry policy, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.Policy.Update(Consul.PolicyEntry policy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.PolicyEntry>>
+Consul.PolicyEntry.Datacenters.get -> string[]
+Consul.PolicyEntry.Datacenters.set -> void
+Consul.PolicyEntry.Description.get -> string
+Consul.PolicyEntry.Description.set -> void
+Consul.PolicyEntry.ID.get -> string
+Consul.PolicyEntry.ID.set -> void
+Consul.PolicyEntry.Name.get -> string
+Consul.PolicyEntry.Name.set -> void
+Consul.PolicyEntry.PolicyEntry(string id) -> void
+Consul.PolicyEntry.PolicyEntry(string id, string name) -> void
+Consul.PolicyEntry.PolicyEntry(string id, string name, string description, string rules, string[] datacenters) -> void
+Consul.PolicyEntry.Rules.get -> string
+Consul.PolicyEntry.Rules.set -> void
+Consul.PolicyLink.ID.get -> string
+Consul.PolicyLink.ID.set -> void
+Consul.PolicyLink.Name.get -> string
+Consul.PolicyLink.Name.set -> void
+Consul.PolicyLink.PolicyLink(string id) -> void
+Consul.PolicyLink.PolicyLink(string id, string name) -> void
+Consul.PostRequest.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.PostRequest.Options.get -> Consul.WriteOptions
+Consul.PostRequest.Options.set -> void
+Consul.PostRequest.PostRequest(Consul.ConsulClient client, string url, string body, Consul.WriteOptions options = null) -> void
+Consul.PostRequest<TIn, TOut>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<TOut>>
+Consul.PostRequest<TIn, TOut>.Options.get -> Consul.WriteOptions
+Consul.PostRequest<TIn, TOut>.Options.set -> void
+Consul.PostRequest<TIn, TOut>.PostRequest(Consul.ConsulClient client, string url, TIn body, Consul.WriteOptions options = null) -> void
+Consul.PostRequest<TIn>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.PostRequest<TIn>.Options.get -> Consul.WriteOptions
+Consul.PostRequest<TIn>.Options.set -> void
+Consul.PostRequest<TIn>.PostRequest(Consul.ConsulClient client, string url, TIn body, Consul.WriteOptions options = null) -> void
+Consul.PostReturningRequest<TOut>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<TOut>>
+Consul.PostReturningRequest<TOut>.Options.get -> Consul.WriteOptions
+Consul.PostReturningRequest<TOut>.Options.set -> void
+Consul.PostReturningRequest<TOut>.PostReturningRequest(Consul.ConsulClient client, string url, Consul.WriteOptions options = null) -> void
+Consul.PreparedQuery.Create(Consul.PreparedQueryDefinition query) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.PreparedQuery.Create(Consul.PreparedQueryDefinition query, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.PreparedQuery.Create(Consul.PreparedQueryDefinition query, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.PreparedQuery.Delete(string queryID) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.PreparedQuery.Delete(string queryID, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.PreparedQuery.Delete(string queryID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.PreparedQuery.Execute(string queryIDOrName) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExecuteResponse>>
+Consul.PreparedQuery.Execute(string queryIDOrName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExecuteResponse>>
+Consul.PreparedQuery.Execute(string queryIDOrName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExecuteResponse>>
+Consul.PreparedQuery.Explain(string queryIDOrName) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExplainResponse>>
+Consul.PreparedQuery.Explain(string queryIDOrName, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExplainResponse>>
+Consul.PreparedQuery.Explain(string queryIDOrName, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryExplainResponse>>
+Consul.PreparedQuery.Get(string queryID) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
+Consul.PreparedQuery.Get(string queryID, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
+Consul.PreparedQuery.Get(string queryID, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
+Consul.PreparedQuery.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
+Consul.PreparedQuery.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
+Consul.PreparedQuery.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.PreparedQueryDefinition[]>>
+Consul.PreparedQuery.Update(Consul.PreparedQueryDefinition query) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.PreparedQuery.Update(Consul.PreparedQueryDefinition query, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.PreparedQuery.Update(Consul.PreparedQueryDefinition query, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.PreparedQueryDefinition.DNS.get -> Consul.QueryDNSOptions
+Consul.PreparedQueryDefinition.DNS.set -> void
+Consul.PreparedQueryDefinition.ID.get -> string
+Consul.PreparedQueryDefinition.ID.set -> void
+Consul.PreparedQueryDefinition.Name.get -> string
+Consul.PreparedQueryDefinition.Name.set -> void
+Consul.PreparedQueryDefinition.Service.get -> Consul.ServiceQuery
+Consul.PreparedQueryDefinition.Service.set -> void
+Consul.PreparedQueryDefinition.Session.get -> string
+Consul.PreparedQueryDefinition.Session.set -> void
+Consul.PreparedQueryDefinition.Template.get -> Consul.QueryTemplate
+Consul.PreparedQueryDefinition.Template.set -> void
+Consul.PreparedQueryDefinition.Token.get -> string
+Consul.PreparedQueryDefinition.Token.set -> void
+Consul.PreparedQueryExecuteResponse.Datacenter.get -> string
+Consul.PreparedQueryExecuteResponse.Datacenter.set -> void
+Consul.PreparedQueryExecuteResponse.DNS.get -> Consul.QueryDNSOptions
+Consul.PreparedQueryExecuteResponse.DNS.set -> void
+Consul.PreparedQueryExecuteResponse.Nodes.get -> Consul.ServiceEntry[]
+Consul.PreparedQueryExecuteResponse.Nodes.set -> void
+Consul.PreparedQueryExecuteResponse.Service.get -> string
+Consul.PreparedQueryExecuteResponse.Service.set -> void
+Consul.PreparedQueryExplainResponse.Query.get -> Consul.PreparedQueryDefinition
+Consul.PreparedQueryExplainResponse.Query.set -> void
+Consul.Provider.Action.get -> string
+Consul.Provider.Action.set -> void
+Consul.Provider.HTTP.get -> System.Collections.Generic.Dictionary<string, object>
+Consul.Provider.HTTP.set -> void
+Consul.Provider.Name.get -> string
+Consul.Provider.Name.set -> void
+Consul.Provider.Namespace.get -> string
+Consul.Provider.Namespace.set -> void
+Consul.Provider.Partition.get -> string
+Consul.Provider.Partition.set -> void
+Consul.Provider.Peer.get -> string
+Consul.Provider.Peer.set -> void
+Consul.Provider.Permissions.get -> System.Collections.Generic.List<string>
+Consul.Provider.Permissions.set -> void
+Consul.Provider.SamenessGroup.get -> string
+Consul.Provider.SamenessGroup.set -> void
+Consul.Provider.Sources.get -> System.Collections.Generic.List<string>
+Consul.Provider.Sources.set -> void
+Consul.Provider.VerifyClaims.get -> System.Collections.Generic.List<Consul.VerifyClaim>
+Consul.Provider.VerifyClaims.set -> void
+Consul.ProviderLocation.Cookie.get -> Consul.CookieLocation
+Consul.ProviderLocation.Cookie.set -> void
+Consul.ProviderLocation.Header.get -> Consul.HeaderLocation
+Consul.ProviderLocation.Header.set -> void
+Consul.ProviderLocation.QueryParam.get -> Consul.QueryParamLocation
+Consul.ProviderLocation.QueryParam.set -> void
+Consul.Proxy.Config.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.Proxy.Config.set -> void
+Consul.Proxy.DestinationServiceID.get -> string
+Consul.Proxy.DestinationServiceID.set -> void
+Consul.Proxy.DestinationServiceName.get -> string
+Consul.Proxy.DestinationServiceName.set -> void
+Consul.Proxy.LocalServiceAddress.get -> string
+Consul.Proxy.LocalServiceAddress.set -> void
+Consul.Proxy.Mode.get -> string
+Consul.Proxy.Mode.set -> void
+Consul.Proxy.TransparentProxy.get -> Consul.TransparentProxy
+Consul.Proxy.TransparentProxy.set -> void
+Consul.Proxy.Upstreams.get -> System.Collections.Generic.List<Consul.Upstream>
+Consul.Proxy.Upstreams.set -> void
+Consul.ProxyDefaultEntry.AccessLogs.get -> Consul.AccessLogsConfig
+Consul.ProxyDefaultEntry.AccessLogs.set -> void
+Consul.ProxyDefaultEntry.Config.get -> System.Collections.Generic.Dictionary<string, object>
+Consul.ProxyDefaultEntry.Config.set -> void
+Consul.ProxyDefaultEntry.EnvoyExtensions.get -> System.Collections.Generic.List<Consul.EnvoyExtension>
+Consul.ProxyDefaultEntry.EnvoyExtensions.set -> void
+Consul.ProxyDefaultEntry.Expose.get -> Consul.ExposeConfig
+Consul.ProxyDefaultEntry.Expose.set -> void
+Consul.ProxyDefaultEntry.Kind.get -> string
+Consul.ProxyDefaultEntry.Kind.set -> void
+Consul.ProxyDefaultEntry.MeshGateway.get -> Consul.MeshGatewayConfig
+Consul.ProxyDefaultEntry.MeshGateway.set -> void
+Consul.ProxyDefaultEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ProxyDefaultEntry.Meta.set -> void
+Consul.ProxyDefaultEntry.Mode.get -> string
+Consul.ProxyDefaultEntry.Mode.set -> void
+Consul.ProxyDefaultEntry.MutualTLSMode.get -> string
+Consul.ProxyDefaultEntry.MutualTLSMode.set -> void
+Consul.ProxyDefaultEntry.Name.get -> string
+Consul.ProxyDefaultEntry.Name.set -> void
+Consul.ProxyDefaultEntry.Namespace.get -> string
+Consul.ProxyDefaultEntry.Namespace.set -> void
+Consul.ProxyDefaultEntry.TransparentProxy.get -> Consul.TransparentProxyConfig
+Consul.ProxyDefaultEntry.TransparentProxy.set -> void
+Consul.PutNothingRequest.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.PutNothingRequest.Options.get -> Consul.WriteOptions
+Consul.PutNothingRequest.Options.set -> void
+Consul.PutNothingRequest.PutNothingRequest(Consul.ConsulClient client, string url, Consul.WriteOptions options = null) -> void
+Consul.PutRequest<TIn, TOut>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<TOut>>
+Consul.PutRequest<TIn, TOut>.Options.get -> Consul.WriteOptions
+Consul.PutRequest<TIn, TOut>.Options.set -> void
+Consul.PutRequest<TIn, TOut>.PutRequest(Consul.ConsulClient client, string url, TIn body, Consul.WriteOptions options = null) -> void
+Consul.PutRequest<TIn>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.PutRequest<TIn>.Options.get -> Consul.WriteOptions
+Consul.PutRequest<TIn>.Options.set -> void
+Consul.PutRequest<TIn>.PutRequest(Consul.ConsulClient client, string url, TIn body, Consul.WriteOptions options = null) -> void
+Consul.PutReturningRequest<TOut>.Execute(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<TOut>>
+Consul.PutReturningRequest<TOut>.Options.get -> Consul.WriteOptions
+Consul.PutReturningRequest<TOut>.Options.set -> void
+Consul.PutReturningRequest<TOut>.PutReturningRequest(Consul.ConsulClient client, string url, Consul.WriteOptions options = null) -> void
+Consul.QueryDatacenterOptions.Datacenters.get -> System.Collections.Generic.List<string>
+Consul.QueryDatacenterOptions.Datacenters.set -> void
+Consul.QueryOptions.Datacenter.get -> string
+Consul.QueryOptions.Datacenter.set -> void
+Consul.QueryOptions.Namespace.get -> string
+Consul.QueryOptions.Namespace.set -> void
+Consul.QueryOptions.Near.get -> string
+Consul.QueryOptions.Near.set -> void
+Consul.QueryOptions.Token.get -> string
+Consul.QueryOptions.Token.set -> void
+Consul.QueryParamConfig.Exact.get -> string
+Consul.QueryParamConfig.Exact.set -> void
+Consul.QueryParamConfig.Name.get -> string
+Consul.QueryParamConfig.Name.set -> void
+Consul.QueryParamConfig.Regex.get -> string
+Consul.QueryParamConfig.Regex.set -> void
+Consul.QueryParamLocation.Name.get -> string
+Consul.QueryParamLocation.Name.set -> void
+Consul.QueryResult.QueryResult(Consul.QueryResult other) -> void
+Consul.QueryResult<T>.QueryResult(Consul.QueryResult other) -> void
+Consul.QueryResult<T>.QueryResult(Consul.QueryResult other, T value) -> void
+Consul.QueryTemplate.Regexp.get -> string
+Consul.QueryTemplate.Regexp.set -> void
+Consul.QueryTemplate.Type.get -> string
+Consul.QueryTemplate.Type.set -> void
+Consul.RaftConfiguration.Servers.get -> System.Collections.Generic.List<Consul.RaftServer>
+Consul.RaftConfiguration.Servers.set -> void
+Consul.RaftServer.Address.get -> string
+Consul.RaftServer.Address.set -> void
+Consul.RaftServer.ID.get -> string
+Consul.RaftServer.ID.set -> void
+Consul.RaftServer.Node.get -> string
+Consul.RaftServer.Node.set -> void
+Consul.RateLimitsConfig.InstanceLevel.get -> Consul.InstanceLevelConfig
+Consul.RateLimitsConfig.InstanceLevel.set -> void
+Consul.Raw.Query(string endpoint, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<dynamic>>
+Consul.Raw.Write(string endpoint, object obj, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<dynamic>>
+Consul.RemoteJSONWebKeySet.CacheDuration.get -> string
+Consul.RemoteJSONWebKeySet.CacheDuration.set -> void
+Consul.RemoteJSONWebKeySet.JWKSCluster.get -> Consul.JWKSClusterConfig
+Consul.RemoteJSONWebKeySet.JWKSCluster.set -> void
+Consul.RemoteJSONWebKeySet.RequestTimeoutMs.get -> string
+Consul.RemoteJSONWebKeySet.RequestTimeoutMs.set -> void
+Consul.RemoteJSONWebKeySet.RetryPolicy.get -> Consul.RetryPolicyConfig
+Consul.RemoteJSONWebKeySet.RetryPolicy.set -> void
+Consul.RemoteJSONWebKeySet.URI.get -> string
+Consul.RemoteJSONWebKeySet.URI.set -> void
+Consul.ResolvedConsumers.Partitions.get -> System.Collections.Generic.List<string>
+Consul.ResolvedConsumers.Partitions.set -> void
+Consul.ResolvedConsumers.Peers.get -> System.Collections.Generic.List<string>
+Consul.ResolvedConsumers.Peers.set -> void
+Consul.ResolvedExportedService.Consumers.get -> Consul.ResolvedConsumers
+Consul.ResolvedExportedService.Consumers.set -> void
+Consul.ResolvedExportedService.Namespace.get -> string
+Consul.ResolvedExportedService.Namespace.set -> void
+Consul.ResolvedExportedService.Partition.get -> string
+Consul.ResolvedExportedService.Partition.set -> void
+Consul.ResolvedExportedService.Service.get -> string
+Consul.ResolvedExportedService.Service.set -> void
+Consul.RetryPolicyBackOffConfig.BaseInterval.get -> string
+Consul.RetryPolicyBackOffConfig.BaseInterval.set -> void
+Consul.RetryPolicyBackOffConfig.MaxInterval.get -> string
+Consul.RetryPolicyBackOffConfig.MaxInterval.set -> void
+Consul.RetryPolicyConfig.NumRetries.get -> string
+Consul.RetryPolicyConfig.NumRetries.set -> void
+Consul.RetryPolicyConfig.RetryPolicyBackOff.get -> Consul.RetryPolicyBackOffConfig
+Consul.RetryPolicyConfig.RetryPolicyBackOff.set -> void
+Consul.Role.Create(Consul.RoleEntry policy) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
+Consul.Role.Create(Consul.RoleEntry policy, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
+Consul.Role.Create(Consul.RoleEntry policy, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
+Consul.Role.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Role.Delete(string id, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Role.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Role.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry[]>>
+Consul.Role.List(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry[]>>
+Consul.Role.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry[]>>
+Consul.Role.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
+Consul.Role.Read(string id, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
+Consul.Role.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
+Consul.Role.ReadByName(string name) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
+Consul.Role.ReadByName(string name, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
+Consul.Role.ReadByName(string name, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.RoleEntry>>
+Consul.Role.Update(Consul.RoleEntry role) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
+Consul.Role.Update(Consul.RoleEntry role, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
+Consul.Role.Update(Consul.RoleEntry role, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.RoleEntry>>
+Consul.RoleEntry.Description.get -> string
+Consul.RoleEntry.Description.set -> void
+Consul.RoleEntry.ID.get -> string
+Consul.RoleEntry.ID.set -> void
+Consul.RoleEntry.Name.get -> string
+Consul.RoleEntry.Name.set -> void
+Consul.RoleEntry.NodeIdentities.get -> Consul.NodeIdentity[]
+Consul.RoleEntry.NodeIdentities.set -> void
+Consul.RoleEntry.Policies.get -> Consul.PolicyLink[]
+Consul.RoleEntry.Policies.set -> void
+Consul.RoleEntry.RoleEntry(string id, string name, string description) -> void
+Consul.RoleEntry.RoleEntry(string id, string name, string description, Consul.PolicyLink[] policies) -> void
+Consul.RoleEntry.RoleEntry(string id, string name, string description, Consul.PolicyLink[] policies, Consul.ServiceIdentity[] serviceIdentities) -> void
+Consul.RoleEntry.RoleEntry(string id, string name, string description, Consul.ServiceIdentity[] serviceIdentities) -> void
+Consul.RoleEntry.RoleEntry(string name) -> void
+Consul.RoleEntry.RoleEntry(string name, string description) -> void
+Consul.RoleEntry.ServiceIdentities.get -> Consul.ServiceIdentity[]
+Consul.RoleEntry.ServiceIdentities.set -> void
+Consul.RoleLink.ID.get -> string
+Consul.RoleLink.ID.set -> void
+Consul.RoleLink.Name.get -> string
+Consul.RoleLink.Name.set -> void
+Consul.RoleLink.RoleLink(string id) -> void
+Consul.RoleLink.RoleLink(string id, string name) -> void
+Consul.Root.ExternalTrustDomain.get -> string
+Consul.Root.ExternalTrustDomain.set -> void
+Consul.Root.ID.get -> string
+Consul.Root.ID.set -> void
+Consul.Root.IntermediateCerts.get -> System.Collections.Generic.List<string>
+Consul.Root.IntermediateCerts.set -> void
+Consul.Root.Name.get -> string
+Consul.Root.Name.set -> void
+Consul.Root.NotAfter.get -> string
+Consul.Root.NotAfter.set -> void
+Consul.Root.NotBefore.get -> string
+Consul.Root.NotBefore.set -> void
+Consul.Root.PrivateKeyType.get -> string
+Consul.Root.PrivateKeyType.set -> void
+Consul.Root.RootCert.get -> string
+Consul.Root.RootCert.set -> void
+Consul.Root.SigningKeyID.get -> string
+Consul.Root.SigningKeyID.set -> void
+Consul.RouteConfig.PathExact.get -> string
+Consul.RouteConfig.PathExact.set -> void
+Consul.RouteConfig.PathPrefix.get -> string
+Consul.RouteConfig.PathPrefix.set -> void
+Consul.RouteConfig.PathRegex.get -> string
+Consul.RouteConfig.PathRegex.set -> void
+Consul.Routes.Destination.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.Routes.Destination.set -> void
+Consul.Routes.HTTP.get -> Consul.HTTPConfig
+Consul.Routes.HTTP.set -> void
+Consul.Routes.Match.get -> Consul.MapConfig
+Consul.Routes.Match.set -> void
+Consul.SamenessGroupEntry.Kind.get -> string
+Consul.SamenessGroupEntry.Kind.set -> void
+Consul.SamenessGroupEntry.Members.get -> System.Collections.Generic.List<Consul.SamenessGroupMember>
+Consul.SamenessGroupEntry.Members.set -> void
+Consul.SamenessGroupEntry.Name.get -> string
+Consul.SamenessGroupEntry.Name.set -> void
+Consul.SamenessGroupEntry.Partition.get -> string
+Consul.SamenessGroupEntry.Partition.set -> void
+Consul.SamenessGroupMember.Partition.get -> string
+Consul.SamenessGroupMember.Partition.set -> void
+Consul.SamenessGroupMember.Peer.get -> string
+Consul.SamenessGroupMember.Peer.set -> void
+Consul.Sample.Labels.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.Sample.Labels.set -> void
+Consul.Sample.Name.get -> string
+Consul.Sample.Name.set -> void
+Consul.SDSConfig.CertResource.get -> string
+Consul.SDSConfig.CertResource.set -> void
+Consul.SDSConfig.ClusterName.get -> string
+Consul.SDSConfig.ClusterName.set -> void
+Consul.Semaphore.Acquire() -> System.Threading.Tasks.Task<System.Threading.CancellationToken>
+Consul.Semaphore.Acquire(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<System.Threading.CancellationToken>
+Consul.Semaphore.Destroy(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.Semaphore.Release(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Consul.SemaphoreConflictException.SemaphoreConflictException(string message) -> void
+Consul.SemaphoreConflictException.SemaphoreConflictException(string message, System.Exception inner) -> void
+Consul.SemaphoreHeldException.SemaphoreHeldException(string message) -> void
+Consul.SemaphoreHeldException.SemaphoreHeldException(string message, System.Exception inner) -> void
+Consul.SemaphoreInUseException.SemaphoreInUseException(string message) -> void
+Consul.SemaphoreInUseException.SemaphoreInUseException(string message, System.Exception inner) -> void
+Consul.SemaphoreLimitConflictException.SemaphoreLimitConflictException(string message, int remoteLimit, int localLimit) -> void
+Consul.SemaphoreLimitConflictException.SemaphoreLimitConflictException(string message, int remoteLimit, int localLimit, System.Exception inner) -> void
+Consul.SemaphoreMaxAttemptsReachedException.SemaphoreMaxAttemptsReachedException(string message) -> void
+Consul.SemaphoreMaxAttemptsReachedException.SemaphoreMaxAttemptsReachedException(string message, System.Exception inner) -> void
+Consul.SemaphoreNotHeldException.SemaphoreNotHeldException(string message) -> void
+Consul.SemaphoreNotHeldException.SemaphoreNotHeldException(string message, System.Exception inner) -> void
+Consul.SemaphoreOptions.Prefix.get -> string
+Consul.SemaphoreOptions.Prefix.set -> void
+Consul.SemaphoreOptions.SemaphoreOptions(string prefix, int limit) -> void
+Consul.SemaphoreOptions.Session.get -> string
+Consul.SemaphoreOptions.Session.set -> void
+Consul.SemaphoreOptions.SessionName.get -> string
+Consul.SemaphoreOptions.SessionName.set -> void
+Consul.SemaphoreOptions.Value.get -> byte[]
+Consul.SemaphoreOptions.Value.set -> void
+Consul.SerfCoordinate.Vec.get -> System.Collections.Generic.List<double>
+Consul.SerfCoordinate.Vec.set -> void
+Consul.ServiceAddress.Address.get -> string
+Consul.ServiceAddress.Address.set -> void
+Consul.ServiceConfiguration.Address.get -> string
+Consul.ServiceConfiguration.Address.set -> void
+Consul.ServiceConfiguration.ContentHash.get -> string
+Consul.ServiceConfiguration.ContentHash.set -> void
+Consul.ServiceConfiguration.Datacenter.get -> string
+Consul.ServiceConfiguration.Datacenter.set -> void
+Consul.ServiceConfiguration.ID.get -> string
+Consul.ServiceConfiguration.ID.set -> void
+Consul.ServiceConfiguration.Kind.get -> string
+Consul.ServiceConfiguration.Kind.set -> void
+Consul.ServiceConfiguration.Meta.get -> object
+Consul.ServiceConfiguration.Meta.set -> void
+Consul.ServiceConfiguration.Namespace.get -> string
+Consul.ServiceConfiguration.Namespace.set -> void
+Consul.ServiceConfiguration.Proxy.get -> Consul.Proxy
+Consul.ServiceConfiguration.Proxy.set -> void
+Consul.ServiceConfiguration.Service.get -> string
+Consul.ServiceConfiguration.Service.set -> void
+Consul.ServiceConfiguration.TaggedAddresses.get -> Consul.TaggedAddresses
+Consul.ServiceConfiguration.TaggedAddresses.set -> void
+Consul.ServiceConfiguration.Tags.get -> object
+Consul.ServiceConfiguration.Tags.set -> void
+Consul.ServiceConfiguration.Weights.get -> Consul.Weights
+Consul.ServiceConfiguration.Weights.set -> void
+Consul.ServiceDefaultsEntry.BalanceInboundConnections.get -> string
+Consul.ServiceDefaultsEntry.BalanceInboundConnections.set -> void
+Consul.ServiceDefaultsEntry.Defaults.get -> Consul.DefaultsConfig
+Consul.ServiceDefaultsEntry.Defaults.set -> void
+Consul.ServiceDefaultsEntry.Destination.get -> Consul.DestinationConfig
+Consul.ServiceDefaultsEntry.Destination.set -> void
+Consul.ServiceDefaultsEntry.EnvoyExtensions.get -> System.Collections.Generic.List<Consul.EnvoyExtensionConfig>
+Consul.ServiceDefaultsEntry.EnvoyExtensions.set -> void
+Consul.ServiceDefaultsEntry.Expose.get -> Consul.ExposeConfig
+Consul.ServiceDefaultsEntry.Expose.set -> void
+Consul.ServiceDefaultsEntry.ExternalSNI.get -> string
+Consul.ServiceDefaultsEntry.ExternalSNI.set -> void
+Consul.ServiceDefaultsEntry.Kind.get -> string
+Consul.ServiceDefaultsEntry.Kind.set -> void
+Consul.ServiceDefaultsEntry.MeshGateway.get -> Consul.MeshGatewayConfig
+Consul.ServiceDefaultsEntry.MeshGateway.set -> void
+Consul.ServiceDefaultsEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ServiceDefaultsEntry.Meta.set -> void
+Consul.ServiceDefaultsEntry.Mode.get -> string
+Consul.ServiceDefaultsEntry.Mode.set -> void
+Consul.ServiceDefaultsEntry.MutualTLSMode.get -> string
+Consul.ServiceDefaultsEntry.MutualTLSMode.set -> void
+Consul.ServiceDefaultsEntry.Name.get -> string
+Consul.ServiceDefaultsEntry.Name.set -> void
+Consul.ServiceDefaultsEntry.Namespace.get -> string
+Consul.ServiceDefaultsEntry.Namespace.set -> void
+Consul.ServiceDefaultsEntry.Partition.get -> string
+Consul.ServiceDefaultsEntry.Partition.set -> void
+Consul.ServiceDefaultsEntry.Protocol.get -> string
+Consul.ServiceDefaultsEntry.Protocol.set -> void
+Consul.ServiceDefaultsEntry.RateLimits.get -> Consul.RateLimitsConfig
+Consul.ServiceDefaultsEntry.RateLimits.set -> void
+Consul.ServiceDefaultsEntry.TransparentProxy.get -> Consul.TransparentProxyConfig
+Consul.ServiceDefaultsEntry.TransparentProxy.set -> void
+Consul.ServiceDefaultsEntry.UpstreamConfig.get -> Consul.UpstreamConfig
+Consul.ServiceDefaultsEntry.UpstreamConfig.set -> void
+Consul.ServiceDefinition.Consumers.get -> System.Collections.Generic.List<Consul.ConsumerDefinition>
+Consul.ServiceDefinition.Consumers.set -> void
+Consul.ServiceDefinition.Name.get -> string
+Consul.ServiceDefinition.Name.set -> void
+Consul.ServiceDefinition.Namespace.get -> string
+Consul.ServiceDefinition.Namespace.set -> void
+Consul.ServiceEntry.Checks.get -> Consul.HealthCheck[]
+Consul.ServiceEntry.Checks.set -> void
+Consul.ServiceEntry.Node.get -> Consul.Node
+Consul.ServiceEntry.Node.set -> void
+Consul.ServiceEntry.Service.get -> Consul.AgentService
+Consul.ServiceEntry.Service.set -> void
+Consul.ServiceIdentity.Datacenters.get -> string[]
+Consul.ServiceIdentity.Datacenters.set -> void
+Consul.ServiceIdentity.ServiceIdentity(string serviceName, string[] datacenters) -> void
+Consul.ServiceIdentity.ServiceName.get -> string
+Consul.ServiceIdentity.ServiceName.set -> void
+Consul.ServiceInfo.ID.get -> string
+Consul.ServiceInfo.ID.set -> void
+Consul.ServiceInfo.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ServiceInfo.Meta.set -> void
+Consul.ServiceInfo.Namespace.get -> string
+Consul.ServiceInfo.Namespace.set -> void
+Consul.ServiceInfo.Service.get -> string
+Consul.ServiceInfo.Service.set -> void
+Consul.ServiceInfo.TaggedAddresses.get -> System.Collections.Generic.Dictionary<string, Consul.ServiceAddress>
+Consul.ServiceInfo.TaggedAddresses.set -> void
+Consul.ServiceInfo.Tags.get -> string[]
+Consul.ServiceInfo.Tags.set -> void
+Consul.ServiceIntention.Action.get -> string
+Consul.ServiceIntention.Action.set -> void
+Consul.ServiceIntention.Description.get -> string
+Consul.ServiceIntention.Description.set -> void
+Consul.ServiceIntention.DestinationName.get -> string
+Consul.ServiceIntention.DestinationName.set -> void
+Consul.ServiceIntention.DestinationNS.get -> string
+Consul.ServiceIntention.DestinationNS.set -> void
+Consul.ServiceIntention.ID.get -> string
+Consul.ServiceIntention.ID.set -> void
+Consul.ServiceIntention.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ServiceIntention.Meta.set -> void
+Consul.ServiceIntention.SourceName.get -> string
+Consul.ServiceIntention.SourceName.set -> void
+Consul.ServiceIntention.SourceNS.get -> string
+Consul.ServiceIntention.SourceNS.set -> void
+Consul.ServiceIntention.SourceType.get -> string
+Consul.ServiceIntention.SourceType.set -> void
+Consul.ServiceIntentionsEntry.Kind.get -> string
+Consul.ServiceIntentionsEntry.Kind.set -> void
+Consul.ServiceIntentionsEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ServiceIntentionsEntry.Meta.set -> void
+Consul.ServiceIntentionsEntry.Name.get -> string
+Consul.ServiceIntentionsEntry.Name.set -> void
+Consul.ServiceIntentionsEntry.Namespace.get -> string
+Consul.ServiceIntentionsEntry.Namespace.set -> void
+Consul.ServiceIntentionsEntry.Partition.get -> string
+Consul.ServiceIntentionsEntry.Partition.set -> void
+Consul.ServiceIntentionsEntry.Sources.get -> System.Collections.Generic.List<Consul.SourceIntention>
+Consul.ServiceIntentionsEntry.Sources.set -> void
+Consul.ServiceKind.Equals(Consul.ServiceKind other) -> bool
+Consul.ServiceQuery.Failover.get -> Consul.QueryDatacenterOptions
+Consul.ServiceQuery.Failover.set -> void
+Consul.ServiceQuery.Near.get -> string
+Consul.ServiceQuery.Near.set -> void
+Consul.ServiceQuery.Service.get -> string
+Consul.ServiceQuery.Service.set -> void
+Consul.ServiceQuery.Tags.get -> System.Collections.Generic.List<string>
+Consul.ServiceQuery.Tags.set -> void
+Consul.ServiceResolverEntry.ConnectTimeout.get -> string
+Consul.ServiceResolverEntry.ConnectTimeout.set -> void
+Consul.ServiceResolverEntry.DefaultSubset.get -> string
+Consul.ServiceResolverEntry.DefaultSubset.set -> void
+Consul.ServiceResolverEntry.Filter.get -> string
+Consul.ServiceResolverEntry.Filter.set -> void
+Consul.ServiceResolverEntry.Kind.get -> string
+Consul.ServiceResolverEntry.Kind.set -> void
+Consul.ServiceResolverEntry.LoadBalancer.get -> Consul.LoadBalancerConfig
+Consul.ServiceResolverEntry.LoadBalancer.set -> void
+Consul.ServiceResolverEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ServiceResolverEntry.Meta.set -> void
+Consul.ServiceResolverEntry.Name.get -> string
+Consul.ServiceResolverEntry.Name.set -> void
+Consul.ServiceResolverEntry.Namespace.get -> string
+Consul.ServiceResolverEntry.Namespace.set -> void
+Consul.ServiceResolverEntry.Partition.get -> string
+Consul.ServiceResolverEntry.Partition.set -> void
+Consul.ServiceResolverEntry.Redirect.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ServiceResolverEntry.Redirect.set -> void
+Consul.ServiceResolverEntry.RequestTimeout.get -> string
+Consul.ServiceResolverEntry.RequestTimeout.set -> void
+Consul.ServiceResolverEntry.Subsets.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ServiceResolverEntry.Subsets.set -> void
+Consul.ServiceRouterEntry.Kind.get -> string
+Consul.ServiceRouterEntry.Kind.set -> void
+Consul.ServiceRouterEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ServiceRouterEntry.Meta.set -> void
+Consul.ServiceRouterEntry.Name.get -> string
+Consul.ServiceRouterEntry.Name.set -> void
+Consul.ServiceRouterEntry.Namespace.get -> string
+Consul.ServiceRouterEntry.Namespace.set -> void
+Consul.ServiceRouterEntry.Partition.get -> string
+Consul.ServiceRouterEntry.Partition.set -> void
+Consul.ServiceRouterEntry.Routes.get -> System.Collections.Generic.List<Consul.Routes>
+Consul.ServiceRouterEntry.Routes.set -> void
+Consul.ServiceSplitterEntry.Kind.get -> string
+Consul.ServiceSplitterEntry.Kind.set -> void
+Consul.ServiceSplitterEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.ServiceSplitterEntry.Meta.set -> void
+Consul.ServiceSplitterEntry.Name.get -> string
+Consul.ServiceSplitterEntry.Name.set -> void
+Consul.ServiceSplitterEntry.Namespace.get -> string
+Consul.ServiceSplitterEntry.Namespace.set -> void
+Consul.ServiceSplitterEntry.Partition.get -> string
+Consul.ServiceSplitterEntry.Partition.set -> void
+Consul.ServiceSplitterEntry.Splits.get -> System.Collections.Generic.List<Consul.SplitConfig>
+Consul.ServiceSplitterEntry.Splits.set -> void
+Consul.ServiceTaggedAddress.Address.get -> string
+Consul.ServiceTaggedAddress.Address.set -> void
+Consul.Session.Create() -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Session.Create(Consul.SessionEntry se) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Session.Create(Consul.SessionEntry se, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Session.Create(Consul.SessionEntry se, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Session.Create(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Session.CreateNoChecks() -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Session.CreateNoChecks(Consul.SessionEntry se) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Session.CreateNoChecks(Consul.SessionEntry se, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Session.CreateNoChecks(Consul.SessionEntry se, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Session.CreateNoChecks(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<string>>
+Consul.Session.Destroy(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Session.Destroy(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Session.Destroy(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Session.Info(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry>>
+Consul.Session.Info(string id, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry>>
+Consul.Session.Info(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry>>
+Consul.Session.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
+Consul.Session.List(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
+Consul.Session.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
+Consul.Session.Node(string node) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
+Consul.Session.Node(string node, Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
+Consul.Session.Node(string node, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.SessionEntry[]>>
+Consul.Session.Renew(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.SessionEntry>>
+Consul.Session.Renew(string id, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.SessionEntry>>
+Consul.Session.Renew(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.SessionEntry>>
+Consul.Session.RenewPeriodic(System.TimeSpan initialTTL, string id, Consul.WriteOptions q, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
+Consul.Session.RenewPeriodic(System.TimeSpan initialTTL, string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task
+Consul.SessionBehavior.Behavior.get -> string
+Consul.SessionBehavior.Equals(Consul.SessionBehavior other) -> bool
+Consul.SessionCreationException.SessionCreationException(string message) -> void
+Consul.SessionCreationException.SessionCreationException(string message, System.Exception inner) -> void
+Consul.SessionEntry.Behavior.get -> Consul.SessionBehavior
+Consul.SessionEntry.Behavior.set -> void
+Consul.SessionEntry.Checks.get -> System.Collections.Generic.List<string>
+Consul.SessionEntry.Checks.set -> void
+Consul.SessionEntry.ID.get -> string
+Consul.SessionEntry.ID.set -> void
+Consul.SessionEntry.Name.get -> string
+Consul.SessionEntry.Name.set -> void
+Consul.SessionEntry.Node.get -> string
+Consul.SessionEntry.Node.set -> void
+Consul.SessionExpiredException.SessionExpiredException(string message) -> void
+Consul.SessionExpiredException.SessionExpiredException(string message, System.Exception inner) -> void
+Consul.Snapshot.Restore(System.IO.Stream s) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Snapshot.Restore(System.IO.Stream s, Consul.WriteOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Snapshot.Restore(System.IO.Stream s, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult>
+Consul.Snapshot.Save() -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
+Consul.Snapshot.Save(Consul.QueryOptions q, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
+Consul.Snapshot.Save(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<System.IO.Stream>>
+Consul.SourceIntention.Action.get -> string
+Consul.SourceIntention.Action.set -> void
+Consul.SourceIntention.Description.get -> string
+Consul.SourceIntention.Description.set -> void
+Consul.SourceIntention.LegacyID.get -> string
+Consul.SourceIntention.LegacyID.set -> void
+Consul.SourceIntention.LegacyMeta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.SourceIntention.LegacyMeta.set -> void
+Consul.SourceIntention.Name.get -> string
+Consul.SourceIntention.Name.set -> void
+Consul.SourceIntention.Namespace.get -> string
+Consul.SourceIntention.Namespace.set -> void
+Consul.SourceIntention.Partition.get -> string
+Consul.SourceIntention.Partition.set -> void
+Consul.SourceIntention.Peer.get -> string
+Consul.SourceIntention.Peer.set -> void
+Consul.SourceIntention.Permissions.get -> System.Collections.Generic.List<Consul.IntentionPermission>
+Consul.SourceIntention.Permissions.set -> void
+Consul.SourceIntention.Type.get -> string
+Consul.SourceIntention.Type.set -> void
+Consul.SplitConfig.Namespace.get -> string
+Consul.SplitConfig.Namespace.set -> void
+Consul.SplitConfig.Partition.get -> string
+Consul.SplitConfig.Partition.set -> void
+Consul.SplitConfig.RequestHeaders.get -> System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>>
+Consul.SplitConfig.RequestHeaders.set -> void
+Consul.SplitConfig.ResponseHeaders.get -> System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>>
+Consul.SplitConfig.ResponseHeaders.set -> void
+Consul.SplitConfig.Service.get -> string
+Consul.SplitConfig.Service.set -> void
+Consul.SplitConfig.ServiceSubset.get -> string
+Consul.SplitConfig.ServiceSubset.set -> void
+Consul.Status.Leader(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
+Consul.Status.Peers(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string[]>
+Consul.TaggedAddresses.Lan.get -> Consul.AddressDetails
+Consul.TaggedAddresses.Lan.set -> void
+Consul.TaggedAddresses.Wan.get -> Consul.AddressDetails
+Consul.TaggedAddresses.Wan.set -> void
+Consul.TcpRouteEntry.Kind.get -> string
+Consul.TcpRouteEntry.Kind.set -> void
+Consul.TcpRouteEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.TcpRouteEntry.Meta.set -> void
+Consul.TcpRouteEntry.Name.get -> string
+Consul.TcpRouteEntry.Name.set -> void
+Consul.TcpRouteEntry.Namespace.get -> string
+Consul.TcpRouteEntry.Namespace.set -> void
+Consul.TcpRouteEntry.Parents.get -> System.Collections.Generic.List<Consul.ApiGatewayReference>
+Consul.TcpRouteEntry.Parents.set -> void
+Consul.TcpRouteEntry.Partition.get -> string
+Consul.TcpRouteEntry.Partition.set -> void
+Consul.TcpRouteEntry.Services.get -> System.Collections.Generic.List<Consul.TcpRouteService>
+Consul.TcpRouteEntry.Services.set -> void
+Consul.TcpRouteService.Name.get -> string
+Consul.TcpRouteService.Name.set -> void
+Consul.TcpRouteService.Namespace.get -> string
+Consul.TcpRouteService.Namespace.set -> void
+Consul.TcpRouteService.Partition.get -> string
+Consul.TcpRouteService.Partition.set -> void
+Consul.TemplatedPolicyResponse.Schema.get -> string
+Consul.TemplatedPolicyResponse.Schema.set -> void
+Consul.TemplatedPolicyResponse.Template.get -> string
+Consul.TemplatedPolicyResponse.Template.set -> void
+Consul.TemplatedPolicyResponse.TemplateName.get -> string
+Consul.TemplatedPolicyResponse.TemplateName.set -> void
+Consul.TerminatingGatewayEntry.Kind.get -> string
+Consul.TerminatingGatewayEntry.Kind.set -> void
+Consul.TerminatingGatewayEntry.Meta.get -> System.Collections.Generic.Dictionary<string, string>
+Consul.TerminatingGatewayEntry.Meta.set -> void
+Consul.TerminatingGatewayEntry.Name.get -> string
+Consul.TerminatingGatewayEntry.Name.set -> void
+Consul.TerminatingGatewayEntry.Namespace.get -> string
+Consul.TerminatingGatewayEntry.Namespace.set -> void
+Consul.TerminatingGatewayEntry.Partition.get -> string
+Consul.TerminatingGatewayEntry.Partition.set -> void
+Consul.TerminatingGatewayEntry.Services.get -> System.Collections.Generic.List<Consul.LinkedService>
+Consul.TerminatingGatewayEntry.Services.set -> void
+Consul.TLSCertificatesConfig.CaCertificateProviderInstance.get -> Consul.CaCertificateProviderInstanceConfig
+Consul.TLSCertificatesConfig.CaCertificateProviderInstance.set -> void
+Consul.TLSCertificatesConfig.TrustedCA.get -> Consul.TrustedCAConfig
+Consul.TLSCertificatesConfig.TrustedCA.set -> void
+Consul.TLSConfig.CipherSuites.get -> System.Collections.Generic.List<string>
+Consul.TLSConfig.CipherSuites.set -> void
+Consul.TLSConfig.SDS.get -> Consul.SDSConfig
+Consul.TLSConfig.SDS.set -> void
+Consul.TLSConfig.TLSMaxVersion.get -> string
+Consul.TLSConfig.TLSMaxVersion.set -> void
+Consul.TLSConfig.TLSMinVersion.get -> string
+Consul.TLSConfig.TLSMinVersion.set -> void
+Consul.TLSDirectionConfig.CipherSuites.get -> System.Collections.Generic.List<string>
+Consul.TLSDirectionConfig.CipherSuites.set -> void
+Consul.TLSDirectionConfig.TLSMaxVersion.get -> string
+Consul.TLSDirectionConfig.TLSMaxVersion.set -> void
+Consul.TLSDirectionConfig.TLSMinVersion.get -> string
+Consul.TLSDirectionConfig.TLSMinVersion.set -> void
+Consul.Token.Bootstrap() -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Bootstrap(Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Bootstrap(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Clone(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Clone(string id, Consul.WriteOptions writeOptions) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Clone(string id, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Clone(string id, string description, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Clone(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Create(Consul.TokenEntry token) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Create(Consul.TokenEntry token, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Create(Consul.TokenEntry token, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Delete(string id) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Token.Delete(string id, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Token.Delete(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<bool>>
+Consul.Token.List() -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry[]>>
+Consul.Token.List(Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry[]>>
+Consul.Token.List(System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry[]>>
+Consul.Token.Read(string id) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
+Consul.Token.Read(string id, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
+Consul.Token.Read(string id, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
+Consul.Token.ReadSelfToken(string token) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
+Consul.Token.ReadSelfToken(string token, Consul.QueryOptions queryOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
+Consul.Token.ReadSelfToken(string token, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.QueryResult<Consul.TokenEntry>>
+Consul.Token.Update(Consul.TokenEntry token) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Update(Consul.TokenEntry token, Consul.WriteOptions writeOptions, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.Token.Update(Consul.TokenEntry token, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<Consul.WriteResult<Consul.TokenEntry>>
+Consul.TokenEntry.AccessorID.get -> string
+Consul.TokenEntry.AccessorID.set -> void
+Consul.TokenEntry.AuthMethod.get -> string
+Consul.TokenEntry.AuthMethod.set -> void
+Consul.TokenEntry.Description.get -> string
+Consul.TokenEntry.Description.set -> void
+Consul.TokenEntry.NodeIdentities.get -> Consul.NodeIdentity[]
+Consul.TokenEntry.NodeIdentities.set -> void
+Consul.TokenEntry.Policies.get -> Consul.PolicyLink[]
+Consul.TokenEntry.Policies.set -> void
+Consul.TokenEntry.Roles.get -> Consul.RoleLink[]
+Consul.TokenEntry.Roles.set -> void
+Consul.TokenEntry.SecretID.get -> string
+Consul.TokenEntry.SecretID.set -> void
+Consul.TokenEntry.ServiceIdentities.get -> Consul.ServiceIdentity[]
+Consul.TokenEntry.ServiceIdentities.set -> void
+Consul.TokenEntry.TokenEntry(string accessorId, string description) -> void
+Consul.TokenEntry.TokenEntry(string accessorId, string description, Consul.PolicyLink[] policies, Consul.RoleLink[] roles, Consul.ServiceIdentity[] serviceIdentities) -> void
+Consul.TokenEntry.TokenEntry(string description, Consul.PolicyLink[] policies) -> void
+Consul.TokenEntry.TokenEntry(string description, Consul.RoleLink[] roles) -> void
+Consul.TokenEntry.TokenEntry(string description, Consul.ServiceIdentity[] serviceIdentities) -> void
+Consul.TrustedCAConfig.EnvironmentVariable.get -> string
+Consul.TrustedCAConfig.EnvironmentVariable.set -> void
+Consul.TrustedCAConfig.Filename.get -> string
+Consul.TrustedCAConfig.Filename.set -> void
+Consul.TrustedCAConfig.InlineBytes.get -> string
+Consul.TrustedCAConfig.InlineBytes.set -> void
+Consul.TrustedCAConfig.InlineString.get -> string
+Consul.TrustedCAConfig.InlineString.set -> void
+Consul.TTLStatus.Equals(Consul.TTLStatus other) -> bool
+Consul.TTLStatus.Status.get -> string
+Consul.TxnError.What.get -> string
+Consul.Upstream.DestinationName.get -> string
+Consul.Upstream.DestinationName.set -> void
+Consul.Upstream.DestinationType.get -> string
+Consul.Upstream.DestinationType.set -> void
+Consul.UpstreamConfig.Overrides.get -> System.Collections.Generic.List<Consul.OverrideConfig>
+Consul.UpstreamConfig.Overrides.set -> void
+Consul.UserEvent.ID.get -> string
+Consul.UserEvent.ID.set -> void
+Consul.UserEvent.Name.get -> string
+Consul.UserEvent.Name.set -> void
+Consul.UserEvent.NodeFilter.get -> string
+Consul.UserEvent.NodeFilter.set -> void
+Consul.UserEvent.Payload.get -> byte[]
+Consul.UserEvent.Payload.set -> void
+Consul.UserEvent.ServiceFilter.get -> string
+Consul.UserEvent.ServiceFilter.set -> void
+Consul.UserEvent.TagFilter.get -> string
+Consul.UserEvent.TagFilter.set -> void
+Consul.VerifyClaim.Path.get -> string
+Consul.VerifyClaim.Path.set -> void
+Consul.VerifyClaim.Value.get -> string
+Consul.VerifyClaim.Value.set -> void
+Consul.VerifyClaims.Path.get -> System.Collections.Generic.List<string>
+Consul.VerifyClaims.Path.set -> void
+Consul.VerifyClaims.Value.get -> string
+Consul.VerifyClaims.Value.set -> void
+Consul.WriteOptions.Datacenter.get -> string
+Consul.WriteOptions.Datacenter.set -> void
+Consul.WriteOptions.Namespace.get -> string
+Consul.WriteOptions.Namespace.set -> void
+Consul.WriteOptions.Token.get -> string
+Consul.WriteOptions.Token.set -> void
+Consul.WriteResult.WriteResult(Consul.WriteResult other) -> void
+Consul.WriteResult<T>.WriteResult(Consul.WriteResult other) -> void
+Consul.WriteResult<T>.WriteResult(Consul.WriteResult other, T value) -> void
+override Consul.ACLType.Equals(object other) -> bool
+override Consul.ACLTypeConverter.CanConvert(System.Type objectType) -> bool
+override Consul.ACLTypeConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
+override Consul.ACLTypeConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override Consul.DeleteAcceptingRequest<TIn>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.DeleteAcceptingRequest<TIn>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.DeleteRequest.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.DeleteRequest.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.DeleteReturnRequest<TOut>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.DeleteReturnRequest<TOut>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.DurationTimespanConverter.CanConvert(System.Type objectType) -> bool
+override Consul.DurationTimespanConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
+override Consul.DurationTimespanConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override Consul.Filtering.MetaSelector.Encode() -> string
+override Consul.Filtering.NodeSelector.Encode() -> string
+override Consul.Filtering.ServiceMetaEntrySelector.Encode() -> string
+override Consul.Filtering.ServiceSelector.Encode() -> string
+override Consul.Filtering.StringFieldSelector.Encode() -> string
+override Consul.Filtering.TagsSelector.Encode() -> string
+override Consul.GetRequest.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.GetRequest.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.GetRequest<TOut>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.GetRequest<TOut>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.HealthStatus.Equals(object other) -> bool
+override Consul.HealthStatusConverter.CanConvert(System.Type objectType) -> bool
+override Consul.HealthStatusConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
+override Consul.HealthStatusConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override Consul.KVPairConverter.CanConvert(System.Type objectType) -> bool
+override Consul.KVPairConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
+override Consul.KVPairConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override Consul.KVTxnVerb.Equals(object other) -> bool
+override Consul.KVTxnVerbTypeConverter.CanConvert(System.Type objectType) -> bool
+override Consul.KVTxnVerbTypeConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
+override Consul.KVTxnVerbTypeConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override Consul.NanoSecTimespanConverter.CanConvert(System.Type objectType) -> bool
+override Consul.NanoSecTimespanConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
+override Consul.NanoSecTimespanConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override Consul.PostRequest.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PostRequest.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PostRequest<TIn, TOut>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PostRequest<TIn, TOut>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PostRequest<TIn>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PostRequest<TIn>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PostReturningRequest<TOut>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PostReturningRequest<TOut>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PutNothingRequest.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PutNothingRequest.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PutRequest<TIn, TOut>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PutRequest<TIn, TOut>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PutRequest<TIn>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PutRequest<TIn>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PutReturningRequest<TOut>.ApplyHeaders(System.Net.Http.HttpRequestMessage message, Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.PutReturningRequest<TOut>.ApplyOptions(Consul.ConsulClientConfiguration clientConfig) -> void
+override Consul.ServiceKind.Equals(object obj) -> bool
+override Consul.ServiceKind.ToString() -> string
+override Consul.SessionBehavior.Equals(object other) -> bool
+override Consul.SessionBehaviorConverter.CanConvert(System.Type objectType) -> bool
+override Consul.SessionBehaviorConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
+override Consul.SessionBehaviorConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+override Consul.TTLStatus.Equals(object other) -> bool
+override Consul.TTLStatusConverter.CanConvert(System.Type objectType) -> bool
+override Consul.TTLStatusConverter.ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) -> object
+override Consul.TTLStatusConverter.WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) -> void
+static Consul.ACLType.Client.get -> Consul.ACLType
+static Consul.ACLType.Management.get -> Consul.ACLType
+static Consul.Filtering.Filter.operator !(Consul.Filtering.Filter filter) -> Consul.Filtering.Filter
+static Consul.Filtering.Filter.operator &(Consul.Filtering.Filter left, Consul.Filtering.Filter right) -> Consul.Filtering.Filter
+static Consul.Filtering.Filter.operator |(Consul.Filtering.Filter left, Consul.Filtering.Filter right) -> Consul.Filtering.Filter
+static Consul.Filtering.Filter.Quote(string s) -> string
+static Consul.Filtering.Selector.Combine(string prefix, string self) -> string
+static Consul.Filtering.Selectors.Service.get -> Consul.Filtering.ServiceSelector
+static Consul.Filtering.Selectors.ServiceName.get -> Consul.Filtering.StringFieldSelector
+static Consul.Filtering.ServiceMetaEntrySelector.operator !=(Consul.Filtering.ServiceMetaEntrySelector selector, string value) -> Consul.Filtering.Filter
+static Consul.Filtering.ServiceMetaEntrySelector.operator ==(Consul.Filtering.ServiceMetaEntrySelector selector, string value) -> Consul.Filtering.Filter
+static Consul.Filtering.ServiceSelector.operator !=(Consul.Filtering.ServiceSelector selector, string value) -> Consul.Filtering.Filter
+static Consul.Filtering.ServiceSelector.operator ==(Consul.Filtering.ServiceSelector selector, string value) -> Consul.Filtering.Filter
+static Consul.Filtering.StringFieldSelector.operator !=(Consul.Filtering.StringFieldSelector selector, string value) -> Consul.Filtering.Filter
+static Consul.Filtering.StringFieldSelector.operator ==(Consul.Filtering.StringFieldSelector selector, string value) -> Consul.Filtering.Filter
+static Consul.HealthCheckExtension.AggregatedStatus(this System.Collections.Generic.IEnumerable<Consul.HealthCheck> checks) -> Consul.HealthStatus
+static Consul.HealthStatus.Any.get -> Consul.HealthStatus
+static Consul.HealthStatus.Critical.get -> Consul.HealthStatus
+static Consul.HealthStatus.Maintenance.get -> Consul.HealthStatus
+static Consul.HealthStatus.Parse(string status) -> Consul.HealthStatus
+static Consul.HealthStatus.Passing.get -> Consul.HealthStatus
+static Consul.HealthStatus.Warning.get -> Consul.HealthStatus
+static Consul.KVTxnVerb.CAS.get -> Consul.KVTxnVerb
+static Consul.KVTxnVerb.CheckIndex.get -> Consul.KVTxnVerb
+static Consul.KVTxnVerb.CheckSession.get -> Consul.KVTxnVerb
+static Consul.KVTxnVerb.Delete.get -> Consul.KVTxnVerb
+static Consul.KVTxnVerb.DeleteCAS.get -> Consul.KVTxnVerb
+static Consul.KVTxnVerb.DeleteTree.get -> Consul.KVTxnVerb
+static Consul.KVTxnVerb.Get.get -> Consul.KVTxnVerb
+static Consul.KVTxnVerb.GetTree.get -> Consul.KVTxnVerb
+static Consul.KVTxnVerb.Lock.get -> Consul.KVTxnVerb
+static Consul.KVTxnVerb.Set.get -> Consul.KVTxnVerb
+static Consul.KVTxnVerb.Unlock.get -> Consul.KVTxnVerb
+static Consul.PolicyEntry.implicit operator Consul.PolicyLink(Consul.PolicyEntry p) -> Consul.PolicyLink
+static Consul.RoleEntry.implicit operator Consul.RoleLink(Consul.RoleEntry r) -> Consul.RoleLink
+static Consul.ServiceKind.ConnectProxy.get -> Consul.ServiceKind
+static Consul.ServiceKind.IngressGateway.get -> Consul.ServiceKind
+static Consul.ServiceKind.MeshGateway.get -> Consul.ServiceKind
+static Consul.ServiceKind.TerminatingGateway.get -> Consul.ServiceKind
+static Consul.ServiceKind.TryParse(string value, out Consul.ServiceKind result) -> bool
+static Consul.SessionBehavior.Delete.get -> Consul.SessionBehavior
+static Consul.SessionBehavior.Release.get -> Consul.SessionBehavior
+static Consul.TTLStatus.Critical.get -> Consul.TTLStatus
+static Consul.TTLStatus.Fail.get -> Consul.TTLStatus
+static Consul.TTLStatus.Pass.get -> Consul.TTLStatus
+static Consul.TTLStatus.Warn.get -> Consul.TTLStatus
+static readonly Consul.QueryOptions.Default -> Consul.QueryOptions
+static readonly Consul.Semaphore.DefaultSemaphoreKey -> string
+static readonly Consul.WriteOptions.Default -> Consul.WriteOptions

--- a/Consul/PublicAPI/net461/PublicAPI.Shipped.txt
+++ b/Consul/PublicAPI/net461/PublicAPI.Shipped.txt
@@ -1,1 +1,0 @@
-#nullable enable

--- a/Consul/PublicAPI/net461/PublicAPI.Unshipped.txt
+++ b/Consul/PublicAPI/net461/PublicAPI.Unshipped.txt
@@ -1,20 +1,19 @@
-#nullable enable
-~Consul.ConsulClient.ConsulClient(System.Action<Consul.ConsulClientConfiguration> configOverride, System.Action<System.Net.Http.HttpClient> clientOverride, System.Action<System.Net.Http.WebRequestHandler> handlerOverride) -> void
-~Consul.ConsulConfigurationException.ConsulConfigurationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.ConsulRequestException.ConsulRequestException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.InvalidKeyPairException.InvalidKeyPairException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.LockConflictException.LockConflictException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.LockHeldException.LockHeldException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.LockInUseException.LockInUseException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.LockMaxAttemptsReachedException.LockMaxAttemptsReachedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.LockNotHeldException.LockNotHeldException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.SemaphoreConflictException.SemaphoreConflictException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.SemaphoreHeldException.SemaphoreHeldException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.SemaphoreInUseException.SemaphoreInUseException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.SemaphoreLimitConflictException.SemaphoreLimitConflictException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.SemaphoreMaxAttemptsReachedException.SemaphoreMaxAttemptsReachedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.SemaphoreNotHeldException.SemaphoreNotHeldException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.SessionCreationException.SessionCreationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~Consul.SessionExpiredException.SessionExpiredException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~override Consul.ConsulRequestException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-~override Consul.SemaphoreLimitConflictException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.ConsulClient.ConsulClient(System.Action<Consul.ConsulClientConfiguration> configOverride, System.Action<System.Net.Http.HttpClient> clientOverride, System.Action<System.Net.Http.WebRequestHandler> handlerOverride) -> void
+Consul.ConsulConfigurationException.ConsulConfigurationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.ConsulRequestException.ConsulRequestException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.InvalidKeyPairException.InvalidKeyPairException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.LockConflictException.LockConflictException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.LockHeldException.LockHeldException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.LockInUseException.LockInUseException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.LockMaxAttemptsReachedException.LockMaxAttemptsReachedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.LockNotHeldException.LockNotHeldException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.SemaphoreConflictException.SemaphoreConflictException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.SemaphoreHeldException.SemaphoreHeldException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.SemaphoreInUseException.SemaphoreInUseException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.SemaphoreLimitConflictException.SemaphoreLimitConflictException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.SemaphoreMaxAttemptsReachedException.SemaphoreMaxAttemptsReachedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.SemaphoreNotHeldException.SemaphoreNotHeldException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.SessionCreationException.SessionCreationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Consul.SessionExpiredException.SessionExpiredException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+override Consul.ConsulRequestException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+override Consul.SemaphoreLimitConflictException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void

--- a/Consul/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/Consul/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,1 +1,0 @@
-#nullable enable

--- a/Consul/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/Consul/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
-#nullable enable
-~Consul.ConsulClient.ConsulClient(System.Action<Consul.ConsulClientConfiguration> configOverride, System.Action<System.Net.Http.HttpClient> clientOverride, System.Action<System.Net.Http.HttpClientHandler> handlerOverride) -> void
+Consul.ConsulClient.ConsulClient(System.Action<Consul.ConsulClientConfiguration> configOverride, System.Action<System.Net.Http.HttpClient> clientOverride, System.Action<System.Net.Http.HttpClientHandler> handlerOverride) -> void


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Consul.NET! Please provide the following information to help us review and merge
your changes effectively.
 -->

<!-- PR Title format
Please use one of the following formats for the title of your pull request above:
- [FEATURE]: <a one-liner summary of the changes>
- [ENHANCEMENT]: <a one-liner summary of the changes>
- [BUG FIX]: <a one-liner summary of the changes>
-->

## Description
We can get rid of that warnings by:
- removing `#nullable enable` from all Public.API files
- removing the `~` marker from all API entries

Given that we don't have a plan to annotate the entire library, removing the `#nullable enable` seem to be a possible approach. See [Nullable reference type support](https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/PublicApiAnalyzers/PublicApiAnalyzers.Help.md#nullable-reference-type-support)

Other possible approaches:
- use nullable annotations `?` but that requires upgrading the language version
- or disable this warning until completing the annotation. The rule can be disabled via `.editorconfig` with `dotnet_diagnostic.RS0041.severity = none`

<!-- (required)
A clear and concise description of the changes made in this pull request
-->

## Related Issues

<!-- (optional)
List any related issues, if applicable, using the format `#issue_number`
Example: #123
-->
#415 

## Additional Context

<!-- (optional)
Add any additional context or information about this pull request
-->

## Checklist

<!-- (required) -->
Please make sure to check the following before submitting your pull request:

- [x] Did you read the [contributing guidelines](https://consuldot.net/docs/contributing/guidelines)?
- [ ] Did you update the docs?
- [ ] Did you write any tests to validate this change?
