### PR TITLE
CI: Use GITHUB_TOKEN when checking for new Consul versions

### DIFF
--- a/.github/workflows/scripts/update-consul-versions.ps1
+++ b/.github/workflows/scripts/update-consul-versions.ps1
@@ -8,6 +8,7 @@ Set-GitHubConfiguration -SuppressTelemetryReminder
 # Use GITHUB_TOKEN if provided
 if ($Env:GITHUB_TOKEN -ne $null)
 {
+  echo "Using provided GITHUB_TOKEN"
   $token = ($Env:GITHUB_TOKEN | ConvertTo-SecureString -AsPlainText -Force)
   $cred = New-Object System.Management.Automation.PSCredential "username is ignored", $token
   Set-GitHubAuthentication -Credential $cred -SessionOnly

--- a/.github/workflows/update-consul-versions.yml
+++ b/.github/workflows/update-consul-versions.yml
@@ -40,7 +40,7 @@ jobs:
         uses: technote-space/create-pr-action@v2
         with:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
-          EXECUTE_COMMANDS: pwsh .github/workflows/scripts/update-consul-versions.ps1
+          EXECUTE_COMMANDS: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} pwsh .github/workflows/scripts/update-consul-versions.ps1
           COMMIT_MESSAGE: 'Update Consul agent versions used for testing'
           COMMIT_NAME: 'Consul.NET CI'
           COMMIT_EMAIL: 'consuldotnet@gr-oss.io'


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Consul.NET! Please provide the following information to help us review and merge
your changes effectively.
 -->

<!-- PR Title format
Please use one of the following formats for the title of your pull request above:
- [FEATURE]: <a one-liner summary of the changes>
- [ENHANCEMENT]: <a one-liner summary of the changes>
- [BUG FIX]: <a one-liner summary of the changes>
-->

## Description

We run into rate limits every few weeks when running the scheduled `update-consul-versions` workflow. (Example: https://github.com/G-Research/consuldotnet/actions/runs/22790748882/job/66116745534)

This is an attempt at using the workflow's built-in token to avoid running into rate limits.

<!-- (required)
A clear and concise description of the changes made in this pull request
-->

## Related Issues

<!-- (optional)
List any related issues, if applicable, using the format `#issue_number`
Example: #123
-->

## Additional Context

<!-- (optional)
Add any additional context or information about this pull request
-->

## Checklist

<!-- (required) -->
Please make sure to check the following before submitting your pull request:

- [x] Did you read the [contributing guidelines](https://consuldot.net/docs/contributing/guidelines)?
- [ ] ~Did you update the docs?~
- [ ] ~Did you write any tests to validate this change?~
