### PR TITLE
ci: Dependabot - disable regular updates for NuGet and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 7
     groups:
@@ -33,6 +34,7 @@ updates:
     directory: "/docs"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 7
     groups:


### PR DESCRIPTION
According to Claude, this should prevent creating ungrouped non-security updates