### PR TITLE
fix(ci): harden formatter security

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -11,8 +11,6 @@ on:
 
 permissions: {}
 concurrency: ${{ github.workflow }}-${{ github.head_ref }}
-env:
-  BRANCH: ${{ github.head_ref }}
 
 jobs:
   format:
@@ -25,7 +23,7 @@ jobs:
           show-progress: false
           persist-credentials: false
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ env.BRANCH }}
+          ref: ${{ github.head_ref }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5.1.0
@@ -54,7 +52,7 @@ jobs:
         with:
           show-progress: false
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ env.BRANCH }}
+          ref: ${{ github.head_ref }}
 
       - name: Download patch
         uses: actions/download-artifact@v8.0.0


### PR DESCRIPTION
Hey @marcin-krystianc,

I have come back to refactor my original workflow addition to `consuldotnet` about 3 years ago in #236.

In light of some recent [news](https://www.upwind.io/feed/hackerbot-claw-github-actions-pull-request-rce), I've been auditing my past contributions that use `pull_request_target` and patching them to reduce the attack surface.

Here's what has changed:

- The workflow is now split into unprivileged (format) and privileged (push) jobs. 
- In `format`, untrusted scripts will no longer have access to **any** token(s), not even a read token, as the global permissions setting is now `permissions: {}`. See [here](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes)
- In `format`, `persist-credentials` is set to `false` for obvious reasons
- To mitigate script injection attacks, we explicitly craft a patch from only `*.cs` files, and only commit them if they are already tracked on remote
- We also switch to the `ubuntu-slim` runner to reduce the attack surface
- `dotnet-format` has now [migrated](https://github.com/dotnet/format/issues/1268) to `.NET` so we will now use that to continue receiving security patches
- Not security-related but we now add a `concurrency` constraint to mitigate merge conflicts

Hopefully, there will be no need to do a `git blame` on me any time soon.