### PR TITLE
security: disable credential persistence on workflow checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
       # For the time being (https://github.com/dotnet/format/issues/1500, https://github.com/dotnet/format/issues/1560) we need to use `dotnet-format` instead of `dotnet format`
@@ -33,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -51,6 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - name: Setup .NET SDK v8.0.x
         if: matrix.framework == 'net8.0'
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
@@ -87,6 +93,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - name: Setup .NET SDK v8.0.x
         if: matrix.framework == 'net8.0'
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
@@ -165,6 +173,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
       - name: Create NuGet packages

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      with:
+        persist-credentials: false
 
     - name: Set up mono
       if: runner.os == 'Linux'

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0 # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          persist-credentials: false
 
       - name: Get Consul.NET latest version
         id: version


### PR DESCRIPTION
## What

Resolves the `artipacked` findings reported by the zizmor workflow (#640).

`actions/checkout` persists the `GITHUB_TOKEN` into `.git/config` by default. For jobs that only read the repo, that credential is never needed after checkout and risks being captured by later steps or uploaded inside an artifact. Setting `persist-credentials: false` removes it.

## Changes

Added `persist-credentials: false` to every checkout that does **not** push:

- **`ci.yml`** — all 5 build/test/package checkouts.
- **`codeql-analysis.yml`** — the analysis checkout.
- **`deploy-website.yml`** — the docs `build` checkout (kept alongside `fetch-depth: 0`).

## Intentionally excluded

- **`formatter.yml`** `push` job checkout — it needs the persisted credential to `git push` the formatting fixup commit, so it must keep credentials. This remaining `artipacked` finding is documented/suppressed separately in the zizmor config PR.

## Verification

`zizmor .github/workflows/` reports only the expected `formatter.yml` push-job finding afterwards; all read-only checkouts are clean.

Part of a series addressing zizmor findings (template-injection / excessive-permissions / artipacked).