### PR TITLE
security: apply least-privilege GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,16 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
+# Top-level: no permissions. Each job declares only what it needs.
+permissions: {}
+
 jobs:
   # Enforces the consistency of code formatting using `.editorconfig` and the `dotnet format`.
   check-format:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -30,6 +35,8 @@ jobs:
   validate-api-docs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -48,6 +55,8 @@ jobs:
         framework: [net8.0, net9.0]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -57,7 +66,7 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Setup .NET SDK v9.0.x
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2    
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
         with:
           dotnet-version: 9.0.x
       - name: Build
@@ -84,6 +93,8 @@ jobs:
 
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -162,6 +173,8 @@ jobs:
   package:
     runs-on: windows-latest
     needs: [Consul_AspNetCore, Consul]
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -203,6 +216,8 @@ jobs:
     if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/master' }}
     needs: package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download NuGet package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -219,6 +234,8 @@ jobs:
     if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}
     needs: package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download NuGet package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -10,10 +10,8 @@ on:
       - 'docs/**'
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
 
-permissions: # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-  contents: read
-  pages: write
-  id-token: write
+# Top-level: no permissions. Each job declares only what it needs.
+permissions: {}
 
 defaults: # Default to bash
   run:
@@ -22,6 +20,8 @@ defaults: # Default to bash
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Checkout + `gh api` repo metadata read
     outputs:
       has_pages: ${{ steps.has-pages.outputs.has_pages }}
     steps:
@@ -113,6 +113,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write # Deploy to GitHub Pages
+      id-token: write # Verify deployment origin via OIDC
     if: github.ref == 'refs/heads/master' && needs.build.outputs.has_pages == 'true'
     concurrency: # Allow one concurrent deployment
       group: "pages"

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -6,6 +6,8 @@ on:
     types: [completed]
     branches: [master]
 
+# Sends an external webhook only; no GITHUB_TOKEN access required.
+permissions: {}
 
 jobs:
   nudge:

--- a/.github/workflows/update-consul-versions.yml
+++ b/.github/workflows/update-consul-versions.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '22 2 * * *' # Run once per day, at a randomly chosen time.
 
+# Top-level: no permissions. The pull request is created with a dedicated
+# GitHub App token (see the "Create access token" step), so the default
+# GITHUB_TOKEN only needs read access.
+permissions: {}
+
 jobs:
   update-consul-versions:
     # Only run on main repository
@@ -11,6 +16,8 @@ jobs:
     if: github.repository == 'G-Research/consuldotnet'
     environment: update-consul-versions
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Install Step CLI
         env:


### PR DESCRIPTION
## What

Resolves the `excessive-permissions` findings reported by the zizmor workflow (#640).

Several workflows had no `permissions:` block, so their jobs ran with the repository's *default* `GITHUB_TOKEN` scopes; `deploy-website.yml` granted `pages: write` / `id-token: write` to **all** jobs when only the deploy job needs them.

## Changes

Following the same top-level-`{}`-plus-per-job pattern as the existing `zizmor.yml`:

- **`ci.yml`** — top-level `permissions: {}`; each job gets `contents: read`.
- **`deploy-website.yml`** — top-level `{}`; `build` job keeps `contents: read`, `pages: write` / `id-token: write` move to the `deploy` job only.
- **`nudge.yml`** — `permissions: {}` (sends an external webhook, no `GITHUB_TOKEN` needed).
- **`update-consul-versions.yml`** — top-level `{}` + job `contents: read` (the PR is opened with a dedicated GitHub App token, so the default token only needs read).

## Verification

`zizmor .github/workflows/` reports no `excessive-permissions` findings after the change. Scopes were chosen to match what each job actually exercises, so there should be no functional change.

Part of a series addressing zizmor findings (template-injection / excessive-permissions / artipacked).