### PR TITLE
security: prevent template injection in workflow run blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,16 +168,18 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
       - name: Create NuGet packages
+        env:
+          GITHUB_REF: ${{ github.ref }}
         run: |
-          if (-not ("${{ github.ref }}" -like "refs/tags/v*")) {
+          if (-not ($env:GITHUB_REF -like "refs/tags/v*")) {
             $suffix = "preview-$(Get-Date -Format yyyyMMddHHmmss -AsUTC)-$(git rev-parse --short HEAD)"
             $params = "--version-suffix", $suffix
           }
 
           dotnet pack --configuration=Release --output dist @params
 
-          if ("${{ github.ref }}" -like "refs/tags/v*") {
-              $tag = "${{ github.ref }}".SubString(11)
+          if ($env:GITHUB_REF -like "refs/tags/v*") {
+              $tag = $env:GITHUB_REF.SubString(11)
               $expectedConsulFile = "dist/Consul.$tag.nupkg"
               $expectedConsulAspNetCoreFile = "dist/Consul.AspNetCore.$tag.nupkg"
 

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -43,13 +43,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract URL and BASE_URL
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          if [[ "${{ github.repository_owner }}" == "G-Research" ]]; then
+          if [[ "$REPO_OWNER" == "G-Research" ]]; then
             echo "URL=https://consuldot.net" >> $GITHUB_ENV
             echo "BASE_URL=/" >> $GITHUB_ENV
           else
-            echo "URL=https://${{ github.repository_owner }}.github.io" >> $GITHUB_ENV
-            echo "BASE_URL=/${{ github.event.repository.name }}/" >> $GITHUB_ENV
+            echo "URL=https://$REPO_OWNER.github.io" >> $GITHUB_ENV
+            echo "BASE_URL=/$REPO_NAME/" >> $GITHUB_ENV
           fi
 
       - name: Setup Node
@@ -134,11 +137,13 @@ jobs:
         id: wait-for-new-version
         if: ${{ env.ALGOLIA_SECRETS == 'true' }}
         continue-on-error: true # Allows this step to fail without failing the job
+        env:
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
         run: |
           max_retries=5
           new_version="${{ github.sha }}"
           for i in $(seq 1 $max_retries); do
-            published_version=$(curl -s -f ${{ steps.deployment.outputs.page_url }}.build)
+            published_version=$(curl -s -f "${PAGE_URL}.build")
             if [ "$published_version" == "$new_version" ]; then
               echo "New version published!"
               exit 0


### PR DESCRIPTION
## What

Resolves the `template-injection` findings reported by the newly-added zizmor workflow (#640).

User-controllable GitHub Actions context expressions were interpolated directly into `run:` blocks, where they expand into the shell/PowerShell source *before* execution. An attacker able to influence those contexts could inject code into the runner.

## Changes

- **`ci.yml`** (`package` job): route `${{ github.ref }}` through a step-level `GITHUB_REF` env var; use `$env:GITHUB_REF` in the PowerShell block.
- **`deploy-website.yml`** (`build` job): route `github.repository_owner` and `github.event.repository.name` through `REPO_OWNER` / `REPO_NAME` env vars.
- **`deploy-website.yml`** (`deploy` job): route `steps.deployment.outputs.page_url` through a `PAGE_URL` env var and quote the curl argument.

## Verification

`zizmor .github/workflows/ci.yml .github/workflows/deploy-website.yml` reports no template-injection findings after the change. No behavioural change — same values, passed via the environment instead of inlined.

Part of a series addressing zizmor findings (template-injection / excessive-permissions / artipacked).